### PR TITLE
Add rule copy drift check

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Active every session. `/ponytail-review` finds what to delete in your diff. `/po
 
 Cursor, Windsurf, Cline, Copilot, Aider: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md)).
 
+## Development
+
+When changing the compact rule text, keep the agent copies aligned:
+
+```bash
+node scripts/check-rule-copies.js
+```
+
 ## FAQ
 
 **Does it need a config file?**

--- a/scripts/check-rule-copies.js
+++ b/scripts/check-rule-copies.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+
+function read(relPath) {
+  return fs.readFileSync(path.join(root, relPath), 'utf8').replace(/\r\n/g, '\n').trim();
+}
+
+function stripCursorFrontmatter(text) {
+  return text.replace(/^---\n[\s\S]*?\n---\n*/, '').trim();
+}
+
+const agents = read('AGENTS.md');
+const canonical = agents.replace(/\n\n\(Yes, this file also applies[\s\S]*?\)$/, '').trim();
+
+const copies = [
+  ['.cursor/rules/ponytail.mdc', stripCursorFrontmatter],
+  ['.windsurf/rules/ponytail.md', text => text.trim()],
+  ['.clinerules/ponytail.md', text => text.trim()],
+  ['.github/copilot-instructions.md', text => text.trim()],
+];
+
+let failed = false;
+
+for (const [relPath, normalize] of copies) {
+  const actual = normalize(read(relPath));
+  if (actual !== canonical) {
+    console.error(`${relPath} drifted from AGENTS.md`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error('Update the copied rule text or AGENTS.md so the shared body matches.');
+  process.exit(1);
+}
+
+console.log('Rule copies match AGENTS.md shared body.');


### PR DESCRIPTION
## Summary
- add a tiny Node script that checks copied compact rule files against AGENTS.md
- ignore the repo-local AGENTS.md self-application note so external adapter files stay clean
- document the check in the README development section

## Checks
- node scripts/check-rule-copies.js
- node --check scripts/check-rule-copies.js
- git diff --check

No prompt behavior changes.