### PR TITLE
Add missing ponytail-help command files

### DIFF
--- a/.opencode/command/ponytail-help.md
+++ b/.opencode/command/ponytail-help.md
@@ -1,0 +1,5 @@
+---
+description: Show quick reference for Ponytail commands
+---
+
+Display the Ponytail quick reference card. One-shot display only: do not change mode, write flag files, or persist anything. Include levels, command list, deactivation, default mode configuration, update flow, and full docs link.

--- a/commands/ponytail-help.toml
+++ b/commands/ponytail-help.toml
@@ -1,0 +1,2 @@
+description = "Show quick reference for Ponytail commands"
+prompt = "Display the Ponytail quick reference card. One-shot display only: do not change mode, write flag files, or persist anything. Include levels, command list, deactivation, default mode configuration, update flow, and full docs link."

--- a/tests/copilot-plugin.test.js
+++ b/tests/copilot-plugin.test.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 // Smoke test for the Copilot plugin adapter: keep command wiring minimal and
-// ensure the debt command is part of the shared command surface.
+// ensure the shared command surface stays wired.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
@@ -13,13 +13,14 @@ const REQUIRED_COMMAND_FILES = [
   'ponytail-review.toml',
   'ponytail-audit.toml',
   'ponytail-debt.toml',
+  'ponytail-help.toml',
 ];
 
 function readJSON(relPath) {
   return JSON.parse(fs.readFileSync(path.join(root, relPath), 'utf8'));
 }
 
-test('copilot plugin command directory includes ponytail-debt', () => {
+test('copilot plugin command directory includes shared ponytail commands', () => {
   const manifest = readJSON('.github/plugin/plugin.json');
   assert.equal(manifest.name, 'ponytail');
   assert.equal(manifest.commands, 'commands/');


### PR DESCRIPTION
## Summary

This PR adds the missing `/ponytail-help` command surfaces so the README command list matches the actual command files.

## Changes

- Added `commands/ponytail-help.toml`
- Added `.opencode/command/ponytail-help.md`
- Updated the Copilot command smoke test to require `ponytail-help.toml`

## Tests

- `node tests\copilot-plugin.test.js`
- `node tests\gemini-extension.test.js`
- `node tests\opencode-plugin.test.js`
- `node scripts\check-rule-copies.js`

Note: `npm.cmd test` could not complete in this local sandbox because Node's test runner failed to spawn test-file subprocesses with `EPERM`; the targeted tests above passed when run directly.