### PR TITLE
docs: use the dark logo in the README header on dark themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 <p align="center">
-  <img src="assets/logo.png" width="220" alt="Ponytail, the lazy senior dev">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.png">
+    <img src="assets/logo.png" width="220" alt="Ponytail, the lazy senior dev">
+  </picture>
 </p>
 
 <h1 align="center">Ponytail</h1>


### PR DESCRIPTION
The README header showed `logo.png` (black on transparent), which nearly vanishes for anyone viewing the repo in GitHub's dark theme. Now it's wrapped in a `<picture>`:

```html
<picture>
  <source media="(prefers-color-scheme: dark)" srcset="assets/logo-dark.png">
  <img src="assets/logo.png" width="220" alt="Ponytail, the lazy senior dev">
</picture>
```

Dark theme gets @pixexid's contoured `logo-dark.png` (#42/#43); light theme keeps the original. This is the first actual use of the dark logo on a dark surface.

Note: GitHub renders `prefers-color-scheme` in `<picture>` server-side per the viewer's theme, so it can't be checked locally, confirm by viewing the README with the GitHub dark theme after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)