### PR TITLE
chore: bump version to 4.7.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ponytail",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "author": {
     "name": "Dietrich Gebert",
     "url": "https://github.com/DietrichGebert"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.6.0",
+  "version": "4.7.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "contextFileName": "AGENTS.md"
 }


### PR DESCRIPTION
Bumps all four plugin manifests 4.6.0 -> 4.7.0 for the OpenClaw / ClawHub skill package shipped in #102. Version-alignment test green (51/51).

🤖 Generated with [Claude Code](https://claude.com/claude-code)