### PR TITLE
fix: hooks no-op silently when node is missing from PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ codex
 Open `/plugins`, select the Ponytail marketplace, and install Ponytail. Then
 open `/hooks`, review and trust its two lifecycle hooks, and start a new thread.
 
+The hooks need `node` on the shell's `PATH` (they power the statusline badge and `/ponytail <level>` switching). If it isn't there — a Nix dev shell, a scoped install — the hooks no-op silently and the skills and commands still work; the mode badge just won't update.
+
 ### Pi agent harness
 
 ```

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,8 +6,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
-            "commandWindows": "node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\"",
+            "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\" || exit 0",
+            "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\" } else { exit 0 }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
           }
@@ -19,8 +19,8 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
-            "commandWindows": "node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\"",
+            "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\" || exit 0",
+            "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\" } else { exit 0 }",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."
           }

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -99,5 +99,36 @@ assert.equal(
   'flag must not land in ~/.claude when CLAUDE_CONFIG_DIR is set',
 );
 
+// issue #51: when node isn't on the shell's PATH, the lifecycle hooks must
+// degrade silently (exit 0, no stderr) instead of erroring on every prompt.
+// The guard lives in hooks.json, not the JS, so run the real command strings.
+if (process.platform !== 'win32') {
+  const hooksConfig = JSON.parse(
+    fs.readFileSync(path.join(root, 'hooks', 'hooks.json'), 'utf8'),
+  );
+  const commands = Object.values(hooksConfig.hooks)
+    .flat()
+    .flatMap((entry) => entry.hooks)
+    .map((h) => h.command.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, root));
+
+  for (const command of commands) {
+    const missingNode = spawnSync('/bin/sh', ['-c', command], {
+      env: { PATH: '/nonexistent' },
+      input: JSON.stringify({ prompt: 'hello' }),
+      encoding: 'utf8',
+    });
+    assert.equal(missingNode.status, 0, `hook must exit 0 without node: ${command}`);
+    assert.equal(missingNode.stderr, '', `hook must stay silent without node: ${command}`);
+  }
+
+  // Sanity: with node present the guard still runs the hook normally.
+  const activate = commands.find((c) => c.includes('ponytail-activate.js'));
+  const present = spawnSync('/bin/sh', ['-c', activate], {
+    env: { ...process.env, ...codexEnv },
+    encoding: 'utf8',
+  });
+  assert.equal(present.status, 0, present.stderr);
+}
+
 fs.rmSync(temp, { recursive: true, force: true });
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
fix: hooks no-op silently when node is missing from PATH

Claude Code runs lifecycle hooks via a non-interactive /bin/sh. When node
isn't on that shell's PATH (Nix / nix-darwin dev shells, scoped installs),
every SessionStart and UserPromptSubmit fired "node: command not found".

Guard each command (POSIX `command -v node` / PowerShell `Get-Command node`)
so it exits 0 and stays silent when node is absent -- the tracker is
bookkeeping and shouldn't surface an error on every prompt. Document the
node requirement in the install steps; skills and commands work without it,
only the statusline badge and /ponytail switching need it.

Adds a regression test running the real hooks.json commands under sh with
node off PATH.

Fixes #51.
