### PR TITLE
Fix markdown formatting in ponytail-debt.md

### DIFF
--- a/.opencode/command/ponytail-debt.md
+++ b/.opencode/command/ponytail-debt.md
@@ -1,5 +1,5 @@
 ---
-description: Harvest ponytail: comments into a tracked debt ledger
+description: "Harvest ponytail: comments into a tracked debt ledger"
 ---
 
 Harvest every `ponytail:` comment in this repository into a debt ledger so deferrals do not rot into 'later means never'. Grep the whole tree for comment markers (grep -rnE '(#|//) ?ponytail:' ., skipping node_modules/.git/build output). One row per marker, grouped by file: <file>:<line> — <what was simplified>. ceiling: <the limit named in the comment>. upgrade: <the trigger to revisit>. Tag any marker that names no upgrade path or trigger as no-trigger, those rot silently. End with the count of markers and how many lack a trigger. If none: 'No ponytail: debt. Clean ledger.' Report only, change nothing.


### PR DESCRIPTION
Fixed "mapping values not allowed in this context error", by adding quotes around the description so parser does not detect a key/value mapping