### PR TITLE
Fix: stop mode filter from stripping rule bullets that contain a colo…

### DIFF
--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -12,14 +12,24 @@ function filterSkillBodyForMode(body, mode) {
   const effectiveMode = normalizeMode(mode) || DEFAULT_MODE;
   const withoutFrontmatter = String(body || '').replace(/^---[\s\S]*?---\s*/, '');
 
+  // Only the intensity table rows and worked examples are mode-specific, and
+  // both are keyed by a mode name (lite/full/ultra). A bullet whose label is
+  // not a mode — e.g. "No unrequested abstractions: ..." — is a normal rule
+  // and must be kept verbatim.
   return withoutFrontmatter
     .split(/\r?\n/)
     .filter((line) => {
-      const tableMatch = line.match(/^\|\s*\*\*(.+?)\*\*\s*\|/);
-      if (tableMatch) return tableMatch[1].trim() === effectiveMode;
+      const tableLabel = line.match(/^\|\s*\*\*(.+?)\*\*\s*\|/);
+      if (tableLabel) {
+        const labelMode = normalizeMode(tableLabel[1].trim());
+        if (labelMode) return labelMode === effectiveMode;
+      }
 
-      const exampleMatch = line.match(/^-\s*([^:]+):\s*/);
-      if (exampleMatch) return exampleMatch[1].trim() === effectiveMode;
+      const exampleLabel = line.match(/^-\s*([^:]+):\s*/);
+      if (exampleLabel) {
+        const labelMode = normalizeMode(exampleLabel[1].trim());
+        if (labelMode) return labelMode === effectiveMode;
+      }
 
       return true;
     })

--- a/pi-extension/test/helpers.test.js
+++ b/pi-extension/test/helpers.test.js
@@ -66,3 +66,20 @@ test("filterSkillBodyForMode keeps only requested intensity examples and rows", 
   assert.ok(filtered.includes("Ultra example"));
   assert.ok(filtered.includes("Other line"));
 });
+
+test("filterSkillBodyForMode keeps rule bullets that contain a colon", () => {
+  // Regression: rule bullets outside the Intensity section (e.g. the
+  // "No unrequested abstractions:" rule or the `ponytail:` comment convention)
+  // contain a colon and must not be mistaken for mode-example lines.
+  const skillPath = join(import.meta.dirname, "..", "..", "skills", "ponytail", "SKILL.md");
+  const body = readFileSync(skillPath, "utf8");
+
+  const filtered = filterSkillBodyForMode(body, "full");
+
+  assert.ok(filtered.includes("No unrequested abstractions"));
+  assert.ok(filtered.includes("Mark deliberate simplifications"));
+  // The Intensity examples are still filtered down to the active mode.
+  assert.ok(filtered.includes('full: "`@lru_cache'));
+  assert.ok(!filtered.includes('lite: "Done'));
+  assert.ok(!filtered.includes('ultra: "No cache'));
+});


### PR DESCRIPTION
## Problem
`filterSkillBodyForMode` classified any `- label: ...` markdown bullet as an
Intensity mode-example, keeping it only when the label matched the active mode.
Two real rule bullets contain a colon, so they were silently stripped from the
SessionStart injection in every mode:

- `No unrequested abstractions: ...`
- the entire `ponytail:` comment convention (`Mark deliberate simplifications ...`)

## Fix
A row/bullet is only mode-specific when its label normalizes to a runtime mode
(lite/full/ultra) via the existing `normalizeMode` helper. Every other
colon-bearing bullet falls through and is kept verbatim. No new state, no
coupling to SKILL.md's heading names.

## Tests
Added a regression test that runs the filter over the real SKILL.md and asserts
the colon-bearing rules survive while off-mode examples are still filtered out.
All 12 tests pass (`node --test` in `pi-extension/`).
