### PR TITLE
docs: note the Codex install also covers the desktop app

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ codex
 Open `/plugins`, select the Ponytail marketplace, and install Ponytail. Then
 open `/hooks`, review and trust its two lifecycle hooks, and start a new thread.
 
+This same install also covers the Codex desktop app: restart the app after installing and it picks up the plugin.
+
 ### GitHub Copilot CLI
 
 ```bash


### PR DESCRIPTION
Closes #53. A user asked for Codex *app* support; @vldF confirmed (with a screenshot) that the existing Codex CLI install already works in the desktop app after a restart. This adds a one-line note to the Codex section so future users don't have to ask.