### PR TITLE
Add Hermes Agent plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img src="https://img.shields.io/github/stars/DietrichGebert/ponytail?style=flat-square&color=111111&label=stars" alt="Stars">
   <img src="https://img.shields.io/github/v/release/DietrichGebert/ponytail?style=flat-square&color=111111&label=release" alt="Release">
-  <img src="https://img.shields.io/badge/works%20with-13%20agents-111111?style=flat-square" alt="Works with 13 agents">
+  <img src="https://img.shields.io/badge/works%20with-14%20agents-111111?style=flat-square" alt="Works with 14 agents">
   <img src="https://img.shields.io/badge/license-MIT-111111?style=flat-square" alt="MIT license">
 </p>
 
@@ -139,6 +139,14 @@ gemini extensions install https://github.com/DietrichGebert/ponytail
 
 Loads the ruleset as always-on context every session and registers the `/ponytail` commands; the `skills/` ship too, activated when a task needs them.
 
+### Hermes Agent
+
+```bash
+hermes plugins install DietrichGebert/ponytail --enable
+```
+
+Restart Hermes after installing. Hermes starts with ponytail off; turn it on explicitly with `/ponytail on`, `/ponytail lite`, `/ponytail full`, or `/ponytail ultra`. Turn it off with `/ponytail off`. The plugin injects the active ponytail level through Hermes' `pre_llm_call` hook and registers the bundled skills as `ponytail:<skill-name>` for explicit loading.
+
 ### Antigravity CLI
 
 Google is renaming Gemini CLI to Antigravity CLI (the `agy` binary); the same extension installs there:
@@ -169,13 +177,13 @@ Which files map to which agent: [Agent portability](docs/agent-portability.md).
 
 | Command | What it does |
 |---------|--------------|
-| `/ponytail [lite \| full \| ultra \| off]` | Set the intensity, or turn it off. No argument reports the current level. |
+| `/ponytail on \| off \| lite \| full \| ultra` | Set the intensity, or turn it off. `on` maps to `full`. |
 | `/ponytail-review` | Review the current diff for over-engineering, hands back a delete-list. |
 | `/ponytail-audit` | Audit the whole repo for over-engineering, not just the diff. |
 | `/ponytail-debt` | Harvest the `ponytail:` shortcuts you've deferred into a ledger, so "later" doesn't become "never". |
 | `/ponytail-help` | Quick reference for the commands above. |
 
-Commands need a skill-capable host (Claude Code, Codex, OpenCode, Gemini, pi). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
+Commands need a skill-capable host (Claude Code, Codex, OpenCode, Gemini, Hermes Agent, pi). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
 
 ## Development
 

