### PR TITLE
fix: use python3 for correctness checks and add CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,29 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Python deps for correctness checks
+        run: pip install pandas
+
+      - name: Check rule copies
+        run: node scripts/check-rule-copies.js
+
+      - name: Run tests
+        run: npm test

--- a/README.md
+++ b/README.md
@@ -144,7 +144,10 @@ When changing the compact rule text, keep the agent copies aligned:
 
 ```bash
 node scripts/check-rule-copies.js
+npm test
 ```
+
+The correctness benchmark spawns Python for email and CSV checks; `python3` is tried before `python`. CSV checks need `pandas` installed locally.
 
 ## FAQ
 

--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -38,6 +38,20 @@ function exec(cmd, opts = {}) {
   }
 }
 
+// ponytail: probe once at load; macOS and many Linux images ship python3 only.
+let pythonCmd;
+function python() {
+  if (pythonCmd) return pythonCmd;
+  for (const cmd of ['python3', 'python']) {
+    if (exec(`${cmd} -c "import sys"`).ok) {
+      pythonCmd = cmd;
+      return pythonCmd;
+    }
+  }
+  pythonCmd = 'python3';
+  return pythonCmd;
+}
+
 // Write content to a temp file, return the path.
 function tmpFile(ext, content) {
   const p = path.join(os.tmpdir(), `ponytail-bench-${Date.now()}-${Math.random().toString(36).slice(2)}${ext}`);
@@ -100,7 +114,7 @@ if failures:
 print("PASS")
 `;
     const f = tmpFile('.py', harness);
-    const result = exec(`python "${f}"`);
+    const result = exec(`${python()} "${f}"`);
     fs.unlinkSync(f);
     if (result.ok) return { pass: true, reason: 'Email validator passes all checks' };
     return { pass: false, reason: result.stderr || 'Email validator failed' };
@@ -194,7 +208,7 @@ else:
     sys.exit(1)
 `;
     const f = tmpFile('.py', harness);
-    const result = exec(`python "${f}"`);
+    const result = exec(`${python()} "${f}"`);
     try { fs.unlinkSync(f); } catch (e) {}
     try { fs.unlinkSync(csvPath); } catch (e) {}
     if (result.ok) return { pass: true, reason: 'CSV sum produces correct result (351)' };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
   "keywords": ["pi-package", "pi", "skills", "ponytail"],
   "license": "MIT",
+  "scripts": {
+    "test": "node --test tests/*.test.js && npm test --prefix pi-extension"
+  },
   "pi": {
     "extensions": ["./pi-extension/index.js"],
     "skills": ["./skills"]


### PR DESCRIPTION
## Summary
- Fix the correctness benchmark harness to probe `python3` before `python` (macOS and many CI images ship only `python3`, which caused email and CSV checks to fail locally)
- Add a root `npm test` script that runs the repo and pi-extension test suites
- Add a GitHub Actions workflow that runs rule-copy checks and the full test suite on every push/PR

## Test plan
- [x] `npm test` passes locally (43 tests)
- [x] `node scripts/check-rule-copies.js` passes
- [ ] CI workflow passes on this PR


Made with [Cursor](https://cursor.com)