### PR TITLE
Add an opt-in readability guard (off by default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,7 +155,12 @@ Active every session, with a handful of commands (see [Commands](#commands)). `/
 
 Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`.
 
-**Readability guard (opt-in, off by default).** Writing little is the senior move, not the goal. Turn this on and ponytail adds one rule to the active level: never buy fewer lines with worse architecture, readability, scalability, maintainability, or modularity — when short and clear pull apart, clear wins. Enable with `PONYTAIL_GUARD_READABILITY=1` or `"guardReadability": true` in the same config file. Nothing changes unless you opt in.
+**Readability guard (opt-in, off by default).** Writing little is the senior move, not the goal. Turn this on and ponytail adds one rule to the active level: never buy fewer lines with worse architecture, readability, scalability, maintainability, or modularity — when short and clear pull apart, clear wins.
+
+- **Turn it on:** `PONYTAIL_GUARD_READABILITY=1` (env), or `"guardReadability": true` in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows).
+- **Turn it off:** drop the env var (or set it to `0`), or `"guardReadability": false`. It's off by default, so doing nothing keeps it off.
+- **Precedence:** the env var wins over the config file. The env var is read at session start; the config file is read each turn.
+- **What it changes:** when on, the agent gets one extra rule at the top of every turn — no slash command, no new dependency. Everyone who doesn't set it sees ponytail exactly as before.
 
 Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Active every session, with a handful of commands (see [Commands](#commands)). `/
 
 Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`.
 
+**Readability guard (opt-in, off by default).** Writing little is the senior move, not the goal. Turn this on and ponytail adds one rule to the active level: never buy fewer lines with worse architecture, readability, scalability, maintainability, or modularity — when short and clear pull apart, clear wins. Enable with `PONYTAIL_GUARD_READABILITY=1` or `"guardReadability": true` in the same config file. Nothing changes unless you opt in.
+
 Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
 
 Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kiro/steering/` in your project.

--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -77,13 +77,34 @@ function getDefaultMode() {
   return DEFAULT_MODE;
 }
 
+function readConfig() {
+  try {
+    return JSON.parse(fs.readFileSync(getConfigPath(), 'utf8'));
+  } catch (e) {
+    return {};
+  }
+}
+
+// Opt-in readability guard (default off). Keeps "write less code" from
+// turning into unreadable golf: env wins, then config, then off.
+function getReadabilityGuard() {
+  const env = process.env.PONYTAIL_GUARD_READABILITY;
+  if (typeof env === 'string') {
+    return ['1', 'true', 'yes', 'on'].includes(env.trim().toLowerCase());
+  }
+  return readConfig().guardReadability === true;
+}
+
 function writeDefaultMode(mode) {
   const normalized = normalizeConfigMode(mode);
   if (!normalized) return null;
 
   const configPath = getConfigPath();
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
-  fs.writeFileSync(configPath, JSON.stringify({ defaultMode: normalized }, null, 2), 'utf8');
+  // Merge so we don't clobber other fields (e.g. guardReadability).
+  const config = readConfig();
+  config.defaultMode = normalized;
+  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
   return normalized;
 }
 
@@ -92,6 +113,7 @@ module.exports = {
   VALID_MODES,
   RUNTIME_MODES,
   getDefaultMode,
+  getReadabilityGuard,
   getConfigDir,
   getConfigPath,
   getClaudeDir,

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -3,9 +3,23 @@
 
 const fs = require('fs');
 const path = require('path');
-const { DEFAULT_MODE, normalizeMode, normalizePersistedMode } = require('./ponytail-config');
+const { DEFAULT_MODE, normalizeMode, normalizePersistedMode, getReadabilityGuard } = require('./ponytail-config');
 
 const INDEPENDENT_MODES = new Set(['review']);
+
+// Appended to the active ruleset only when the opt-in readability guard is on
+// (PONYTAIL_GUARD_READABILITY / config guardReadability). The point of writing
+// little is to work like a senior, not to win at code golf.
+const READABILITY_GUARD_CLAUSE =
+  '\n\n## Readability guard (opt-in)\n\n' +
+  'Writing little is the senior move, not the goal. Never buy fewer lines with worse ' +
+  'architecture, readability, scalability, maintainability, or modularity. A one-liner that ' +
+  'swallows two well-named helpers and now needs decoding is not senior, it is a junior flexing — ' +
+  'keep the helpers. When short and clear pull apart, clear wins; say which corner you cut in one line.';
+
+function withReadabilityGuard(instructions) {
+  return getReadabilityGuard() ? instructions + READABILITY_GUARD_CLAUSE : instructions;
+}
 const SKILL_PATH = path.join(__dirname, '..', 'skills', 'ponytail', 'SKILL.md');
 
 function filterSkillBodyForMode(body, mode) {
@@ -77,12 +91,14 @@ function getPonytailInstructions(mode) {
 
   const effectiveMode = normalizeMode(configuredMode) || DEFAULT_MODE;
 
+  let instructions;
   try {
-    return 'PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' +
+    instructions = 'PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' +
       filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode);
   } catch (e) {
-    return getFallbackInstructions(effectiveMode);
+    instructions = getFallbackInstructions(effectiveMode);
   }
+  return withReadabilityGuard(instructions);
 }
 
 module.exports = {

--- a/tests/readability-guard.test.js
+++ b/tests/readability-guard.test.js
@@ -1,0 +1,46 @@
+#!/usr/bin/env node
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+// Isolate the config dir so the host machine's real config can't sway results.
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-guard-'));
+process.env.XDG_CONFIG_HOME = temp;
+delete process.env.PONYTAIL_GUARD_READABILITY;
+
+const { getReadabilityGuard } = require('../hooks/ponytail-config');
+const { getPonytailInstructions } = require('../hooks/ponytail-instructions');
+
+// Default: off → no clause in the ruleset.
+assert.equal(getReadabilityGuard(), false, 'guard defaults off');
+assert.ok(
+  !getPonytailInstructions('full').includes('Readability guard'),
+  'no clause when the guard is off',
+);
+
+// Config file turns it on.
+fs.mkdirSync(path.join(temp, 'ponytail'), { recursive: true });
+fs.writeFileSync(
+  path.join(temp, 'ponytail', 'config.json'),
+  JSON.stringify({ guardReadability: true }),
+);
+assert.equal(getReadabilityGuard(), true, 'config guardReadability turns it on');
+
+// Env overrides config: an explicit off wins.
+process.env.PONYTAIL_GUARD_READABILITY = 'off';
+assert.equal(getReadabilityGuard(), false, 'env off overrides config on');
+
+// Env on → clause is appended and names the dimensions it protects.
+process.env.PONYTAIL_GUARD_READABILITY = '1';
+const on = getPonytailInstructions('full');
+assert.ok(on.includes('## Readability guard (opt-in)'), 'clause present when on');
+assert.ok(
+  on.includes('architecture, readability, scalability, maintainability, or modularity'),
+  'clause names the protected dimensions',
+);
+
+delete process.env.PONYTAIL_GUARD_READABILITY;
+fs.rmSync(temp, { recursive: true, force: true });
+console.log('readability guard checks passed');


### PR DESCRIPTION
Ponytail already says "lazy means efficient, not careless" and keeps input validation, data-loss handling, security and accessibility off the chopping block. One thing that isn't on that list: readability.

The whole point is to lean on being a senior and write little code — but "little" should never quietly cost the things a senior actually protects: sound architecture, readability, scalability, maintainability, modularity. A one-line lambda that swallows two well-named helpers and now takes a minute to decode isn't the senior move, it's a junior flexing. "Boring over clever" hints at this, but it's a soft preference, not a guard.

This adds it as an opt-in, off by default, so nothing changes for anyone who doesn't want it:

- `PONYTAIL_GUARD_READABILITY=1`, or `"guardReadability": true` in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows)
- When on, the hook appends one clause to the active level: never buy fewer lines with worse architecture, readability, scalability, maintainability or modularity; when short and clear pull apart, clear wins — and name the corner you cut in one line.

A few implementation notes:

- It rides the existing config resolver (`ponytail-config.js`, same place as `defaultMode`): env first, then config, default off.
- It only touches the hook-injected ruleset (`ponytail-instructions.js`). The canonical rule files (`AGENTS.md` and the `.cursor` / `.windsurf` / `.clinerules` / `.kiro` / copilot copies) are untouched, so `check-rule-copies.js` stays green.
- `writeDefaultMode` now merges the config file instead of overwriting it, so `/ponytail <level>` no longer wipes the flag.
- Added `tests/readability-guard.test.js` (off → clause absent; env/config on → clause present and names the dimensions). `npm test` passes locally; the one CSV correctness check needs `pandas` on the machine, unrelated to this change.

Happy to reword the clause, or gate it behind a level instead of a flag, if you'd prefer — this felt like the least invasive shape.
