### PR TITLE
feat: add argument-hint to ponytail skill

### DIFF
--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -10,6 +10,7 @@ description: >
   "minimal solution", "yagni", "do less", or "shortest path", and whenever
   they complain about over-engineering, bloat, boilerplate, or unnecessary
   dependencies.
+argument-hint: "[lite|full|ultra]"
 license: MIT
 ---
 


### PR DESCRIPTION
Adds `argument-hint: "[lite|full|ultra]"` to the ponytail skill frontmatter.

When users type `/ponytail` in Claude Code, the UI shows `[lite|full|ultra]` as a placeholder — making the three intensity levels discoverable without reading the docs.

The other four skills (`ponytail-review`, `ponytail-audit`, `ponytail-debt`, `ponytail-help`) take no arguments, so no hint was added there.