### PR TITLE
fix: register skills directory with opencode skill discovery

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -11,6 +11,9 @@ import { createRequire } from 'module';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // The shared instruction builder is CommonJS; bridge to it from this ES module.
 const require = createRequire(import.meta.url);
@@ -42,7 +45,18 @@ export default async ({ client } = {}) => {
     try { client && client.app && client.app.log({ body: { service: 'ponytail', level, message } }); } catch (e) {}
   };
 
+  const ponytailSkillsDir = path.resolve(__dirname, '../../skills');
+
   return {
+    // Register skills directory so opencode discovers ponytail skills.
+    config: async (config) => {
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+      if (!config.skills.paths.includes(ponytailSkillsDir)) {
+        config.skills.paths.push(ponytailSkillsDir);
+      }
+    },
+
     // Append the ruleset to the system prompt every turn.
     'experimental.chat.system.transform': async (_input, output) => {
       const mode = readMode();


### PR DESCRIPTION
The ponytail plugin does not register its skills/ directory with opencode's skill discovery system. As a result, none of the 5 ponytail skills (ponytail, ponytail-audit, ponytail-debt, ponytail-help, ponytail-review) appear in the skill tool's available list when using opencode.

This adds a config hook that registers the skills directory via config.skills.paths, matching the convention used by other opencode plugins.