### PR TITLE
fix: use CLAUDE_PLUGIN_ROOT in hooks.json, drop duplicate manifest hooks

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -5,31 +5,5 @@
   "author": {
     "name": "Dietrich Gebert",
     "url": "https://github.com/DietrichGebert"
-  },
-  "hooks": {
-    "SessionStart": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js",
-            "timeout": 5,
-            "statusMessage": "Loading ponytail mode..."
-          }
-        ]
-      }
-    ],
-    "UserPromptSubmit": [
-      {
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js",
-            "timeout": 5,
-            "statusMessage": "Tracking ponytail mode..."
-          }
-        ]
-      }
-    ]
   }
 }

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks\\ponytail-activate.js\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
+            "commandWindows": "node \"%CLAUDE_PLUGIN_ROOT%\\hooks\\ponytail-activate.js\"",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
           }
@@ -19,8 +19,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
-            "commandWindows": "node \"%PLUGIN_ROOT%\\hooks\\ponytail-mode-tracker.js\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
+            "commandWindows": "node \"%CLAUDE_PLUGIN_ROOT%\\hooks\\ponytail-mode-tracker.js\"",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."
           }


### PR DESCRIPTION
Fixes #11.

## What

- `hooks/hooks.json`: `${PLUGIN_ROOT}` → `${CLAUDE_PLUGIN_ROOT}` (and `%PLUGIN_ROOT%` → `%CLAUDE_PLUGIN_ROOT%` in `commandWindows`).
- `.claude-plugin/plugin.json`: remove the inline `hooks` block — `hooks/hooks.json` is now the single hook registration for both agents.

## Why

Claude Code auto-loads `hooks/hooks.json` from every plugin but only substitutes `${CLAUDE_PLUGIN_ROOT}`; `${PLUGIN_ROOT}` survives as a literal, so since #7 every Claude Code session start (and every prompt, via the mode tracker) throws:

```
SessionStart:startup hook error
Failed with non-blocking status code: node:internal/modules/cjs/loader:1478
Error: Cannot find module '<cwd>/${PLUGIN_ROOT}/hooks/ponytail-activate.js'
```

Per the [Codex hooks docs](https://developers.openai.com/codex/hooks), Codex sets `CLAUDE_PLUGIN_ROOT` alongside its native `PLUGIN_ROOT` "for compatibility with existing plugin hooks" — so the compat variable works in both agents and the file needs no per-agent fork.

The inline copy in `.claude-plugin/plugin.json` has to go in the same change: with the variable fixed, keeping both registrations would make Claude Code fire every hook twice (double context injection per session start, double tracker per prompt).

## Verified

- `node tests/hooks.test.js` → `hook compatibility checks passed`
- `node scripts/check-rule-copies.js` → rule copies match
- Both JSON files parse
- Repro of the original error: `node '${PLUGIN_ROOT}/hooks/ponytail-activate.js'` → exact `cjs/loader:1478` failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)