### PR TITLE
docs: clarify benchmark numbers are per-task on Claude API, not plan quota

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <p align="center">
   <strong>80-94% less code &middot; 3-6&times; faster &middot; 47-77% cheaper</strong><br>
-  <sub>Median of 10 runs across Haiku, Sonnet, and Opus. <a href="benchmarks/">Reproduce it yourself.</a></sub>
+  <sub>Per-task code, latency, and generation cost on the Claude API &mdash; not a promise about your plan's quota. The ruleset is re-injected every turn, so on a single short prompt that overhead can outweigh the savings. Median of 10 runs across Haiku, Sonnet, and Opus. <a href="benchmarks/">Reproduce it yourself.</a></sub>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 <p align="center">
   <strong>80-94% less code &middot; 3-6&times; faster &middot; 47-77% cheaper</strong><br>
-  <sub>Per-task code, latency, and generation cost on the Claude API &mdash; not a promise about your plan's quota. The ruleset is re-injected every turn, so on a single short prompt that overhead can outweigh the savings. Median of 10 runs across Haiku, Sonnet, and Opus. <a href="benchmarks/">Reproduce it yourself.</a></sub>
+  <sub>Per-task code, latency, and cost on the Claude API, not your plan's quota. The ruleset re-injects each turn, so on one short prompt that overhead can outweigh the savings. Median of 10 runs across Haiku, Sonnet, and Opus. <a href="benchmarks/">Reproduce it yourself.</a></sub>
 </p>
 
 ---


### PR DESCRIPTION
The headline `47-77% cheaper` / `80-94% less code` numbers are per-task code-generation metrics on the Claude API, and the ruleset is re-injected every turn. On a single short prompt that overhead can outweigh the savings, so the numbers are not a promise about a provider's account quota (see #111, where a user read it that way and exhausted a free-tier allowance in one prompt).

Adds a one-line caveat under the headline numbers to prevent that read.