### PR TITLE
docs: Antigravity CLI install, global default level, OpenCode absolute path

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,8 @@ Run OpenCode from a checkout of this repo (the plugin reuses its `hooks/` and `s
 
 Injects the ruleset every turn at the active level; adds the `/ponytail` commands (see [Commands](#commands)). OpenCode also auto-loads this repo's `AGENTS.md`, so the rules hold even without the plugin. The plugin adds the `lite/full/ultra/off` levels.
 
+The `./` path resolves against your project's `opencode.json`; to share one checkout across projects, point it at the absolute path of the `.mjs` instead (it finds its `hooks/` and `skills/` relative to its own file).
+
 ### Gemini CLI
 
 ```bash
@@ -137,9 +139,21 @@ gemini extensions install https://github.com/DietrichGebert/ponytail
 
 Loads the ruleset as always-on context every session and registers the `/ponytail` commands; the `skills/` ship too, activated when a task needs them.
 
+### Antigravity CLI
+
+Google is renaming Gemini CLI to Antigravity CLI (the `agy` binary); the same extension installs there:
+
+```bash
+agy plugin install https://github.com/DietrichGebert/ponytail
+```
+
+It reuses this repo's `gemini-extension.json`. One difference: Antigravity converts the `/ponytail` commands into skills, so you type them into the chat (e.g. `/ponytail-review` as a message) instead of picking them from a slash menu. Until the migration completes (around June 18, 2026), `gemini extensions install` still works too. To run it as an always-on rule instead, drop the ruleset into `.agents/rules/`.
+
 That was it. He'd be proud. He won't say it.
 
 Active every session, with a handful of commands (see [Commands](#commands)). `/ponytail ultra` exists for when the codebase has wronged you personally. Startup and mode-change text shows the current mode.
+
+Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`.
 
 Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
 
@@ -147,7 +161,7 @@ Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kir
 
 GitHub Copilot CLI fallback (instruction-only mode): it reads `AGENTS.md` and `.github/copilot-instructions.md` in a project, or copy the rules into `~/.copilot/copilot-instructions.md` to run ponytail in every project. This path keeps always-on guidance, but does not add plugin mode switches or hooks.
 
-Antigravity and VS Code with the Codex extension: both read `AGENTS.md`, which this repo ships, so it works from the repo root with no setup (`~/.codex/AGENTS.md` makes Codex global, `.agents/rules/` makes it an always-on rule in Antigravity).
+VS Code with the Codex extension reads `AGENTS.md`, which this repo ships, so it works from the repo root with no setup (`~/.codex/AGENTS.md` makes Codex global).
 
 Which files map to which agent: [Agent portability](docs/agent-portability.md).
 
@@ -177,7 +191,7 @@ The correctness benchmark spawns Python for email and CSV checks; `python3` is t
 ## FAQ
 
 **Does it need a config file?**
-No.
+No. An optional `~/.config/ponytail/config.json` or `PONYTAIL_DEFAULT_MODE` env var can set the default level, but nothing is required.
 
 **What if I really need the 120-line cache class?**
 You don't. Insist anyway and he'll build it. Slowly. Correctly. While looking at you.


### PR DESCRIPTION
Three doc gaps surfaced by open issues:

- **Antigravity CLI** (#58): `agy plugin install` now documented, reusing `gemini-extension.json`. Notes that commands convert to skills (type them in chat) and the ~June 18 Gemini migration. Confirmed working by multiple users on the issue.
- **Global default level** (#64): `PONYTAIL_DEFAULT_MODE` and `config.json` `defaultMode` already worked but were undocumented. Now in the install section and FAQ.
- **OpenCode absolute path** (#71): clarified that the `./` plugin path is project-relative, and an absolute path to the `.mjs` works across projects.

Docs only, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)