### PR TITLE
Fix scope ambiguity in ponytail-audit & ponytail-review Boundaries

### DIFF
--- a/.openclaw/skills/ponytail-audit/SKILL.md
+++ b/.openclaw/skills/ponytail-audit/SKILL.md
@@ -31,6 +31,7 @@ End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. S
 
 ## Boundaries
 
-Complexity only, correctness bugs, security holes, and performance go to a
-normal review pass. Lists findings, applies nothing. One-shot.
+Scope: over-engineering and complexity only. Correctness bugs, security holes,
+and performance are explicitly out of scope — route them to a normal review
+pass. Lists findings, applies nothing. One-shot.
 "stop ponytail-audit" or "normal mode" to revert.

--- a/.openclaw/skills/ponytail-review/SKILL.md
+++ b/.openclaw/skills/ponytail-review/SKILL.md
@@ -44,8 +44,9 @@ If there is nothing to cut, say `Lean already. Ship.` and stop.
 
 ## Boundaries
 
-Complexity only, correctness bugs, security holes, and performance go to a
-normal review pass, not this one. A single smoke test or `assert`-based
+Scope: over-engineering and complexity only. Correctness bugs, security holes,
+and performance are explicitly out of scope — route them to a normal review
+pass, not this one. A single smoke test or `assert`-based
 self-check is the ponytail minimum, not bloat, never flag it for deletion.
 Does not apply the fixes, only lists them.
 "stop ponytail-review" or "normal mode": revert to verbose review style.

--- a/skills/ponytail-audit/SKILL.md
+++ b/skills/ponytail-audit/SKILL.md
@@ -35,6 +35,7 @@ End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. S
 
 ## Boundaries
 
-Complexity only, correctness bugs, security holes, and performance go to a
-normal review pass. Lists findings, applies nothing. One-shot.
+Scope: over-engineering and complexity only. Correctness bugs, security holes,
+and performance are explicitly out of scope — route them to a normal review
+pass. Lists findings, applies nothing. One-shot.
 "stop ponytail-audit" or "normal mode" to revert.

--- a/skills/ponytail-review/SKILL.md
+++ b/skills/ponytail-review/SKILL.md
@@ -49,8 +49,9 @@ If there is nothing to cut, say `Lean already. Ship.` and stop.
 
 ## Boundaries
 
-Complexity only, correctness bugs, security holes, and performance go to a
-normal review pass, not this one. A single smoke test or `assert`-based
+Scope: over-engineering and complexity only. Correctness bugs, security holes,
+and performance are explicitly out of scope — route them to a normal review
+pass, not this one. A single smoke test or `assert`-based
 self-check is the ponytail minimum, not bloat, never flag it for deletion.
 Does not apply the fixes, only lists them.
 "stop ponytail-review" or "normal mode": revert to verbose review style.


### PR DESCRIPTION
## Problem

Both `ponytail-audit` and `ponytail-review` open their **Boundaries** section with:

> Complexity only, correctness bugs, security holes, and performance go to a normal review pass.

The comma after **"Complexity only"** fuses the *in-scope* item with the *out-of-scope* list. Read literally — which is how a model parses an instruction — it says complexity **and** correctness bugs **and** security holes **and** performance all "go to a normal review pass," i.e. all four are treated as targets of the audit. That's the opposite of the intended scope, where the skill should focus **only** on over-engineering/complexity and push everything else to a normal review.

(`ponytail-review` already hints at the intent with a trailing "not this one", which is exactly the disambiguation this change makes explicit and complete.)

## Fix

Restate the boundary as an explicit scope fence:

> Scope: over-engineering and complexity only. Correctness bugs, security holes, and performance are explicitly out of scope — route them to a normal review pass. …

- States **what is in scope** affirmatively, then marks the rest **"explicitly out of scope"** — phrasing models reliably honor as a hard constraint.
- Aligns the scope term with each skill's stated purpose (**over-engineering**), matching their `description` frontmatter.
- Keeps the existing single-line prose style of every other Boundaries section in the repo (no structural/format change).

## Scope of the change

Applied to **both** skill trees so they don't drift:

- `skills/ponytail-audit/SKILL.md`
- `skills/ponytail-review/SKILL.md`
- `.openclaw/skills/ponytail-audit/SKILL.md`
- `.openclaw/skills/ponytail-review/SKILL.md`

Boundaries bodies are byte-identical across the two trees; only the wording shown above changed. No frontmatter or behavior-table changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)