### PR TITLE
fix: Windows hooks fail under PowerShell (cmd.exe %VAR% not expanded)

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -7,7 +7,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
-            "commandWindows": "node \"%CLAUDE_PLUGIN_ROOT%\\hooks\\ponytail-activate.js\"",
+            "commandWindows": "node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\"",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
           }
@@ -20,7 +20,7 @@
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
-            "commandWindows": "node \"%CLAUDE_PLUGIN_ROOT%\\hooks\\ponytail-mode-tracker.js\"",
+            "commandWindows": "node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\"",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."
           }

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -1,0 +1,48 @@
+#!/usr/bin/env node
+// Regression test for issue #19: on Windows the lifecycle hooks run via
+// PowerShell, which does NOT expand cmd.exe-style %VAR% — it needs $env:VAR.
+// The hook also has to point at a script that actually ships in hooks/.
+// This guards both failure modes: the original %CLAUDE_PLUGIN_ROOT% bug, and
+// the "switch to a .ps1 that doesn't exist" mistake.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const HOOKS_JSON = 'hooks/hooks.json';
+// cmd.exe variable syntax (%FOO%); PowerShell leaves it literal, breaking the path.
+const CMD_VAR_SYNTAX = /%[A-Za-z_][A-Za-z0-9_]*%/;
+// Pull the hooks/<script> a command launches, so we can check it exists.
+const HOOK_SCRIPT = /hooks[\\/]([\w.-]+\.(?:js|mjs|cjs|ps1|sh))/;
+
+// Read inside each case so a missing/malformed file fails as a clean assertion,
+// not a load-time crash.
+function commandHooks() {
+  const config = JSON.parse(fs.readFileSync(path.join(root, HOOKS_JSON), 'utf8'));
+  return Object.values(config.hooks)
+    .flat()
+    .flatMap((entry) => entry.hooks);
+}
+
+test('every commandWindows uses PowerShell $env: syntax, not cmd.exe %VAR%', () => {
+  const windowsCommands = commandHooks()
+    .map((h) => h.commandWindows)
+    .filter(Boolean);
+  assert.ok(windowsCommands.length > 0, 'expected at least one commandWindows entry');
+  for (const cmd of windowsCommands) {
+    assert.doesNotMatch(cmd, CMD_VAR_SYNTAX, `commandWindows uses cmd.exe %VAR% (breaks under PowerShell): ${cmd}`);
+  }
+});
+
+test('every hook command points at a script that ships in hooks/', () => {
+  for (const hook of commandHooks()) {
+    for (const cmd of [hook.command, hook.commandWindows].filter(Boolean)) {
+      const match = cmd.match(HOOK_SCRIPT);
+      assert.ok(match, `cannot find a hooks/ script in command: ${cmd}`);
+      const script = path.join(root, 'hooks', match[1]);
+      assert.ok(fs.existsSync(script), `command references a missing hook script: ${match[1]}`);
+    }
+  }
+});


### PR DESCRIPTION
Closes #19.

On Windows, Ponytail's lifecycle hooks fail with `SessionStart hook (failed): exit code 1` and `UserPromptSubmit hook (failed): exit code 1`. As @AryanYadav215 (issue author) diagnosed, the `commandWindows` entries use cmd.exe's `%CLAUDE_PLUGIN_ROOT%`, but the command runs under **PowerShell**, which doesn't expand `%VAR%` — so the path is passed literally and the launcher can't find the hook script.

## Fix

Swap the two `commandWindows` entries to PowerShell's `$env:` syntax, keeping the working `node` + `.js` invocation (the `.js` files are what the repo ships):

```diff
- "commandWindows": "node \"%CLAUDE_PLUGIN_ROOT%\\hooks\\ponytail-activate.js\"",
+ "commandWindows": "node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\"",
```

(Same for `ponytail-mode-tracker.js`.) Minimal diff: only the variable syntax changes.

## Why not point at `.ps1` files

#21 attempts the same `$env:` insight but rewrites the commands to `powershell ... -File "$env:CLAUDE_PLUGIN_ROOT\hooks\ponytail-activate.ps1"`. Those `.ps1` files don't exist in the repo (and never have — only `ponytail-statusline.ps1` ships), so the hooks would still fail; that PR also points the mode-tracker hook at `ponytail-activate.ps1`. Keeping `node` + the existing `.js` is the smaller, working fix.

## Reproduction (PowerShell Core 7.4, Linux container — the bug is variable expansion, not OS)

Path separators forced to `/` to isolate the variable-expansion root cause.

```
A) current main  : %CLAUDE_PLUGIN_ROOT%/hooks/ponytail-activate.js  -> literal, found=False, exit=1   (the bug)
B) this fix       : $env:CLAUDE_PLUGIN_ROOT/hooks/ponytail-activate.js -> /plugin/hooks/...js, found=True, exit=0
C) #21 (.ps1)     : $env:CLAUDE_PLUGIN_ROOT/hooks/ponytail-activate.ps1 -> found=False, exit=1          (still broken)
```

## Test verification (RED → GREEN)

Added `tests/hooks-windows.test.js`. Run: `node --test tests/*.test.js pi-extension/test/*.test.js`.

**RED-A** — fix reverted to `%CLAUDE_PLUGIN_ROOT%` (the original bug):

```
not ok 1 - every commandWindows uses PowerShell $env: syntax, not cmd.exe %VAR%
ok 2 - every hook command points at a script that ships in hooks/
# pass 1 / fail 1
```

**RED-B** — commands switched to non-existent `.ps1` (the #21 approach):

```
ok 1 - every commandWindows uses PowerShell $env: syntax, not cmd.exe %VAR%
not ok 2 - every hook command points at a script that ships in hooks/
# pass 1 / fail 1
```

**GREEN** — this fix:

```
ok 1 - every commandWindows uses PowerShell $env: syntax, not cmd.exe %VAR%
ok 2 - every hook command points at a script that ships in hooks/
# tests 18
# pass 18
# fail 0
```

The regression test catches **both** failure modes — the original `%VAR%` bug and the missing-`.ps1` mistake.
