### PR TITLE
fix: pin all four safety carve-outs in the rule-drift canary (not just validation)

### DIFF
--- a/scripts/check-rule-copies.js
+++ b/scripts/check-rule-copies.js
@@ -43,7 +43,14 @@ const INVARIANTS = [
   'naive heuristic',                       // ceiling-comment rule
   'ONE runnable check',                    // test reflex
   'flimsier algorithm',                    // robust-variant rule
-  'input validation at trust boundaries',  // the "not lazy about" clause
+  // the four "not lazy about" safety carve-outs: pin each so a reword in either
+  // file can't silently drop one. Only validation was pinned before. These are the
+  // continuous substrings present in both files ("prevents data loss" because the
+  // full "error handling that prevents data loss" wraps a line in SKILL.md).
+  'input validation at trust boundaries',
+  'prevents data loss',
+  'security',
+  'accessibility',
   'Lazy code without its check is unfinished', // one-check promoted to headline
 ];
 


### PR DESCRIPTION
## What

`check-rule-copies.js` pins load-bearing rule phrases so a reword in `SKILL.md` or `AGENTS.md` can't silently drift. But of the four "never simplify away" safety carve-outs —

> input validation at trust boundaries, error handling that prevents data loss, security, accessibility

— only `input validation at trust boundaries` is in `INVARIANTS`. The other three (data-loss handling, security, accessibility) can be reworded or dropped from either file and CI stays green.

For a skill whose whole risk surface is laziness shading into negligence, those carve-outs are the guardrail. You flagged this exact thing in #17:

> Trusting those carve-outs. They held across our benchmark … but on an unusual domain, sanity-check that "not lazy about" actually caught your critical path.

This makes the drift guard cover all four, not one — so a future reword of `SKILL.md` or `AGENTS.md` that weakens a safety clause trips CI instead of slipping through.

## Change

Three phrases added to `INVARIANTS`, each verified present (verbatim, `includes()`) in **both** `skills/ponytail/SKILL.md` and `AGENTS.md` on current `main`:

- `prevents data loss`
- `security`
- `accessibility`

Note: `"error handling that prevents data loss"` as one string is **not** usable — it wraps across a line break in `SKILL.md`, so `includes()` returns false there. `prevents data loss` is the continuous substring present in both.

```
$ node scripts/check-rule-copies.js
Rule copies match AGENTS.md; 8 rule invariants present in SKILL.md and AGENTS.md.
```

No rule text changed. Smallest diff that holds.

## Optional follow-up (not in this PR)

`SKILL.md` says "security **measures**" / "accessibility **basics**" while `AGENTS.md` says "security" / "accessibility", so two of these canaries are the bare common substrings. If you'd prefer stronger, in-context canaries, harmonizing those two words across both files would let the invariant pin a distinctive phrase. Left out to keep this minimal — your call.
