### PR TITLE
fix: guard final writeHookOutput against stdout EPIPE in ponytail-activate (#149)

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -69,4 +69,8 @@ if (!isCodex) try {
   // Silent fail — don't block session start over statusline detection
 }
 
-writeHookOutput('SessionStart', mode, output);
+try {
+  writeHookOutput('SessionStart', mode, output);
+} catch (e) {
+  // Silent fail — stdout closed/EPIPE at hook exit must not surface as a hook failure
+}


### PR DESCRIPTION
## Summary

Fixes #149. The final `writeHookOutput('SessionStart', mode, output)` call at [ponytail-activate.js:72](hooks/ponytail-activate.js#L72) was the only operation in the file left outside a try/catch — `setMode` and the statusline detection are both guarded.

`writeHookOutput` ends in a bare `process.stdout.write(...)` ([ponytail-runtime.js:42](hooks/ponytail-runtime.js#L42)) with no internal guard, so if stdout is closed or the pipe to the host breaks at hook exit, `process.stdout.write` throws `EPIPE`, which becomes an uncaught exception and crashes the hook with a non-zero exit code.

## Fix

Wrap the final write in try/catch, matching the never-block-session-start posture used everywhere else in the file:

```js
try {
  writeHookOutput('SessionStart', mode, output);
} catch (e) {
  // Silent fail — stdout closed/EPIPE at hook exit must not surface as a hook failure
}
```

`node --check` passes.

## Credit

Thanks to @Indrajeet-Badhel for triaging this issue and confirming the approach — this PR implements the same guard discussed there.