### PR TITLE
Fix for #168: Don't write output on SessionStart for Copilot

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -13,6 +13,7 @@ const { getPonytailInstructions } = require('./ponytail-instructions');
 const {
   clearMode,
   isCodex,
+  isCopilot,
   setMode,
   writeHookOutput,
 } = require('./ponytail-runtime');
@@ -40,7 +41,7 @@ try {
 let output = getPonytailInstructions(mode);
 
 // 3. Detect missing statusline config — nudge Claude to help set it up
-if (!isCodex) try {
+if (!isCodex && !isCopilot) try {
   let hasStatusline = false;
   if (fs.existsSync(settingsPath)) {
     // Strip UTF-8 BOM some editors prepend on Windows (breaks JSON.parse)

--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -26,7 +26,8 @@ const mode = getDefaultMode();
 // "off" mode — skip activation entirely, don't write flag or emit rules
 if (mode === 'off') {
   clearMode();
-  writeHookOutput('SessionStart', 'off', isCodex ? '' : 'OK');
+  const hookOutput = (isCodex || isCopilot) ? '' : 'OK';
+  writeHookOutput('SessionStart', 'off', hookOutput);
   process.exit(0);
 }
 


### PR DESCRIPTION
<img src="https://raw.githubusercontent.com/maxfelker/ponytail/main/assets/logo.png" width="64" height="64" />

**tl;dr:** `!isCodex` was too broad — Copilot sessions leaked Claude-only content into `additionalContext`, breaking token validation on Windows.

---

## What broke

`ponytail-activate.js` had two guards that used `isCodex` to skip Claude-specific behaviour. Both conditions forgot about Copilot — so Copilot sessions fell through into Claude-only paths.

**Bug 1 — statusline nudge injected into Copilot context**

```js
// before
if (!isCodex) try {
```

The statusline nudge appends a raw JSON-like fragment to the hook output:

```
"statusLine": { "type": "command", "command": "powershell -ExecutionPolicy Bypass -File \"...\"" }
```

Copilot's parser received this inside `additionalContext`, tried to interpret it as a structured instruction token, and rejected it: *"the token is not a valid instructions separator in this version."*

The statusline is a Claude Code setting (`~/.claude/settings.json`). Copilot has no equivalent and should never see this nudge.

**Bug 2 — off-mode emitted `'OK'` to Copilot**

```js
// before
writeHookOutput('SessionStart', 'off', isCodex ? '' : 'OK');
```

Codex got `''` → empty JSON output `{}`. Copilot got `'OK'` → `{ "additionalContext": "OK" }`. In off mode nothing should be injected. Same class of bug, same fix.

## What changed

`hooks/ponytail-activate.js` only — two lines:

```js
// import isCopilot alongside isCodex
const { clearMode, isCodex, isCopilot, setMode, writeHookOutput } = require('./ponytail-runtime');

// Bug 1: scope statusline nudge to Claude only
if (!isCodex && !isCopilot) try {

// Bug 2: off mode emits nothing for both non-Claude hosts
const hookOutput = (isCodex || isCopilot) ? '' : 'OK';
writeHookOutput('SessionStart', 'off', hookOutput);
```

`isCopilot` was already exported from `ponytail-runtime.js` — it just wasn't imported here.

## Test

`node tests/hooks.test.js` — hook compatibility checks passed.

---

*on behalf of @maxfelker — ponytail found it, two lines fixed it.*