### PR TITLE
fix: drop em dashes reintroduced by #163 in audit/review skills

### DIFF
--- a/.openclaw/skills/ponytail-audit/SKILL.md
+++ b/.openclaw/skills/ponytail-audit/SKILL.md
@@ -32,6 +32,6 @@ End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. S
 ## Boundaries
 
 Scope: over-engineering and complexity only. Correctness bugs, security holes,
-and performance are explicitly out of scope — route them to a normal review
+and performance are explicitly out of scope. Route them to a normal review
 pass. Lists findings, applies nothing. One-shot.
 "stop ponytail-audit" or "normal mode" to revert.

--- a/.openclaw/skills/ponytail-review/SKILL.md
+++ b/.openclaw/skills/ponytail-review/SKILL.md
@@ -45,7 +45,7 @@ If there is nothing to cut, say `Lean already. Ship.` and stop.
 ## Boundaries
 
 Scope: over-engineering and complexity only. Correctness bugs, security holes,
-and performance are explicitly out of scope — route them to a normal review
+and performance are explicitly out of scope. Route them to a normal review
 pass, not this one. A single smoke test or `assert`-based
 self-check is the ponytail minimum, not bloat, never flag it for deletion.
 Does not apply the fixes, only lists them.

--- a/skills/ponytail-audit/SKILL.md
+++ b/skills/ponytail-audit/SKILL.md
@@ -36,6 +36,6 @@ End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. S
 ## Boundaries
 
 Scope: over-engineering and complexity only. Correctness bugs, security holes,
-and performance are explicitly out of scope — route them to a normal review
+and performance are explicitly out of scope. Route them to a normal review
 pass. Lists findings, applies nothing. One-shot.
 "stop ponytail-audit" or "normal mode" to revert.

--- a/skills/ponytail-review/SKILL.md
+++ b/skills/ponytail-review/SKILL.md
@@ -50,7 +50,7 @@ If there is nothing to cut, say `Lean already. Ship.` and stop.
 ## Boundaries
 
 Scope: over-engineering and complexity only. Correctness bugs, security holes,
-and performance are explicitly out of scope — route them to a normal review
+and performance are explicitly out of scope. Route them to a normal review
 pass, not this one. A single smoke test or `assert`-based
 self-check is the ponytail minimum, not bloat, never flag it for deletion.
 Does not apply the fixes, only lists them.


### PR DESCRIPTION
#163 clarified the ponytail-audit/review scope wording (good) but put em dashes back into the skill files, which the repo deliberately removed in `88431de`. Keeps the clearer wording, swaps the em dash for a period, regenerates the `.openclaw` mirrors. 56/56, mirror synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)