### PR TITLE
fix: hooks degrade gracefully when node is not on PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Lazy, not negligent: trust-boundary validation, data-loss handling, security, an
 
 The most effort ponytail will ever ask of you:
 
+The Claude Code and Codex plugins run two tiny Node.js lifecycle hooks, so `node` needs to be on your PATH (note for Nix/nvm users: it must be on the non-interactive shell's PATH). If it isn't, the skills still work, the always-on activation just stays quiet instead of erroring on every prompt.
+
 ### Claude Code
 
 ```

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
-            "commandWindows": "node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\"",
+            "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\" || exit 0",
+            "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\" }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
           }
@@ -19,8 +19,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
-            "commandWindows": "node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\"",
+            "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\" || exit 0",
+            "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\" }",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."
           }


### PR DESCRIPTION
Fixes #51.

Claude Code runs hooks through a non-interactive `/bin/sh`. On setups where `node` isn't on that shell's PATH (Nix/nix-darwin, nvm, fnm), the `SessionStart` and `UserPromptSubmit` hooks failed with `/bin/sh: node: command not found`, **on every prompt**.

- Guard each hook command: `command -v node >/dev/null 2>&1 && node "..." || exit 0` (and a `Get-Command node` guard for the PowerShell `commandWindows`). Node-absent now exits 0 silently instead of erroring every prompt.
- The slash-command skills are unaffected (Claude Code discovers `skills/` directly); only the always-on activation + mode tracking need node.
- Document the node requirement in the README install section, with a Nix/nvm note.

Verified: hooks.json parses, the guard runs node when present and exits 0 silently when absent, full suite 33/33, rule check green. @githappens offered to test on a node-less PATH.

🤖 Generated with [Claude Code](https://claude.com/claude-code)