### PR TITLE
docs: add CodeWhale to supported agents (native AGENTS.md reader, zero setup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img src="https://img.shields.io/github/stars/DietrichGebert/ponytail?style=flat-square&color=111111&label=stars" alt="Stars">
   <img src="https://img.shields.io/github/v/release/DietrichGebert/ponytail?style=flat-square&color=111111&label=release" alt="Release">
-  <img src="https://img.shields.io/badge/works%20with-13%20agents-111111?style=flat-square" alt="Works with 13 agents">
+  <img src="https://img.shields.io/badge/works%20with-14%20agents-111111?style=flat-square" alt="Works with 14 agents">
   <img src="https://img.shields.io/badge/license-MIT-111111?style=flat-square" alt="MIT license">
 </p>
 
@@ -149,6 +149,10 @@ agy plugin install https://github.com/DietrichGebert/ponytail
 
 It reuses this repo's `gemini-extension.json`. One difference: Antigravity converts the `/ponytail` commands into skills, so you type them into the chat (e.g. `/ponytail-review` as a message) instead of picking them from a slash menu. Until the migration completes (around June 18, 2026), `gemini extensions install` still works too. To run it as an always-on rule instead, drop the ruleset into `.agents/rules/`.
 
+### CodeWhale
+
+Reads `AGENTS.md` from the project root — zero setup. Copy [`AGENTS.md`](AGENTS.md) to your project, or run `codewhale` from a checkout of this repo. That's it.
+
 ### OpenClaw
 
 ```bash
@@ -163,7 +167,7 @@ Active every session, with a handful of commands (see [Commands](#commands)). `/
 
 Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`.
 
-Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
+Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro, Zed, CodeWhale: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
 
 Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kiro/steering/` in your project.
 

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -19,6 +19,7 @@ to load in a given agent.
 | GitHub Copilot | `.github/copilot-instructions.md` | Repository instruction file. |
 | GitHub Copilot CLI | `.github/plugin/`, `AGENTS.md`, `.github/copilot-instructions.md`, `~/.copilot/copilot-instructions.md` | Plugin-supported (`copilot plugin marketplace add DietrichGebert/ponytail` + `copilot plugin install ponytail@ponytail`). Fallback instruction mode remains: per-project from `AGENTS.md` or `.github/copilot-instructions.md`, or globally from `~/.copilot/copilot-instructions.md` (instruction-tier, no `/ponytail` levels or hooks). |
 | Antigravity | `AGENTS.md` | Reads `AGENTS.md` at the repo root as always-on rules (like `.cursorrules`/`CLAUDE.md`); `.agents/rules/` also works for workspace rules. Instruction-tier. |
+| CodeWhale | `AGENTS.md` | Reads `AGENTS.md` from the repo root as project instructions; also reads `CLAUDE.md` and `.claude/instructions.md` as fallbacks. Instruction-tier. |
 | VS Code + Codex extension | `AGENTS.md` | The Codex extension reads `AGENTS.md` (repo root, or `~/.codex/AGENTS.md` globally). Instruction-tier; the full Codex plugin row above adds `/ponytail` levels and hooks. |
 | Kiro | `.kiro/steering/ponytail.md` | Steering rule; copy globally or into a project. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |


### PR DESCRIPTION
Adds CodeWhale to the supported-agents list. CodeWhale (the rebranded DeepSeek-TUI, 38k★, Rust) reads `AGENTS.md` from the project root natively — ponytail works with **zero adapter file**.

## What changes

- README: agent badge `13 → 14`, a `### CodeWhale` install section, and CodeWhale added to the instruction-only adapter list.
- `docs/agent-portability.md`: one table row for CodeWhale.

Docs-only. No code.

## Why it's accurate

CodeWhale's own `docs/CONFIGURATION.md`: *"`AGENTS.md` — cross-agent project instructions … the canonical file … `CLAUDE.md` and `.claude/instructions.md` are read as compatibility fallbacks."* Loader: `crates/tui/src/project_context.rs::load_project_context` reads `AGENTS.md` from the workspace root and `as_system_block()` wraps it as `<project_instructions>` for the system prompt.

I dropped an earlier "`~/.codewhale/AGENTS.md` for global use" line: the installed binary (v0.8.61) still resolves the global path to `~/.deepseek/AGENTS.md` (rename incomplete), so that claim was wrong. Only the verified project-root path is documented.

## Test verification (RED → GREEN)

Installed CodeWhale `0.8.61` (`npm i -g codewhale`) and added a test to **CodeWhale's own loader** that drops ponytail's real `AGENTS.md` into a workspace root and asserts CodeWhale ingests it into the `<project_instructions>` block.

The test (in `crates/tui/src/project_context.rs`):

```rust
#[test]
fn test_load_real_ponytail_overlay() {
    let src = std::env::var("PONYTAIL_AGENTS_MD")
        .expect("set PONYTAIL_AGENTS_MD to the ponytail AGENTS.md path");
    let overlay = fs::read_to_string(&src).expect("read ponytail AGENTS.md");

    let tmp = tempdir().expect("tempdir");
    fs::write(tmp.path().join("AGENTS.md"), &overlay).expect("write");

    let ctx = load_project_context(tmp.path());

    assert!(ctx.has_instructions(), "overlay not loaded");
    let block = ctx.as_system_block().expect("system block");
    assert!(block.starts_with("<project_instructions"), "not wrapped: {block:.80}");
    assert!(block.contains("lazy senior dev"), "ponytail signature missing");
}
```

**GREEN** — overlay written as `AGENTS.md`, CodeWhale discovers it natively:

```
$ PONYTAIL_AGENTS_MD=.../AGENTS.md cargo test -p deepseek-tui --bins test_load_real_ponytail_overlay
     Running unittests src/main.rs (target/debug/deps/deepseek_tui-4fcdc7140bad2d94)
test project_context::tests::test_load_real_ponytail_overlay ... ok
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 3221 filtered out; finished in 0.00s
```

**RED** — same test, overlay written as `NOPE.md` (a filename CodeWhale does not read) → native discovery misses it:

```
test project_context::tests::test_load_real_ponytail_overlay ... FAILED
---- project_context::tests::test_load_real_ponytail_overlay stdout ----
thread 'project_context::tests::test_load_real_ponytail_overlay' panicked at crates/tui/src/project_context.rs:734:9:
overlay not loaded
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 3221 filtered out; finished in 0.00s
```

RED proves the green isn't a tautology — it's specifically the `AGENTS.md` filename CodeWhale keys on. Flipping the name back to `AGENTS.md` returns to GREEN.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
