### PR TITLE
docs: re-sync README.es.md to current English (numbers, CodeWhale, badge)

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -14,13 +14,17 @@
 <p align="center">
   <img src="https://img.shields.io/github/stars/DietrichGebert/ponytail?style=flat-square&color=111111&label=stars" alt="Stars">
   <img src="https://img.shields.io/github/v/release/DietrichGebert/ponytail?style=flat-square&color=111111&label=release" alt="Release">
-  <img src="https://img.shields.io/badge/funciona%20con-13%20agentes-111111?style=flat-square" alt="Works with 13 agents">
+  <img src="https://img.shields.io/badge/funciona%20con-14%20agentes-111111?style=flat-square" alt="Works with 14 agents">
   <img src="https://img.shields.io/badge/licencia-MIT-111111?style=flat-square" alt="MIT license">
 </p>
 
 <p align="center">
-  <strong>80-94% menos código &middot; 3-6&times; más rápido &middot; 47-77% más barato</strong><br>
-  <sub>Mediana de 10 ejecuciones con Haiku, Sonnet y Opus. <a href="benchmarks/">Reprodúcelo tú mismo.</a></sub>
+  <strong>~54% menos código (hasta 94%) &middot; ~20% más barato &middot; ~27% más rápido &middot; 100% seguro</strong><br>
+  <sub>Medido en sesiones reales de Claude Code editando un repo open-source real (FastAPI + React), contra el mismo agente sin skill. ~54% es el promedio de 12 tareas de feature (Haiku 4.5, n=4); llega al 94% cuando un agente sobre-construye (un selector de fechas) y es casi cero cuando el código ya es mínimo. ponytail mantiene cada guarda de seguridad, mientras que un prompt pelado de "escribe one-liners" se salta una. (El benchmark anterior de un solo disparo reportaba 80-94% como cifra plana; contra un baseline agéntico justo, ese es el techo por tarea, no el promedio.) <a href="benchmarks/results/2026-06-18-agentic.md">Reporte completo</a> &middot; <a href="benchmarks/">reprodúcelo</a>.</sub>
+</p>
+
+<p align="center">
+  <sub>Traducción de la comunidad. La versión de referencia y más reciente es el <a href="README.md">README en inglés</a>.</sub>
 </p>
 
 ---
@@ -42,15 +46,38 @@ Con ponytail:
 
 Más sobrevivientes en [examples/](examples/).
 
