### PR TITLE
Add missing ponytail-audit & ponytail-debt to the help card

### DIFF
--- a/.openclaw/skills/ponytail-help/SKILL.md
+++ b/.openclaw/skills/ponytail-help/SKILL.md
@@ -26,10 +26,13 @@ Level sticks until changed or session end.
 |-------|---------|--------------|
 | **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
 | **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
+| **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit. Ranked list of what to delete, simplify, or replace. |
+| **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` comments into a ledger of deferred shortcuts. |
 | **ponytail-gain** | `/ponytail-gain` | Measured-impact scoreboard: less code, less cost, more speed. |
 | **ponytail-help** | `/ponytail-help` | This card. |
 
-Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
+Codex uses `@ponytail`, `@ponytail-review`, `@ponytail-audit`, `@ponytail-debt`,
+`@ponytail-gain`, and `@ponytail-help`; Claude Code
 and OpenCode use the slash-command forms above (OpenCode ships `/ponytail` and
 `/ponytail-review`).
 

--- a/skills/ponytail-help/SKILL.md
+++ b/skills/ponytail-help/SKILL.md
@@ -27,10 +27,13 @@ Level sticks until changed or session end.
 |-------|---------|--------------|
 | **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
 | **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
+| **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit. Ranked list of what to delete, simplify, or replace. |
+| **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` comments into a ledger of deferred shortcuts. |
 | **ponytail-gain** | `/ponytail-gain` | Measured-impact scoreboard: less code, less cost, more speed. |
 | **ponytail-help** | `/ponytail-help` | This card. |
 
-Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
+Codex uses `@ponytail`, `@ponytail-review`, `@ponytail-audit`, `@ponytail-debt`,
+`@ponytail-gain`, and `@ponytail-help`; Claude Code
 and OpenCode use the slash-command forms above (OpenCode ships `/ponytail` and
 `/ponytail-review`).
 


### PR DESCRIPTION
## Problem

`ponytail-help` bills itself as a "quick-reference card for **all** ponytail modes, skills, and commands," but its **Skills** table only lists three of the five skills:

- ✅ `ponytail`
- ✅ `ponytail-review`
- ✅ `ponytail-help`
- ❌ `ponytail-audit` — missing
- ❌ `ponytail-debt` — missing

The Codex `@`-command line had the same gap. A user who runs `/ponytail-help` to discover what's available never learns that two of the five skills exist.

## Fix

- Add a Skills-table row for `ponytail-audit` and `ponytail-debt`.
- Extend the Codex `@`-command list to include both.

No format change — same table/prose style as before. Applied to both `skills/` and the `.openclaw/` mirror so the two trees stay in sync.

Filed separately from the Boundaries punctuation fix (#163) so each can be reviewed on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)