### PR TITLE
Add Hermes Agent support to install matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 <p align="center">
   <img src="https://img.shields.io/github/stars/DietrichGebert/ponytail?style=flat-square&color=111111&label=stars" alt="Stars">
   <img src="https://img.shields.io/github/v/release/DietrichGebert/ponytail?style=flat-square&color=111111&label=release" alt="Release">
-  <img src="https://img.shields.io/badge/works%20with-14%20agents-111111?style=flat-square" alt="Works with 14 agents">
+  <img src="https://img.shields.io/badge/works%20with-15%20agents-111111?style=flat-square" alt="Works with 15 agents">
   <img src="https://img.shields.io/badge/license-MIT-111111?style=flat-square" alt="MIT license">
 </p>
 
@@ -128,7 +128,7 @@ copilot plugin install ponytail@ponytail
 
 In an interactive Copilot CLI session, use the slash equivalents:
 
-```
+```text
 /plugin marketplace add DietrichGebert/ponytail
 /plugin install ponytail@ponytail
 ```
@@ -139,6 +139,16 @@ Copilot CLI namespaces plugin commands by plugin name. For example:
 /ponytail:ponytail ultra
 /ponytail:ponytail-review
 ```
+
+### Hermes
+
+```bash
+hermes skills install https://raw.githubusercontent.com/DietrichGebert/ponytail/main/skills/ponytail/SKILL.md
+```
+
+This installs the portable `skills/ponytail/SKILL.md` skill. After installing, load it with `/skill ponytail` or start a session with `--skills ponytail`. The `lite`/`full`/`ultra` intensity levels are configured via the `PONYTAIL_DEFAULT_MODE` environment variable or `~/.config/ponytail/config.json`.
+
+The skill governs what you build (use the ladder, never cut validation/security/accessibility); not how you talk — pair with [Caveman](https://github.com/JuliusBrussee/caveman) for terse prose.
 
 ### Pi agent harness
 


### PR DESCRIPTION
## Summary

Adds Hermes Agent to Ponytail's supported agents list.

### Changes
- **Badge update**: "works with 14 agents" → "works with 15 agents" 
- **New install section**: Added Hermes Agent install instructions (alphabetically between GitHub Copilot CLI and Pi agent harness)

### Hermes install
```bash
hermes skills install https://raw.githubusercontent.com/DietrichGebert/ponytail/main/skills/ponytail/SKILL.md
```

This installs the portable `skills/ponytail/SKILL.md` skill. After installing, load it with `/skill ponytail` or `hermes --skills ponytail`. Intensity levels (`lite`/`full`/`ultra`) are configured via `PONYTAIL_DEFAULT_MODE` env var or `~/.config/ponytail/config.json`.

No code changes required — the repository's existing portable `skills/ponytail/SKILL.md` works natively on Hermes Agent.

### Testing
- Verified `hermes skills install` works with the raw SKILL.md URL
- Verified `/skill ponytail` loads the skill and activates the lazy-ladder logic
- The skill governs *what you build* (YAGNI, stdlib first, no unrequested abstractions, never cut validation/security/accessibility); not how you talk — pairs with [Caveman](https://github.com/JuliusBrussee/caveman) for terse prose.

Follows existing install section style and conventions. No code changes required if the portable artifact already covers the host.