### PR TITLE
chore(ponytail-mcp): mark private, drop dead bin

### DIFF
--- a/ponytail-mcp/package.json
+++ b/ponytail-mcp/package.json
@@ -2,9 +2,9 @@
   "name": "ponytail-mcp",
   "version": "0.1.0",
   "description": "MCP server that serves Ponytail's lazy-senior-dev instructions as a prompt and a tool.",
+  "private": true,
   "type": "module",
   "license": "MIT",
-  "bin": { "ponytail-mcp": "./index.js" },
   "scripts": { "test": "node --test ./test/*.test.js" },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.19.0",


### PR DESCRIPTION
Follow-up to #91. `ponytail-mcp` reuses the repo's `hooks/` via `createRequire("../hooks/...")`, so it only works from a checkout (as its README states) — a published npm tarball wouldn't include `../hooks/` and would crash. The `bin` + missing `private` made it look publishable. Marking it `private: true` so an accidental `npm publish` can't ship a broken package, and dropping the dead `bin`. Instruction test still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)