+> **Combina bien con** [Modern Web Guidance](https://github.com/GoogleChrome/modern-web-guidance) para trabajo web: ponytail decide *si* apoyarse en la plataforma, MWG es cómo el agente busca *qué* feature nativa hace el trabajo. Ver [examples/web-platform-lookup.md](examples/web-platform-lookup.md).
+
 ## Números
 
-Cinco tareas del día a día (validador de email, debounce, suma de CSV, temporizador, rate limiter), tres modelos, tres variantes: sin skill, el skill [caveman](https://github.com/JuliusBrussee/caveman), y ponytail. Diez ejecuciones por celda, mediana reportada.
+La medición honesta es un agente real haciendo trabajo real: una sesión headless de Claude Code editando [el template full-stack-fastapi de tiangolo](https://github.com/fastapi/full-stack-fastapi-template) (un repo real de FastAPI + React), evaluada sobre el `git diff` que deja. Doce tickets de feature, el mismo agente con y sin el skill, n=4, Haiku 4.5.
 
 <p align="center">
-  <img src="assets/benchmark-3model.svg" width="860" alt="Mediana de líneas de código por variante en Haiku, Sonnet y Opus; ponytail escribe 80-94% menos código que el baseline sin skill">
+  <img src="assets/benchmark-agentic.svg" width="860" alt="Cada variante como porcentaje del baseline sin skill en LOC, tokens, costo y tiempo (Haiku 4.5). ponytail es el más bajo en cada métrica (LOC 46%, tokens 78%, costo 80%, tiempo 73%); caveman sube por encima del 100% en tokens, costo y tiempo; yagni-oneliner LOC 67%. Seguridad, tier adversarial aparte: baseline, caveman y ponytail 100%, yagni-oneliner 95%.">
 </p>
 
-**80-94% menos código, 47-77% menos costo, y 3-6× más rápido que un agente sin skill, en todos los modelos.** Cada atajo que toma ponytail queda marcado en el código con un comentario `ponytail:` que nombra la ruta de actualización. Reprodúcelo: `npx promptfoo eval -c benchmarks/promptfooconfig.yaml`. Método y números completos: [benchmarks/](benchmarks/). Tareas de nivel producción, donde un agente sin restricciones se infla mucho más, están documentadas en [benchmarks/results/](benchmarks/results/).
+| vs baseline sin skill | LOC | tokens | costo | tiempo | seguro |
+|---|--:|--:|--:|--:|--:|
+| **ponytail** | **-54%** | **-22%** | **-20%** | **-27%** | **100%** |
+| caveman (control de prosa concisa) | -20% | +7% | +3% | +2% | 100% |
+| prompt "YAGNI + one-liners" | -33% | -14% | -21% | -30% | 95% |
+
+ponytail es la única variante que recorta cada métrica, y la única que se mantiene totalmente segura al hacerlo. El recorte es mayor donde hay una trampa real de sobre-construcción (selector de fechas de 404 a 23 líneas, selector de color de 287 a 23, porque usa un `<input>` nativo en vez de un componente) y casi cero en código que ya es mínimo. Método completo, tablas por tarea y limitaciones: [benchmarks/results/2026-06-18-agentic.md](benchmarks/results/2026-06-18-agentic.md).
+
+<details>
+<summary><strong>Números anteriores de un solo disparo (generación aislada)</strong></summary>
+
+Cinco tareas del día a día, tres modelos, tres variantes (sin skill, [caveman](https://github.com/JuliusBrussee/caveman), ponytail), diez ejecuciones, mediana reportada. Un prompt, una completación, contando las líneas de la respuesta:
+
+<p align="center">
+  <img src="assets/benchmark-3model.svg" width="860" alt="Mediana de líneas de código por variante en Haiku, Sonnet y Opus">
+</p>
+
+Esto mostraba **80-94% menos código**. [#126](https://github.com/DietrichGebert/ponytail/issues/126) señaló con razón que el baseline del modelo pelado infla su respuesta con prosa y opciones, así que esa diferencia es en parte un artefacto del baseline conversacional. Los números agénticos de arriba son la versión corregida y defendible. Reproduce la corrida de un solo disparo con `npx promptfoo eval -c benchmarks/promptfooconfig.yaml`.
+
+</details>
+
+**La regla nunca fue "menos tokens."** Es: escribe solo lo que la tarea necesita, y nunca recortes validación, manejo de errores, seguridad ni accesibilidad. El código termina pequeño porque es necesario, no por golf. El menor costo y latencia son un efecto secundario en los modelos que siguen la escalera; un modelo de razonamiento conciso que gasta tokens de pensamiento deliberando los peldaños puede ir al revés (en GPT-5.5 lo hace).
 
 ## Cómo funciona
 
@@ -79,6 +106,8 @@ Los plugins de Claude Code y Codex ejecutan dos pequeños lifecycle hooks de Nod
 /plugin marketplace add DietrichGebert/ponytail
 /plugin install ponytail@ponytail
 ```
+
+La app de escritorio no tiene el comando `/plugin`. Instálala desde la interfaz: Customize, el + junto a los plugins personales, Create plugin and add marketplace, Add from repository, y luego ingresa la URL del repo (gracias @NiklasDHahn, #98).
 
 ### Codex
 
@@ -147,6 +176,10 @@ agy plugin install https://github.com/DietrichGebert/ponytail
 ```
 
 Reutiliza el `gemini-extension.json` de este repo. Una diferencia: Antigravity convierte los comandos `/ponytail` en skills, así que los escribes en el chat (por ejemplo `/ponytail-review` como mensaje) en vez de seleccionarlos de un menú slash. Hasta que la migración se complete (alrededor del 18 de junio de 2026), `gemini extensions install` también funciona. Para usarlo como regla permanente, coloca el ruleset en `.agents/rules/`.
+
+### CodeWhale
+
+Lee `AGENTS.md` desde la raíz del proyecto, sin configuración. Copia [`AGENTS.md`](AGENTS.md) a tu proyecto, o ejecuta `codewhale` desde un checkout de este repo. Eso es todo.
 
 ### OpenClaw
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@
   <sub>Measured on real Claude Code sessions editing a real open-source repo (FastAPI + React), against the same agent with no skill. ~54% is the mean across 12 feature tasks (Haiku 4.5, n=4); it reaches 94% where an agent over-builds (a date picker) and is near zero where the code is already minimal. ponytail keeps every safety guard while a bare "write one-liners" prompt drops one. (The earlier single-shot benchmark reported 80-94% as a flat figure; against a fair agentic baseline that is the per-task ceiling, not the average.) <a href="benchmarks/results/2026-06-18-agentic.md">Full writeup</a> &middot; <a href="benchmarks/">reproduce it</a>.</sub>
 </p>
 
+<p align="center">
+  <sub><a href="README.es.md">Español</a></sub>
+</p>
+
 ---
 
 You know him. Long ponytail. Oval glasses. Has been at the company longer than the version control. You show him fifty lines; he looks at them, says nothing, and replaces them with one.


### PR DESCRIPTION
Follow-up to #110. The Spanish README merged stale: old flat "80-94%" single-shot headline (the claim #126 corrected), no CodeWhale, badge at 13, missing the Modern Web Guidance callout (#82) and the Claude Code desktop-install paragraph.

Re-translates the hero + Números to the corrected agentic numbers (~54%, up to 94%, 100% safe), demotes the old figures into the same `<details>` block English uses, adds CodeWhale, fixes the badge to 14, adds a community-translation note, and adds an Español discoverability link to the English README. Structure now matches EN (17 sections), suite + check-rule-copies green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)