### PR TITLE
docs: add Hermes agent support

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Installs ponytail as an OpenClaw skill from ClawHub; the review, audit, debt, an
 npx skills add DietrichGebert/ponytail --all --global
 ```
 
-Installs all five ponytail skills into `~/.hermes/skills/` globally; Hermes auto-discovers them on the next session. Without `npx`, copy [`skills/`](skills/) into `~/.hermes/skills/` or drop it in your project root — Hermes reads `skills/` at the repo root automatically.
+Installs all five ponytail skills into `~/.hermes/skills/` globally; Hermes auto-discovers them on the next session. Without `npx`, copy the skills manually: `cp -r skills/* ~/.hermes/skills/`.
 
 That was it. He'd be proud. He won't say it.
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img src="https://img.shields.io/github/stars/DietrichGebert/ponytail?style=flat-square&color=111111&label=stars" alt="Stars">
   <img src="https://img.shields.io/github/v/release/DietrichGebert/ponytail?style=flat-square&color=111111&label=release" alt="Release">
-  <img src="https://img.shields.io/badge/works%20with-13%20agents-111111?style=flat-square" alt="Works with 13 agents">
+  <img src="https://img.shields.io/badge/works%20with-14%20agents-111111?style=flat-square" alt="Works with 14 agents">
   <img src="https://img.shields.io/badge/license-MIT-111111?style=flat-square" alt="MIT license">
 </p>
 
@@ -159,6 +159,14 @@ clawhub install ponytail
 
 Installs ponytail as an OpenClaw skill from ClawHub; the review, audit, debt, and help skills install the same way (`clawhub install ponytail-review`, and so on). OpenClaw applies it on coding tasks and also exposes it as a `/ponytail` command. Without ClawHub, copy [`.openclaw/skills/ponytail`](.openclaw/skills/) into `~/.openclaw/skills/`.
 
+### Hermes
+
+```bash
+npx skills add DietrichGebert/ponytail --all --global
+```
+
+Installs all five ponytail skills into `~/.hermes/skills/` globally; Hermes auto-discovers them on the next session. Without `npx`, copy [`skills/`](skills/) into `~/.hermes/skills/` or drop it in your project root — Hermes reads `skills/` at the repo root automatically.
+
 That was it. He'd be proud. He won't say it.
 
 Active every session, with a handful of commands (see [Commands](#commands)). `/ponytail ultra` exists for when the codebase has wronged you personally. Startup and mode-change text shows the current mode.
@@ -185,7 +193,7 @@ Which files map to which agent: [Agent portability](docs/agent-portability.md).
 | `/ponytail-debt` | Harvest the `ponytail:` shortcuts you've deferred into a ledger, so "later" doesn't become "never". |
 | `/ponytail-help` | Quick reference for the commands above. |
 
-Commands need a skill-capable host (Claude Code, Codex, OpenCode, Gemini, pi). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
+Commands need a skill-capable host (Claude Code, Codex, OpenCode, Gemini, Hermes, pi). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
 
 ## Development
 

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -21,6 +21,7 @@ to load in a given agent.
 | Antigravity | `AGENTS.md` | Reads `AGENTS.md` at the repo root as always-on rules (like `.cursorrules`/`CLAUDE.md`); `.agents/rules/` also works for workspace rules. Instruction-tier. |
 | VS Code + Codex extension | `AGENTS.md` | The Codex extension reads `AGENTS.md` (repo root, or `~/.codex/AGENTS.md` globally). Instruction-tier; the full Codex plugin row above adds `/ponytail` levels and hooks. |
 | Kiro | `.kiro/steering/ponytail.md` | Steering rule; copy globally or into a project. |
+| Hermes | `skills/` | SKILL.md-compatible: auto-discovers skills from `skills/` in the project root or `~/.hermes/skills/` globally. Install with `npx skills add DietrichGebert/ponytail --all --global`. Supports all five skills and `/ponytail` commands. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 
 ## Adapter Rule

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -21,7 +21,7 @@ to load in a given agent.
 | Antigravity | `AGENTS.md` | Reads `AGENTS.md` at the repo root as always-on rules (like `.cursorrules`/`CLAUDE.md`); `.agents/rules/` also works for workspace rules. Instruction-tier. |
 | VS Code + Codex extension | `AGENTS.md` | The Codex extension reads `AGENTS.md` (repo root, or `~/.codex/AGENTS.md` globally). Instruction-tier; the full Codex plugin row above adds `/ponytail` levels and hooks. |
 | Kiro | `.kiro/steering/ponytail.md` | Steering rule; copy globally or into a project. |
-| Hermes | `skills/` | SKILL.md-compatible: auto-discovers skills from `skills/` in the project root or `~/.hermes/skills/` globally. Install with `npx skills add DietrichGebert/ponytail --all --global`. Supports all five skills and `/ponytail` commands. |
+| Hermes | `skills/` | SKILL.md-compatible: auto-discovers skills from `~/.hermes/skills/` globally (on-demand, not always-on). Install with `npx skills add DietrichGebert/ponytail --all --global`, or copy manually: `cp -r skills/* ~/.hermes/skills/`. Supports all five skills; `/ponytail-review`, `-audit`, `-debt`, `-help` commands work as on-demand skills. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 
 ## Adapter Rule


### PR DESCRIPTION
Closes #133
Closes #125

Hermes Agent (by Nous Research) natively supports the SKILL.md standard
and auto-discovers skills from the `skills/` directory — making it one
of the thinnest integrations in the project. No new adapter code needed.

Changes:
- README: add `### Hermes` install section with `npx skills add` command
  and manual fallback; bump badge from 13 → 14 agents; add Hermes to
  the skill-capable hosts note under Commands
- docs/agent-portability.md: add Hermes row to the adapter table