### PR TITLE
fix: make npm test run on Windows (node <21)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": ["pi-package", "pi", "skills", "ponytail"],
   "license": "MIT",
   "scripts": {
-    "test": "node --test tests/*.test.js && npm test --prefix pi-extension"
+    "test": "node --test tests/ && npm test --prefix pi-extension"
   },
   "pi": {
     "extensions": ["./pi-extension/index.js"],

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "keywords": ["pi-package", "pi", "skills", "ponytail"],
   "license": "MIT",
   "scripts": {
-    "test": "node --test tests/ && npm test --prefix pi-extension"
+    "test": "node --test tests/behavior.test.js tests/commands.test.js tests/copilot-plugin.test.js tests/correctness.test.js tests/gemini-extension.test.js tests/hooks-windows.test.js tests/hooks.test.js tests/openclaw-skills.test.js tests/opencode-plugin.test.js && npm test --prefix pi-extension"
   },
   "pi": {
     "extensions": ["./pi-extension/index.js"],

--- a/pi-extension/package.json
+++ b/pi-extension/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test ./test/*.test.js"
+    "test": "node --test ./test/"
   }
 }

--- a/pi-extension/package.json
+++ b/pi-extension/package.json
@@ -3,6 +3,6 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test ./test/"
+    "test": "node --test ./test/extension.test.js ./test/helpers.test.js"
   }
 }


### PR DESCRIPTION
## Problem

`npm test` fails on Windows. The root and pi-extension test scripts pass a glob to the node test runner:

```
node --test tests/*.test.js
node --test ./test/*.test.js
```

POSIX shells (so CI, on ubuntu) expand the glob before node sees it, but `cmd.exe` does not, and node < 21 does not glob `--test` paths natively. So on Windows the runner gets a literal `tests/*.test.js` and exits with `Could not find 'tests/*.test.js'`.

Found while testing #79 on Windows (node 20.20.0).

## Fix: explicit file list

No single auto-discovery form works across node versions:

| form | node 20 | node 22 (CI) |
|---|---|---|
| `node --test tests/` (directory) | ✅ | ❌ treats path as a module → MODULE_NOT_FOUND |
| `node --test tests/**/*.test.js` (native glob) | ❌ no glob support pre-21 | ✅ |
| **explicit file list** | ✅ | ✅ |

So the scripts now list the test files explicitly — runs identically on node 18/20/22, every OS, no shell glob.

## Verified

`npm test` → exit 0: **51** root tests + **11** pi-extension tests. Confirmed the listed files exactly match what's on disk in both dirs.

## Tradeoff

Explicit lists don't auto-discover, so a newly added test file must be added to the script or it silently won't run. If you'd rather keep auto-discovery and require node ≥ 21 (CI is already on 22), the native-glob form `node --test tests/**/*.test.js` is the alternative — happy to switch to that instead.