### PR TITLE
fix: regenerate .openclaw ponytail skill mirror (red CI)

### DIFF
--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -31,6 +31,16 @@ Stop at the first rung that holds:
 The ladder is a reflex, not a research project. Two rungs work → take the
 higher one and move on. The first lazy solution that works is the right one.
 
+## Web tasks: rung 3 lookup
+
+On web work, rung 3 is where the laziest win hides: a native element or CSS
+behavior the agent forgot exists. If a web task turns on whether the platform
+covers it (a date input, dialog, popover, view transition, container query),
+and the `modern-web` CLI is available, look it up: `modern-web search "<task>"`,
+then `modern-web retrieve <id>`. It is a lookup, not a license, the answer
+still goes through the ladder. MWG suggests the cutting edge; you keep only the
+rung that holds. Not installed? Skip it, the ladder runs fine without it.
+
 ## Rules
 
 - No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.


### PR DESCRIPTION
Main's CI has been red since #82: it added the "Web tasks: rung 3 lookup" section to `skills/ponytail/SKILL.md` without running `scripts/build-openclaw-skills.js`, so the committed `.openclaw/skills/ponytail/SKILL.md` drifted from its generator and the two sync tests failed. Regenerated the mirror. Root 56/56, pi 12/12, rule-copy green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)