### PR TITLE
chore: bump version to 4.3.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.2.0",
+  "version": "4.3.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "contextFileName": "AGENTS.md"
 }


### PR DESCRIPTION
Release-prep version bump (4.2.0 → 4.3.0) across the Claude Code, Codex, and Gemini manifests.

Cutting v4.3.0 fixes #33: `gemini extensions install` pulls the latest GitHub release, and `gemini-extension.json` was added after v4.2.0, so it was missing from the release tarball. Shipping it in a release makes the plain install command work.

The v4.3.0 release will also carry everything merged since v4.2.0: ponytail-audit skill, Gemini CLI support, Antigravity + Copilot CLI docs, the Windows hook fix, the benchmark correctness gate, and the CLAUDE_CONFIG_DIR fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)