### PR TITLE
docs: show the up-to-94% peak in the README hero

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@
 </p>
 
 <p align="center">
-  <strong>~54% less code &middot; ~20% cheaper &middot; ~27% faster &middot; 100% safe</strong><br>
-  <sub>Measured on real Claude Code sessions editing a real open-source repo (FastAPI + React), against the same agent with no skill. Mean across 12 feature tasks (Haiku 4.5, n=4). ponytail keeps every safety guard while a bare "write one-liners" prompt drops one. (An older single-shot test showed a larger 80-94% gap, but that counted a chatty model's prose; this is the honest multi-turn number.) <a href="benchmarks/results/2026-06-18-agentic.md">Full writeup</a> &middot; <a href="benchmarks/">reproduce it</a>.</sub>
+  <strong>~54% less code (up to 94%) &middot; ~20% cheaper &middot; ~27% faster &middot; 100% safe</strong><br>
+  <sub>Measured on real Claude Code sessions editing a real open-source repo (FastAPI + React), against the same agent with no skill. ~54% is the mean across 12 feature tasks (Haiku 4.5, n=4); it reaches 94% where an agent over-builds (a date picker) and is near zero where the code is already minimal. ponytail keeps every safety guard while a bare "write one-liners" prompt drops one. (The earlier single-shot benchmark reported 80-94% as a flat figure; against a fair agentic baseline that is the per-task ceiling, not the average.) <a href="benchmarks/results/2026-06-18-agentic.md">Full writeup</a> &middot; <a href="benchmarks/">reproduce it</a>.</sub>
 </p>
 
 ---


### PR DESCRIPTION
The hero line showed only the ~54% average. The rigorous agentic benchmark also reaches 94% on the tasks where an agent over-builds (the date picker, native input vs a hand-rolled component), so the headline now reads "~54% less code (up to 94%)".

The sub-line is reworded so the 80-94% range reads as the honest per-task ceiling against a fair agentic baseline (mean ~54%, near zero on already-minimal code), instead of the old single-shot figure, which would otherwise contradict the hero.

Both numbers are real and documented in the writeup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
