### PR TITLE
fix: strip UTF-8 BOM before parsing settings.json in ponytail-activate (#148)

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -43,7 +43,9 @@ let output = getPonytailInstructions(mode);
 if (!isCodex) try {
   let hasStatusline = false;
   if (fs.existsSync(settingsPath)) {
-    const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+    // Strip UTF-8 BOM some editors prepend on Windows (breaks JSON.parse)
+    const raw = fs.readFileSync(settingsPath, 'utf8').replace(/^\uFEFF/, '');
+    const settings = JSON.parse(raw);
     if (settings.statusLine) {
       hasStatusline = true;
     }


### PR DESCRIPTION
## Summary

Fixes #148. [ponytail-activate.js:46](hooks/ponytail-activate.js#L46) read and parsed `~/.claude/settings.json` without stripping a UTF-8 BOM. On Windows, `settings.json` written by Notepad or VS Code can carry a BOM; `JSON.parse` then throws `SyntaxError`, the outer `catch` at line 68 silently swallows it, `hasStatusline` stays `false`, and the statusline setup nudge is never emitted.

## Fix

Strip the leading BOM before parsing, matching the handling already present in [ponytail-mode-tracker.js](hooks/ponytail-mode-tracker.js):

```js
// Strip UTF-8 BOM some editors prepend on Windows (breaks JSON.parse)
const raw = fs.readFileSync(settingsPath, 'utf8').replace(/^﻿/, '');
const settings = JSON.parse(raw);
```

## Notes

- #96 added a null guard on the parsed result but did not add BOM stripping.
- Verified: the `﻿` escape matches the sibling hook byte-for-byte, the BOM strip parses a BOM-prefixed payload, and `node --check` passes.

Severity per the issue: MEDIUM — silent failure; the statusline nudge never surfaces for users with a BOM-prefixed `settings.json`.