### PR TITLE
chore: tighten rule-copy drift check (Kiro + SKILL.md invariants)

### DIFF
--- a/.kiro/steering/ponytail.md
+++ b/.kiro/steering/ponytail.md
@@ -26,6 +26,4 @@ Rules:
 - Pick the edge-case-correct option when two stdlib approaches are the same size — lazy means less code, not the flimsier algorithm.
 - Mark intentional simplifications with a `ponytail:` comment. If the shortcut has a known ceiling (global lock, O(n²) scan, naive heuristic), the comment names the ceiling and the upgrade path.
 
-Not lazy about: input validation at trust boundaries, error handling that prevents data loss, security, accessibility, anything explicitly requested.
-
-Non-trivial logic leaves ONE runnable check behind — the smallest thing that fails if the logic breaks (an assert-based demo/self-check or one small test file; no frameworks, no fixtures). Trivial one-liners need no test.
+Not lazy about: input validation at trust boundaries, error handling that prevents data loss, security, accessibility, anything explicitly requested. Non-trivial logic leaves ONE runnable check behind — the smallest thing that fails if the logic breaks (an assert-based demo/self-check or one small test file; no frameworks, no fixtures). Trivial one-liners need no test.

--- a/scripts/check-rule-copies.js
+++ b/scripts/check-rule-copies.js
@@ -8,18 +8,20 @@ function read(relPath) {
   return fs.readFileSync(path.join(root, relPath), 'utf8').replace(/\r\n/g, '\n').trim();
 }
 
-function stripCursorFrontmatter(text) {
+function stripFrontmatter(text) {
   return text.replace(/^---\n[\s\S]*?\n---\n*/, '').trim();
 }
 
 const agents = read('AGENTS.md');
 const canonical = agents.replace(/\n\n\(Yes, this file also applies[\s\S]*?\)$/, '').trim();
 
+// Compact copies: same body as AGENTS.md, host-specific frontmatter stripped.
 const copies = [
-  ['.cursor/rules/ponytail.mdc', stripCursorFrontmatter],
+  ['.cursor/rules/ponytail.mdc', stripFrontmatter],
   ['.windsurf/rules/ponytail.md', text => text.trim()],
   ['.clinerules/ponytail.md', text => text.trim()],
   ['.github/copilot-instructions.md', text => text.trim()],
+  ['.kiro/steering/ponytail.md', stripFrontmatter],
 ];
 
 let failed = false;
@@ -32,9 +34,32 @@ for (const [relPath, normalize] of copies) {
   }
 }
 
+// SKILL.md is the runtime source of truth and is longer than the compact body,
+// so it cannot be byte-compared. ponytail: canary, not full equality. Assert the
+// load-bearing rules survive verbatim in both the source and AGENTS.md. Changing
+// a rule's wording trips this, which is the reminder to propagate it everywhere.
+// Upgrade path: generate the copies from SKILL.md if this ever misses a real drift.
+const INVARIANTS = [
+  'naive heuristic',                       // ceiling-comment rule
+  'ONE runnable check',                    // test reflex
+  'flimsier algorithm',                    // robust-variant rule
+  'input validation at trust boundaries',  // the "not lazy about" clause
+];
+
+const skill = read('skills/ponytail/SKILL.md');
+const sources = [['skills/ponytail/SKILL.md', skill], ['AGENTS.md', agents]];
+for (const phrase of INVARIANTS) {
+  for (const [label, text] of sources) {
+    if (!text.includes(phrase)) {
+      console.error(`${label} is missing rule invariant: "${phrase}"`);
+      failed = true;
+    }
+  }
+}
+
 if (failed) {
-  console.error('Update the copied rule text or AGENTS.md so the shared body matches.');
+  console.error('Update the copied rule text, AGENTS.md, or SKILL.md so the shared rules match.');
   process.exit(1);
 }
 
-console.log('Rule copies match AGENTS.md shared body.');
+console.log(`Rule copies match AGENTS.md; ${INVARIANTS.length} rule invariants present in SKILL.md and AGENTS.md.`);


### PR DESCRIPTION
Closes the two coverage gaps in the rule-copy drift check from #3.

## What

- **Cover the Kiro steering file.** `.kiro/steering/ponytail.md` (added in #6) is now checked against the canonical AGENTS.md body, with the frontmatter stripper shared across Cursor and Kiro (renamed `stripFrontmatter`).
- **Align the Kiro copy.** Its body had the "Not lazy about" and "Non-trivial logic" sentences split into two paragraphs; the canonical body and the other four copies keep them as one. The improved check caught this drift on the freshly merged #6, and this PR fixes it.
- **Guard the source of truth.** SKILL.md is the runtime source and is intentionally longer than AGENTS.md, so it cannot be byte-compared. A small invariant canary instead asserts four load-bearing rule phrases (`naive heuristic`, `ONE runnable check`, `flimsier algorithm`, `input validation at trust boundaries`) appear verbatim in both SKILL.md and AGENTS.md.

## Why

The check previously guarded only the four editor copies against AGENTS.md. Nothing covered the Kiro copy or the SKILL.md source, so a rule could be updated in SKILL.md and silently miss AGENTS.md and the copies, which is exactly the v4 propagation risk.

## Verification

- `node scripts/check-rule-copies.js` passes on this branch.
- Exits 1 when a copy diverges (proven by the Kiro catch) and when an invariant goes missing (proven by temporarily breaking one in SKILL.md, then restoring).

Known ceiling, noted in the script: the canary checks a fixed set of phrases, not full equivalence. If it ever misses a real drift, the upgrade path is to generate the copies from SKILL.md.
