### PR TITLE
docs: add pi (oh-my-pi) install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Active every session. `/ponytail-review` finds what to delete in your diff. `/po
 
 Cursor, Windsurf, Cline, Copilot, Aider: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md)).
 
+Pi (oh-my-pi): copy the [`skills/`](skills/) directory contents to `~/.pi/agent/skills/` (global) or `.pi/skills/` in your project (project-scoped). Pi discovers them natively — no extra config.
+
 ## FAQ
 
 **Does it need a config file?**


### PR DESCRIPTION
The `skills/` directory already ships pi-native skill files (`SKILL.md` with YAML frontmatter), but pi isn't mentioned in the README install section.

## Changes

- Added pi (oh-my-pi) to the README with install instructions
- Points users to copy `skills/` to project root or `~/.config/pi/skills/` for user-level discovery

## Context

Pi discovers skills natively from project directories — the `skills/ponytail/SKILL.md`, `skills/ponytail-review/`, and `skills/ponytail-help/` files are already in the correct format. This just documents it.