### PR TITLE
fix: emit per-turn reminder in UserPromptSubmit to prevent drift after compaction

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -3,14 +3,14 @@
 // Inspects user input for /ponytail commands and writes mode to flag file
 
 const { getDefaultMode } = require('./ponytail-config');
-const { clearMode, setMode, writeHookOutput } = require('./ponytail-runtime');
+const { clearMode, getMode, setMode, writeHookOutput } = require('./ponytail-runtime');
 
 let input = '';
 process.stdin.on('data', chunk => { input += chunk; });
 process.stdin.on('end', () => {
   try {
     // Strip UTF-8 BOM some shells prepend when piping (breaks JSON.parse)
-    const data = JSON.parse(input.replace(/^\uFEFF/, ''));
+    const data = JSON.parse(input.replace(/^﻿/, ''));
     const prompt = (data.prompt || '').trim().toLowerCase();
 
     // Match /ponytail commands
@@ -38,9 +38,11 @@ process.stdin.on('end', () => {
           mode,
           'PONYTAIL MODE CHANGED — level: ' + mode,
         );
+        return;
       } else if (mode === 'off') {
         clearMode();
         writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
+        return;
       }
     }
 
@@ -48,6 +50,13 @@ process.stdin.on('end', () => {
     if (/\b(stop ponytail|normal mode)\b/i.test(prompt)) {
       clearMode();
       writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
+      return;
+    }
+
+    // Per-turn reminder: prevents drift when SessionStart context is compacted away
+    const activeMode = getMode();
+    if (activeMode && activeMode !== 'off') {
+      writeHookOutput('UserPromptSubmit', activeMode, 'PONYTAIL MODE ACTIVE — level: ' + activeMode);
     }
   } catch (e) {
     // Silent fail

--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -21,6 +21,10 @@ function clearMode() {
   try { fs.unlinkSync(statePath); } catch (e) {}
 }
 
+function getMode() {
+  try { return fs.readFileSync(statePath, 'utf8').trim(); } catch (e) { return null; }
+}
+
 function writeHookOutput(event, mode, context = '') {
   if (isCopilot) {
     // Copilot reads additionalContext on SessionStart; ignores output elsewhere.
@@ -44,6 +48,7 @@ function writeHookOutput(event, mode, context = '') {
 
 module.exports = {
   clearMode,
+  getMode,
   isCodex,
   isCopilot,
   setMode,


### PR DESCRIPTION
## Problem

`SessionStart` injects the full ponytail ruleset once. When the context window fills and compacts, that injection disappears. The `UserPromptSubmit` hook only fires context on `/ponytail` commands — silent the rest of the time. Result: model drifts back to over-building mid-session with no reminder.

## Fix

`ponytail-mode-tracker.js` now emits a brief `PONYTAIL MODE ACTIVE — level: {mode}` reminder on every turn (when active), matching the pattern already used by tools like Caveman. This keeps the active mode in context across compaction boundaries.

Changes:
- `hooks/ponytail-runtime.js`: export `getMode()` — reads current mode from the flag file
- `hooks/ponytail-mode-tracker.js`: import `getMode()`, add early `return` on mode-change paths, emit per-turn reminder at the end of the normal (non-command) path

The reminder is one line, zero overhead when ponytail is off.
