### PR TITLE
benchmarks: add system prompt to baseline arm so it doesn't ramble (closes #126)

### DIFF
--- a/benchmarks/arms/baseline.js
+++ b/benchmarks/arms/baseline.js
@@ -1,2 +1,6 @@
-// Baseline arm: no skill, just the task.
-module.exports = ({ vars }) => [{ role: 'user', content: vars.task }];
+// Baseline arm: no skill, with a one-line system prompt so the model doesn't ramble.
+const system = 'Provide just one example for any given task, and no commentary or usage examples.';
+module.exports = ({ vars }) => [
+  { role: 'system', content: system },
+  { role: 'user', content: vars.task },
+];


### PR DESCRIPTION
**What**

Add a one-line system prompt to the baseline benchmark arm so the comparison against ponytail and caveman is apples-to-apples.

**Why**

Closes #126. Without a system prompt, the baseline model often responds with multiple options and usage examples, inflating LOC ~7× for reasons unrelated to the test. The system prompt is the one Colin Eberhardt proposed in the issue and matches the style of the other arm files.

**Diff**

1 file, +6 / -2. Doesn't touch SKILL.md, AGENTS.md, the canary, or any trust-boundary code. `node scripts/check-rule-copies.js` ✅ · `npm test` ✅ (11/11).