### PR TITLE
fix: handle stdin error in ponytail-mode-tracker to avoid uncaught crash (#147)

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -79,5 +79,14 @@ Running the benchmark requires **Python 3**, **pandas**, and **Node.js** (18+).
 ## Notes
 
 - Caveman is a prose-compression skill (it leaves code "normal"), so it lands between baseline and ponytail on code size and wins mainly on prose tokens.
-- Cost reflects single-shot calls that re-send the skill every time. In real sessions the skill is injected once and prompt-cached, so the cost gap widens further in ponytail's favor.
+- Cost reflects single-shot calls that re-send the skill every time. In real sessions the skill is injected once and prompt-cached, so on tasks shaped like these the cost gap widens further in ponytail's favor.
 - These are everyday tasks. For production-grade specs, where an unconstrained agent bloats much harder, see the writeups in `results/`.
+
+## Where ponytail saves vs. costs
+
+These numbers are single-shot completions. In multi-turn agentic runs the result is task-shaped, not universal:
+
+- **Snowball-prone or blocked tasks** (agent keeps adding, installs a dep, scaffolds "for later"): ponytail's restraint cuts the runaway work — this is where the cost win is largest.
+- **Large completion-forced tasks** (a full draft the agent must finish): ponytail's "understand before you write" discipline can add reading/exploration up front, so it may raise tool calls and tokens while shrinking the written output. Net cost can go either way.
+
+An independent Cursor-SDK A/B measuring this (isolated worktrees, toggling only the rule file) saw ponytail ON correlate with more tool calls and higher estimated cost but leaner drafts on completion-forced tasks, with per-model exceptions: [RicardoCostaGit/ponytail-benchmark-from-cursor](https://github.com/RicardoCostaGit/ponytail-benchmark-from-cursor) (#121). Note also that an SDK's startup `skillCount` is the count of skills *available* in the workspace, not skills the model read — only a `read` of a `SKILL.md` is usage.

--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -6,6 +6,8 @@ const { getDefaultMode } = require('./ponytail-config');
 const { clearMode, setMode, writeHookOutput } = require('./ponytail-runtime');
 
 let input = '';
+// Exit cleanly if stdin errors (broken pipe, parent crash) — never block session start
+process.stdin.on('error', () => { process.exit(0); });
 process.stdin.on('data', chunk => { input += chunk; });
 process.stdin.on('end', () => {
   try {


### PR DESCRIPTION
## Summary

Fixes #147. `hooks/ponytail-mode-tracker.js` registered `stdin.on('data')` and `stdin.on('end')` but no `stdin.on('error')` handler. When stdin closes abnormally (broken pipe, parent crash), Node emits an `error` event on the stream; with no listener this surfaces as an uncaught exception, crashing the hook with a non-zero exit code.

## Fix

Register an `error` handler that calls `process.exit(0)` before the `data`/`end` listeners. This preserves the hook contract — always exit 0, never block session start.

```js
let input = '';
// Exit cleanly if stdin errors (broken pipe, parent crash) — never block session start
process.stdin.on('error', () => { process.exit(0); });
process.stdin.on('data', chunk => { input += chunk; });
```

## Notes

- This is the only stdin-reading hook in `hooks/`, so no other files need the same change.
- Severity per the issue: HIGH — unhandled stream error → uncaught exception → hook crashes non-zero.