### PR TITLE
docs: bump the agents badge to 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img src="https://img.shields.io/github/stars/DietrichGebert/ponytail?style=flat-square&color=111111&label=stars" alt="Stars">
   <img src="https://img.shields.io/github/v/release/DietrichGebert/ponytail?style=flat-square&color=111111&label=release" alt="Release">
-  <img src="https://img.shields.io/badge/works%20with-11%20agents-111111?style=flat-square" alt="Works with 11 agents">
+  <img src="https://img.shields.io/badge/works%20with-13%20agents-111111?style=flat-square" alt="Works with 13 agents">
   <img src="https://img.shields.io/badge/license-MIT-111111?style=flat-square" alt="MIT license">
 </p>
 


### PR DESCRIPTION
The 'works with N agents' badge had silently fallen behind. It stayed at 11 when Antigravity and the VS Code + Codex extension landed, and Copilot CLI is now a full plugin host. The portability table lists 13 distinct agents (excluding the generic fallback), so the badge now matches.