### PR TITLE
chore: bump version to 4.5.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ponytail",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "author": {
     "name": "Dietrich Gebert",
     "url": "https://github.com/DietrichGebert"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "contextFileName": "AGENTS.md"
 }


### PR DESCRIPTION
Release-prep bump (4.4.0 -> 4.5.0) across all four plugin manifests. Ships everything merged since v4.4.0: GitHub Copilot CLI plugin support (@maxfelker), CI + npm test + python3 fix (@christophermayfield), the node-on-PATH hook fix, the Codex desktop-app doc, and the agents badge bump.