### PR TITLE
feat(pi): show ponytail mode and activity in the status bar

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -65,9 +65,9 @@ export default function ponytailExtension(pi) {
   // documented palette (accent/muted/dim/...), so guard it and fall back to
   // plain text when no theme is attached (e.g. print/RPC mode).
   const syncStatus = (ctx) => {
-    if (ctx) lastCtx = ctx;
-    const active = ctx || lastCtx;
+    const active = ctx?.ui?.setStatus ? ctx : lastCtx;
     if (!active?.ui?.setStatus) return;
+    if (ctx?.ui?.setStatus) lastCtx = ctx;
 
     if (currentMode === "off") {
       active.ui.setStatus("ponytail", undefined);

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -55,6 +55,32 @@ export { writeDefaultMode };
 export default function ponytailExtension(pi) {
   let currentMode = DEFAULT_MODE;
   let configuredDefaultMode = getDefaultMode();
+  let agentActive = false;
+  let lastCtx = null;
+
+  const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥" };
+
+  // Footer status bar: shows current mode and whether the agent is working.
+  // ponytail: pi clears a status by passing undefined; theme.fg only knows the
+  // documented palette (accent/muted/dim/...), so guard it and fall back to
+  // plain text when no theme is attached (e.g. print/RPC mode).
+  const syncStatus = (ctx) => {
+    if (ctx) lastCtx = ctx;
+    const active = ctx || lastCtx;
+    if (!active?.ui?.setStatus) return;
+
+    if (currentMode === "off") {
+      active.ui.setStatus("ponytail", undefined);
+      return;
+    }
+
+    const theme = active.ui.theme;
+    const paint = (color, text) => (theme?.fg ? theme.fg(color, text) : text);
+    const indicator = agentActive ? paint("accent", "●") : paint("dim", "○");
+    const icon = levelIcons[currentMode] || "";
+    const label = `${paint("muted", "ponytail")} ${paint("accent", `${icon} ${currentMode.toUpperCase()}`.trim())}`;
+    active.ui.setStatus("ponytail", `${indicator} ${label}`);
+  };
 
   const setMode = (mode, ctx) => {
     const normalized = normalizePersistedMode(mode);
@@ -62,6 +88,7 @@ export default function ponytailExtension(pi) {
 
     currentMode = normalized;
     pi.appendEntry("ponytail-mode", { mode: normalized });
+    syncStatus(ctx);
     ctx?.ui?.notify?.(`Ponytail mode set to ${normalized}.`, "info");
   };
 
@@ -142,6 +169,17 @@ export default function ponytailExtension(pi) {
     const entries = ctx?.sessionManager?.getBranch?.() || ctx?.sessionManager?.getEntries?.() || [];
     configuredDefaultMode = getDefaultMode();
     currentMode = resolveSessionMode(entries, configuredDefaultMode);
+    syncStatus(ctx);
+  });
+
+  pi.on("agent_start", async (_event, ctx) => {
+    agentActive = true;
+    syncStatus(ctx);
+  });
+
+  pi.on("agent_end", async (_event, ctx) => {
+    agentActive = false;
+    syncStatus(ctx);
   });
 
   pi.on("before_agent_start", async (event) => {

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -121,3 +121,33 @@ test("normal mode disables persistent instructions", async () => withTempConfig(
   const disabled = await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx);
   assert.equal(disabled, undefined);
 }));
+
+test("status bar reflects mode, agent activity, and clears when off", async () => withTempConfig(async () => {
+  const { commands, events } = createPiHarness();
+  const statusCalls = [];
+  const ctx = createCommandContext({
+    ui: {
+      notify() {},
+      setStatus(id, text) { statusCalls.push({ id, text }); },
+      theme: { fg: (_color, text) => text },
+    },
+  });
+
+  await events.get("session_start")({ reason: "startup" }, ctx);
+  await commands.get("ponytail").handler("ultra", ctx);
+
+  const afterSet = statusCalls.at(-1);
+  assert.equal(afterSet.id, "ponytail");
+  assert.match(afterSet.text, /ULTRA/);
+  assert.match(afterSet.text, /○/); // idle before the agent starts working
+
+  await events.get("agent_start")({}, ctx);
+  assert.match(statusCalls.at(-1).text, /●/); // active while working
+
+  await events.get("agent_end")({}, ctx);
+  assert.match(statusCalls.at(-1).text, /○/); // back to idle
+
+  // "normal mode" turns ponytail off (no ctx passed) and clears the status bar
+  await events.get("input")({ text: "normal mode", source: "interactive" }, ctx);
+  assert.equal(statusCalls.at(-1).text, undefined);
+}));


### PR DESCRIPTION
Closes #84.

Adds a status bar to the Pi extension. It shows the current Ponytail mode and whether the agent is working.

It reads `○ ponytail ⚡ FULL` when idle. The dot turns `●` while the agent runs. Each mode has an icon: lite 🌿, full ⚡, ultra 🔥. The bar clears when Ponytail is off (`stop ponytail` / `normal mode`). Thanks to @h2oearth for the idea and the sketch in #84.

How it works: `syncStatus(ctx)` draws the bar with `ctx.ui.setStatus`. It runs on `session_start`, the new `agent_start` and `agent_end` handlers, and in `setMode`. It caches the last ctx, so turning off still clears the bar.

Note: the sketch used `theme.fg("text", ...)`, but `text` is not a Pi theme color. Valid keys are toolTitle, accent, success, error, warning, muted, dim. So I used accent, muted, and dim. `theme.fg` is guarded, so the bar falls back to plain text with no theme. The off state clears with `setStatus(id, undefined)`.

Testing: check-rule-copies and `npm test` both pass. I added a regression test for the mode label, the active/idle dot, and the off-state clear.