### PR TITLE
Fix: CI trigger for pull requests #182

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
   pull_request:
+    branches: [main]
 
 jobs:
   test:


### PR DESCRIPTION
closes #182

This PR updates the workflow configuration to ensure CI runs when a pull request is opened or updated against the main branch.

Testing
Verified that CI is triggered when creating a pull request targeting main.
Tested using a pull request from a forked repository.