### PR TITLE
docs: link agent-portability from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ Cursor, Windsurf, Cline, Copilot, Aider, Kiro: copy the matching rules file from
 
 Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kiro/steering/` in your project.
 
+Which files map to which agent: [Agent portability](docs/agent-portability.md).
+
 ## Development
 
 When changing the compact rule text, keep the agent copies aligned:


### PR DESCRIPTION
The agent-portability doc that merged in #2 was unlinked. This points to it from the adapters section of the README. One line, no behavior change.