### PR TITLE
fix: six small bugs from a codebase read

### DIFF
--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -182,29 +182,25 @@ setTimeout(() => {
 import sys, os
 os.chdir(r"${path.dirname(csvPath)}")
 
-# Capture print output
 import io
-_stdout = sys.stdout
-sys.stdout = io.StringIO()
-
+_buf = io.StringIO()
+_exc = ''
+sys.stdout = _buf
 try:
 ${patched.split('\n').map((l) => '    ' + l).join('\n')}
 except Exception as e:
-    sys.stdout = _stdout
-    # If it needs sales.csv in cwd, write it there and retry
-    pass
+    _exc = str(e)
+finally:
+    sys.stdout = sys.__stdout__
 
-output = sys.stdout.getvalue()
-sys.stdout = _stdout
+output = _buf.getvalue()
 
-# Check output contains the number 351 (100.5 + 200.0 + 50.5)
-# Match as a standalone number (not as substring of e.g. 13510)
 import re
 if re.search(r'(?<![\\d])351(?:\\.0)?(?![\\d])', output):
     print("PASS")
 else:
-    # Try running it differently: maybe it defines a function
-    print("FAIL: output was: " + repr(output[:200]))
+    detail = ('exception: ' + _exc) if _exc else ('output: ' + repr(output[:200]))
+    print("FAIL: " + detail)
     sys.exit(1)
 `;
     const f = tmpFile('.py', harness);

--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -44,7 +44,7 @@ if (!isCodex) try {
   let hasStatusline = false;
   if (fs.existsSync(settingsPath)) {
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
-    if (settings.statusLine) {
+    if (settings && typeof settings === 'object' && settings.statusLine) {
       hasStatusline = true;
     }
   }

--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -83,7 +83,14 @@ function writeDefaultMode(mode) {
 
   const configPath = getConfigPath();
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
-  fs.writeFileSync(configPath, JSON.stringify({ defaultMode: normalized }, null, 2), 'utf8');
+
+  let existing = {};
+  try {
+    const raw = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    if (raw && typeof raw === 'object') existing = raw;
+  } catch (e) {}
+
+  fs.writeFileSync(configPath, JSON.stringify({ ...existing, defaultMode: normalized }, null, 2), 'utf8');
   return normalized;
 }
 

--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -14,6 +14,7 @@ process.stdin.on('end', () => {
     const prompt = (data.prompt || '').trim().toLowerCase();
 
     // Match /ponytail commands
+    let handled = false;
     if (/^[/@$]ponytail/.test(prompt)) {
       const parts = prompt.split(/\s+/);
       const cmd = parts[0].replace(/^[@$]/, '/');
@@ -38,14 +39,16 @@ process.stdin.on('end', () => {
           mode,
           'PONYTAIL MODE CHANGED — level: ' + mode,
         );
+        handled = true;
       } else if (mode === 'off') {
         clearMode();
         writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
+        handled = true;
       }
     }
 
-    // Detect deactivation
-    if (/\b(stop ponytail|normal mode)\b/i.test(prompt)) {
+    // Detect deactivation — only if the command branch didn't already handle it
+    if (!handled && /\b(stop ponytail|normal mode)\b/i.test(prompt)) {
       clearMode();
       writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
     }

--- a/hooks/ponytail-statusline.ps1
+++ b/hooks/ponytail-statusline.ps1
@@ -1,4 +1,5 @@
-$Flag = Join-Path $HOME ".claude/.ponytail-active"
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
+$Flag = Join-Path $ClaudeDir ".ponytail-active"
 if (-not (Test-Path $Flag)) {
     exit 0
 }

--- a/hooks/ponytail-statusline.sh
+++ b/hooks/ponytail-statusline.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-flag="$HOME/.claude/.ponytail-active"
+flag="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.ponytail-active"
 [ -f "$flag" ] || exit 0
 
 mode=$(head -n1 "$flag" | tr -d '[:space:]')

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -146,6 +146,8 @@ export default function ponytailExtension(pi) {
 
   pi.on("before_agent_start", async (event) => {
     if (!currentMode || currentMode === "off") return;
-    return { systemPrompt: `${event.systemPrompt}\n\n${getPonytailInstructions(currentMode)}` };
+    const base = event.systemPrompt || '';
+    const instructions = getPonytailInstructions(currentMode);
+    return { systemPrompt: base ? `${base}\n\n${instructions}` : instructions };
   });
 }


### PR DESCRIPTION
Went through the whole codebase. Found six things, fixed all of them in one commit.

**statusline.sh / statusline.ps1** — both hardcoded `$HOME/.claude` instead of reading `CLAUDE_CONFIG_DIR`. The runtime got this fix in #37 but the statusline scripts weren't updated. Anyone with a custom Claude config dir would see a permanently blank badge.

**ponytail-config.js writeDefaultMode** — was doing a full overwrite of config.json with just `{defaultMode}`, so any other keys the user had in there were gone. Now reads first, spreads, writes.

**ponytail-mode-tracker.js** — if a prompt matched the `/ponytail off` command branch AND the `stop ponytail` regex (e.g. `/ponytail off, normal mode`), both branches fired and wrote two JSON objects to stdout back to back. Invalid JSON. Added a `handled` flag so the regex branch only runs when the command branch didn't already deal with it.

**ponytail-activate.js** — `JSON.parse('null')` returns `null`, then `null.statusLine` throws. The outer catch swallowed it silently and the statusline nudge never appeared. Added a null + typeof check before the property access.

**pi-extension/index.js** — ```${event.systemPrompt}\n\n...``` coerces `undefined` to the string `"undefined"`, which then shows up at the top of every agent system prompt. The Pi test suite always passes `systemPrompt: 'BASE'` so this never got caught. Fall back to empty string when it's absent.

**benchmarks/correctness.js CSV harness** — the try/except restored `sys.stdout` to the real stdout inside the except block, then the very next line called `.getvalue()` on it (which doesn't exist on `TextIOWrapper`). So any exception in the generated code caused a secondary `AttributeError` that completely hid the original error. Switched to a `finally` block to restore stdout and put the actual exception message in the FAIL output.

All 47 tests pass.