### PR TITLE
Update Windows hook environment variable syntax for PowerShell

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
-            "commandWindows": "node \"%CLAUDE_PLUGIN_ROOT%\\hooks\\ponytail-activate.js\"",
+            "commandWindows": "powershell -ExecutionPolicy Bypass -File \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.ps1\"",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
           }
@@ -20,7 +20,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
-            "commandWindows": "node \"%CLAUDE_PLUGIN_ROOT%\\hooks\\ponytail-mode-tracker.js\"",
+            "commandWindows": "powershell -ExecutionPolicy Bypass -File \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.ps1\"",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."
           }


### PR DESCRIPTION
This updates the commandWindows paths to use PowerShell's $env: syntax instead of cmd's %VAR% syntax, which fixes the hook failures on Windows