--- a/__init__.py
+++ b/__init__.py
@@ -1,0 +1,94 @@
+"""Hermes Agent adapter for Ponytail."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Any
+
+PLUGIN_DIR = Path(__file__).resolve().parent
+SKILLS_DIR = PLUGIN_DIR / "skills"
+DEFAULT_MODE = "full"
+VALID_MODES = {"off", "lite", "full", "ultra"}
+ACTIVE_MODES = VALID_MODES - {"off"}
+
+_MODE_CMD = re.compile(r"^/ponytail(?:\s+(on|off|lite|full|ultra))?\s*$")
+_MODES: dict[str, str] = {}
+
+
+def _mode(value: object) -> str | None:
+    value = str(value or "").strip().lower()
+    if value == "on":
+        return DEFAULT_MODE
+    return value if value in VALID_MODES else None
+
+
+def _key(session_id: object = None) -> str:
+    return str(session_id or "global")
+
+
+def _get_mode(session_id: object = None) -> str:
+    return _MODES.get(_key(session_id)) or _MODES.get("global") or "off"
+
+
+def _set_mode(mode: str, session_id: object = None) -> str:
+    _MODES[_key(session_id)] = _mode(mode) or DEFAULT_MODE
+    return _MODES[_key(session_id)]
+
+
+def _hermes_line(line: str) -> str:
+    line = line.replace('Off only: "stop ponytail" / "normal mode".', "Off: `/ponytail off`.")
+    return line.replace('"stop ponytail" / "normal mode": revert.', "`/ponytail off`: revert.")
+
+
+def _skill_body(mode: str) -> str:
+    body = re.sub(
+        r"^---[\s\S]*?---\s*",
+        "",
+        (SKILLS_DIR / "ponytail" / "SKILL.md").read_text(encoding="utf-8"),
+        count=1,
+    )
+    kept: list[str] = []
+    for line in body.splitlines():
+        label = re.match(r"^\|\s*\*\*(.+?)\*\*\s*\|", line) or re.match(r"^-\s*([^:]+):\s*", line)
+        if label and label.group(1).strip().lower() in ACTIVE_MODES - {mode}:
+            continue
+        kept.append(_hermes_line(line))
+    return "\n".join(kept)
+
+
+def _instructions(mode: str) -> str:
+    mode = mode if mode in ACTIVE_MODES else DEFAULT_MODE
+    return f"PONYTAIL MODE ACTIVE — level: {mode}\n\n" + _skill_body(mode)
+
+
+def _pre_llm_call(**kwargs: Any) -> dict[str, str] | None:
+    session_id = kwargs.get("session_id")
+    prompt = str(kwargs.get("user_message") or "").strip().lower()
+
+    if match := _MODE_CMD.match(prompt):
+        requested = match.group(1)
+        if requested:
+            _set_mode(requested, session_id)
+
+    mode = _get_mode(session_id)
+    return {"context": _instructions(mode)} if mode in ACTIVE_MODES else None
+
+
+def _handle_ponytail_command(args: str = "") -> str:
+    mode = _mode(args)
+    if not mode:
+        return "Usage: /ponytail on|off|lite|full|ultra"
+    return f"Ponytail mode: {_set_mode(mode, 'global')}"
+
+
+def register(ctx: Any) -> None:
+    ctx.register_hook("pre_llm_call", _pre_llm_call)
+    for skill_md in sorted(SKILLS_DIR.glob("*/SKILL.md")):
+        ctx.register_skill(skill_md.parent.name, skill_md)
+    ctx.register_command(
+        "ponytail",
+        _handle_ponytail_command,
+        description="Set Ponytail mode: on/off/lite/full/ultra",
+        args_hint="on|off|lite|full|ultra",
+    )

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -13,6 +13,7 @@ to load in a given agent.
 | OpenCode | `.opencode/plugins/ponytail.mjs`, `.opencode/command/`, `hooks/`, `skills/` | Server plugin injects the ruleset each turn via `experimental.chat.system.transform` and persists `/ponytail` switches; reuses the shared instruction builder. |
 | pi | `pi-extension/`, `skills/`, `hooks/` | Package extension: injects the ruleset each turn through the shared instruction builder and registers the `/ponytail` commands. |
 | Gemini CLI | `gemini-extension.json`, `AGENTS.md`, `commands/`, `skills/` | Extension manifest points `contextFileName` at `AGENTS.md` for always-on rules, and reuses the existing `commands/*.toml` and `skills/`, which Gemini CLI auto-discovers. |
+| Hermes Agent | `plugin.yaml`, `__init__.py`, `skills/` | Python plugin defaults off, registers strict `/ponytail on|off|lite|full|ultra` mode switching, injects the active ruleset via `pre_llm_call`, and exposes the bundled skills as `ponytail:<skill-name>`. |
 | Cursor | `.cursor/rules/ponytail.mdc` | Always-on project rule. |
 | Windsurf | `.windsurf/rules/ponytail.md` | Project rule. |
 | Cline | `.clinerules/ponytail.md` | Project rule. |

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,22 @@
+name: ponytail
+version: 4.6.0
+description: Lazy senior dev mode for Hermes Agent. Prefer YAGNI, stdlib, native features, and the smallest correct implementation.
+author: Dietrich Gebert
+homepage: https://github.com/DietrichGebert/ponytail
+repository: https://github.com/DietrichGebert/ponytail
+license: MIT
+keywords:
+  - yagni
+  - minimalism
+  - code-review
+  - productivity
+provides_hooks:
+  - pre_llm_call
+provides_commands:
+  - ponytail
+provides_skills:
+  - ponytail
+  - ponytail-review
+  - ponytail-audit
+  - ponytail-debt
+  - ponytail-help


### PR DESCRIPTION
## Summary

Adds a minimal Hermes Agent adapter for Ponytail.

The adapter reuses the existing `skills/` content and exposes Ponytail to Hermes as an explicit opt-in plugin. Hermes starts with Ponytail OFF by default. Users can turn it ON with `/ponytail on`, `/ponytail lite`, `/ponytail full`, or `/ponytail ultra`, and turn it off with `/ponytail off`.

The reason it's off by default is due to some users not always using their Hermes Agents for coding, so it would be wrong to have this plugin always enabled. It's also tricky to know when is the right time to automatically enable it, so users can exercise discretion and ask their agent to enable/disable the plugin automatically if they don't want to explicitly turn it on/off.

## Hermes Behavior

```bash
hermes plugins install DietrichGebert/ponytail --enable
```

After restart, Hermes loads the plugin but does not inject Ponytail until the user explicitly turns it on:

- `/ponytail on` --> defaults to `full` mode
- `/ponytail full`
- `/ponytail lite`
- `/ponytail ultra`
- `/ponytail off` --> off

When active, the plugin injects the selected Ponytail ruleset through Hermes' `pre_llm_call` hook.

## Validation

- Python smoke test for Hermes adapter registration and strict on/off behavior
- `node scripts/check-rule-copies.js`
- `PATH="$PWD/.venv/bin:$PATH" npm test`
  - Ponytail tests: 36 passed
  - Pi extension tests: 11 passed
- Installed locally with `hermes plugins install file://... --enable --force`
- Verified Hermes plugin discovery, command registration, skill registration, default-off behavior, strict slash-command mode injection, and no natural-language shutdown handling
- Ran it on this PR