### PR TITLE
docs: document GitHub Copilot CLI support

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Cursor, Windsurf, Cline, Copilot, Aider, Kiro: copy the matching rules file from
 
 Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kiro/steering/` in your project.
 
+GitHub Copilot CLI: it already reads `AGENTS.md` and `.github/copilot-instructions.md` in a project, or copy the rules into `~/.copilot/copilot-instructions.md` to run ponytail in every project.
+
 Which files map to which agent: [Agent portability](docs/agent-portability.md).
 
 ## Development

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -16,6 +16,7 @@ to load in a given agent.
 | Windsurf | `.windsurf/rules/ponytail.md` | Project rule. |
 | Cline | `.clinerules/ponytail.md` | Project rule. |
 | GitHub Copilot | `.github/copilot-instructions.md` | Repository instruction file. |
+| GitHub Copilot CLI | `AGENTS.md`, `.github/copilot-instructions.md`, `~/.copilot/copilot-instructions.md` | Reads custom instructions: per-project from `AGENTS.md` or `.github/copilot-instructions.md`, or globally from `~/.copilot/copilot-instructions.md`. Instruction-tier (no `/ponytail` levels or hooks). |
 | Kiro | `.kiro/steering/ponytail.md` | Steering rule; copy globally or into a project. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 


### PR DESCRIPTION
Copilot CLI already reads `AGENTS.md` and `.github/copilot-instructions.md` (both shipped in this repo), plus a global `~/.copilot/copilot-instructions.md`. No new adapter needed.

Adds an agent-portability row and a README note so it's discoverable. Instruction-tier only (no `/ponytail` levels or hooks), same as the Cursor/Windsurf adapters.

Closes #27.

🤖 Generated with [Claude Code](https://claude.com/claude-code)