### PR TITLE
fix: statusline honors CLAUDE_CONFIG_DIR (completes #34)

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -2,7 +2,7 @@
 // ponytail — Claude Code SessionStart activation hook
 //
 // Runs on every session start:
-//   1. Writes flag file at ~/.claude/.ponytail-active (statusline reads this)
+//   1. Writes flag file at $CLAUDE_CONFIG_DIR/.ponytail-active (defaults to ~/.claude; statusline reads this)
 //   2. Emits ponytail ruleset as hidden SessionStart context
 //   3. Detects missing statusline config and emits setup nudge
 

--- a/hooks/ponytail-statusline.ps1
+++ b/hooks/ponytail-statusline.ps1
@@ -1,4 +1,6 @@
-$Flag = Join-Path $HOME ".claude/.ponytail-active"
+# CLAUDE_CONFIG_DIR overrides ~/.claude, matching where the hooks write the flag (issue #34)
+$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
+$Flag = Join-Path $ClaudeDir ".ponytail-active"
 if (-not (Test-Path $Flag)) {
     exit 0
 }

--- a/hooks/ponytail-statusline.sh
+++ b/hooks/ponytail-statusline.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-flag="$HOME/.claude/.ponytail-active"
+# CLAUDE_CONFIG_DIR overrides ~/.claude, matching where the hooks write the flag (issue #34)
+flag="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.ponytail-active"
 [ -f "$flag" ] || exit 0
 
 mode=$(head -n1 "$flag" | tr -d '[:space:]')


### PR DESCRIPTION
Closes #153.

## Summary

Issue #34 made the hooks honor `CLAUDE_CONFIG_DIR` when **writing** the mode flag, and [tests/hooks.test.js](tests/hooks.test.js#L81-L100) enforces it lands in `$CLAUDE_CONFIG_DIR/.ponytail-active`. But both statusline scripts still **read** a hardcoded `$HOME/.claude/.ponytail-active`:

- [ponytail-statusline.sh:2](hooks/ponytail-statusline.sh#L2)
- [ponytail-statusline.ps1:1](hooks/ponytail-statusline.ps1#L1)

So for any user with `CLAUDE_CONFIG_DIR` set, the write side and read side point at different files: the badge shows nothing, or a **stale mode** from a pre-migration `~/.claude` flag that never updates. The write half of #34 was fixed; the read half was missed.

## Fix

Resolve the flag in both scripts exactly as `getClaudeDir()` does — prefer `CLAUDE_CONFIG_DIR`, fall back to `~/.claude`:

```bash
flag="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.ponytail-active"
```
```powershell
$ClaudeDir = if ($env:CLAUDE_CONFIG_DIR) { $env:CLAUDE_CONFIG_DIR } else { Join-Path $HOME ".claude" }
$Flag = Join-Path $ClaudeDir ".ponytail-active"
```

The fallback branch is byte-for-byte the previous behavior, so users without the env var are unaffected. Also corrects the now-inaccurate path comment in the activation hook header.

## Verification

- `bash -n` and PowerShell parser both pass.
- Functionally checked both scripts: with `CLAUDE_CONFIG_DIR` set they read the custom dir (`[PONYTAIL:ULTRA]`); unset, they read `~/.claude` (`[PONYTAIL:LITE]`).
- Full suite green: `node --test tests/*.test.js` → 51/51, and `node scripts/check-rule-copies.js` passes.