### PR TITLE
feat: add Gemini CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 <p align="center">
   <img src="https://img.shields.io/github/stars/DietrichGebert/ponytail?style=flat-square&color=111111&label=stars" alt="Stars">
   <img src="https://img.shields.io/github/v/release/DietrichGebert/ponytail?style=flat-square&color=111111&label=release" alt="Release">
-  <img src="https://img.shields.io/badge/works%20with-10%20agents-111111?style=flat-square" alt="Works with 10 agents">
+  <img src="https://img.shields.io/badge/works%20with-11%20agents-111111?style=flat-square" alt="Works with 11 agents">
   <img src="https://img.shields.io/badge/license-MIT-111111?style=flat-square" alt="MIT license">
 </p>
 
@@ -100,6 +100,14 @@ Run OpenCode from a checkout of this repo (the plugin reuses its `hooks/` and `s
 ```
 
 Injects the ruleset every turn at the active level; adds `/ponytail` and `/ponytail-review`. OpenCode also auto-loads this repo's `AGENTS.md`, so the rules hold even without the plugin. The plugin adds the `lite/full/ultra/off` levels.
+
+### Gemini CLI
+
+```bash
+gemini extensions install https://github.com/DietrichGebert/ponytail
+```
+
+Loads the ruleset as always-on context every session and registers `/ponytail` and `/ponytail-review`; the `skills/` ship too, activated when a task needs them.
 
 That was it. He'd be proud. He won't say it.
 

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -11,6 +11,7 @@ to load in a given agent.
 | Claude Code | `.claude-plugin/`, `commands/`, `hooks/` | Full plugin install with session activation, mode tracking, commands, and statusline support. |
 | Codex | `.codex-plugin/plugin.json`, `hooks/hooks.json`, `hooks/`, `skills/` | Plugin install with the same skills plus lifecycle hooks for activation and mode tracking. |
 | OpenCode | `.opencode/plugins/ponytail.mjs`, `.opencode/command/`, `hooks/`, `skills/` | Server plugin injects the ruleset each turn via `experimental.chat.system.transform` and persists `/ponytail` switches; reuses the shared instruction builder. |
+| Gemini CLI | `gemini-extension.json`, `AGENTS.md`, `commands/`, `skills/` | Extension manifest points `contextFileName` at `AGENTS.md` for always-on rules, and reuses the existing `commands/*.toml` (`/ponytail`, `/ponytail-review`) and `skills/`, which Gemini CLI auto-discovers. |
 | Cursor | `.cursor/rules/ponytail.mdc` | Always-on project rule. |
 | Windsurf | `.windsurf/rules/ponytail.md` | Project rule. |
 | Cline | `.clinerules/ponytail.md` | Project rule. |

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,0 +1,6 @@
+{
+  "name": "ponytail",
+  "version": "4.2.0",
+  "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
+  "contextFileName": "AGENTS.md"
+}

--- a/tests/gemini-extension.test.js
+++ b/tests/gemini-extension.test.js
@@ -31,19 +31,28 @@ function read(relPath) {
   return fs.readFileSync(path.join(root, relPath), 'utf8');
 }
 
-const manifest = JSON.parse(read(MANIFEST));
+// Read inside each test (not at module scope) so a missing or malformed manifest
+// surfaces as a clean per-test assertion failure, not a load-time crash that
+// collapses every case into one unreadable stack trace.
+function loadManifest() {
+  assert.ok(fs.existsSync(path.join(root, MANIFEST)), `${MANIFEST} must exist`);
+  return JSON.parse(read(MANIFEST));
+}
 
 test('manifest names the ponytail extension with a pinned version', () => {
+  const manifest = loadManifest();
   assert.equal(manifest.name, EXTENSION_NAME);
   assert.match(manifest.version, PINNED_SEMVER);
 });
 
 test('version stays aligned with the other plugin manifests', () => {
+  const manifest = loadManifest();
   const claude = JSON.parse(read('.claude-plugin/plugin.json'));
   assert.equal(manifest.version, claude.version);
 });
 
 test('contextFileName resolves to a file carrying the ponytail rules', () => {
+  const manifest = loadManifest();
   assert.ok(manifest.contextFileName, 'contextFileName must be set so rules load every session');
   const context = read(manifest.contextFileName);
   for (const phrase of RULE_INVARIANTS) {

--- a/tests/gemini-extension.test.js
+++ b/tests/gemini-extension.test.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+// Smoke test for the Gemini CLI adapter. The adapter is a single thin manifest
+// (gemini-extension.json) that reuses the repo's existing files: AGENTS.md for
+// always-on context, commands/*.toml for /ponytail + /ponytail-review, and
+// skills/ for the agent skills. This test fails if the manifest is removed,
+// loses its pinned version, or points contextFileName at a file that no longer
+// carries the load-bearing rules — i.e. if the adapter stops wiring ponytail.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const MANIFEST = 'gemini-extension.json';
+const EXTENSION_NAME = 'ponytail';
+// Floating refs are a supply-chain footgun; the manifest version must be pinned.
+const PINNED_SEMVER = /^\d+\.\d+\.\d+$/;
+// Gemini auto-discovers these by directory; the manifest is only useful if they exist.
+const REUSED_COMMANDS = ['commands/ponytail.toml', 'commands/ponytail-review.toml'];
+const REUSED_SKILLS = ['skills/ponytail/SKILL.md'];
+// Same load-bearing phrases asserted by scripts/check-rule-copies.js: the file
+// contextFileName points at must actually carry the rules, not just exist.
+const RULE_INVARIANTS = [
+  'lazy senior',
+  'input validation at trust boundaries',
+  'naive heuristic',
+];
+
+function read(relPath) {
+  return fs.readFileSync(path.join(root, relPath), 'utf8');
+}
+
+const manifest = JSON.parse(read(MANIFEST));
+
+test('manifest names the ponytail extension with a pinned version', () => {
+  assert.equal(manifest.name, EXTENSION_NAME);
+  assert.match(manifest.version, PINNED_SEMVER);
+});
+
+test('version stays aligned with the other plugin manifests', () => {
+  const claude = JSON.parse(read('.claude-plugin/plugin.json'));
+  assert.equal(manifest.version, claude.version);
+});
+
+test('contextFileName resolves to a file carrying the ponytail rules', () => {
+  assert.ok(manifest.contextFileName, 'contextFileName must be set so rules load every session');
+  const context = read(manifest.contextFileName);
+  for (const phrase of RULE_INVARIANTS) {
+    assert.ok(context.includes(phrase), `context file missing rule invariant: "${phrase}"`);
+  }
+});
+
+test('the commands and skills the adapter reuses are present', () => {
+  for (const rel of [...REUSED_COMMANDS, ...REUSED_SKILLS]) {
+    assert.ok(fs.existsSync(path.join(root, rel)), `reused file missing: ${rel}`);
+  }
+});


### PR DESCRIPTION
Closes #22.

Adds a Gemini CLI adapter. In the spirit of this repo, it's the laziest adapter possible: **one new manifest** that reuses files ponytail already ships.

## What it does

`gemini-extension.json` points `contextFileName` at the existing `AGENTS.md` (always-on rules every session) and lets Gemini CLI auto-discover the existing `commands/*.toml` (`/ponytail`, `/ponytail-review`) and `skills/`. No rule text is duplicated, so there's no new drift surface to keep in sync.

Install:

```bash
gemini extensions install https://github.com/DietrichGebert/ponytail
```

## Files

- `gemini-extension.json` — the adapter (name, pinned version `4.2.0`, `contextFileName: "AGENTS.md"`).
- `tests/gemini-extension.test.js` — node:test smoke test for the manifest + wiring.
- `docs/agent-portability.md` — Gemini CLI row in the Supported Adapters table.
- `README.md` — install block + `works with` badge 10 → 11.

## Test verification (RED → GREEN)

Suite run with `node --test tests/*.test.js pi-extension/test/*.test.js`.

**RED** — adapter reverted (`gemini-extension.json` removed):

```
not ok 1 - manifest names the ponytail extension with a pinned version
not ok 2 - version stays aligned with the other plugin manifests
not ok 3 - contextFileName resolves to a file carrying the ponytail rules
ok 4 - the commands and skills the adapter reuses are present
# pass 1
# fail 3
```

The three manifest-dependent cases fail with readable assertions; case 4 (commands/skills present) still passes — only the manifest wiring goes red.

**GREEN** — adapter present:

```
ok 1 - manifest names the ponytail extension with a pinned version
ok 2 - version stays aligned with the other plugin manifests
ok 3 - contextFileName resolves to a file carrying the ponytail rules
ok 4 - the commands and skills the adapter reuses are present
# tests 20
# pass 20
# fail 0
```

`node scripts/check-rule-copies.js` stays green (AGENTS.md untouched).

## End-to-end verification on real Gemini CLI (v0.38.2)

Linked the extension and ran a prompt that normally invites over-engineering. Gemini auto-activated the bundled `ponytail` skill and produced lazy-senior output with the ceiling-comment upgrade path:

```
$ gemini extensions link . --consent
$ gemini -p "Write a JavaScript function that validates an email address."

I will use the `ponytail` skill to provide the simplest and most efficient
solution for email validation.

const validateEmail = (email) => /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
→ skipped: complex regex, add when you need to strictly match RFC 5322.
```
