### PR TITLE
fix: skip the Claude Code statusline nudge for Copilot

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -13,6 +13,7 @@ const { getPonytailInstructions } = require('./ponytail-instructions');
 const {
   clearMode,
   isCodex,
+  isCopilot,
   setMode,
   writeHookOutput,
 } = require('./ponytail-runtime');
@@ -39,8 +40,10 @@ try {
 // 2. Emit the ponytail ruleset, filtered to the active intensity level.
 let output = getPonytailInstructions(mode);
 
-// 3. Detect missing statusline config — nudge Claude to help set it up
-if (!isCodex) try {
+// 3. The statusline badge is a Claude Code feature configured in ~/.claude.
+// Skip the setup nudge for Codex and Copilot — neither reads that statusline,
+// so nudging them points at an irrelevant ~/.claude/settings.json.
+if (!isCodex && !isCopilot) try {
   let hasStatusline = false;
   if (fs.existsSync(settingsPath)) {
     const settings = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -77,6 +77,12 @@ assert.equal(
   fs.readFileSync(path.join(home, '.claude', '.ponytail-active'), 'utf8'),
   'full',
 );
+// Claude Code with no statusline configured still gets the setup nudge.
+assert.match(
+  result.stdout,
+  /STATUSLINE SETUP NEEDED/,
+  'Claude Code should be nudged to configure the statusline',
+);
 
 // CLAUDE_CONFIG_DIR overrides ~/.claude for the flag file (issue #34).
 const home2 = path.join(temp, 'home2');
@@ -117,6 +123,11 @@ assert.equal(
 );
 output = JSON.parse(result.stdout);
 assert.match(output.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);
+// The statusline is Claude Code-only; Copilot must not get its setup nudge.
+assert.ok(
+  !output.additionalContext.includes('STATUSLINE SETUP NEEDED'),
+  'Copilot must not receive the Claude Code statusline setup nudge',
+);
 
 result = run(
   'ponytail-mode-tracker.js',


### PR DESCRIPTION
Fixes #186.

The SessionStart activation hook gated the statusline setup nudge with `if (!isCodex)`, which let Copilot CLI through. The statusline badge is a Claude Code feature (configured in `~/.claude/settings.json`); Copilot has no equivalent, so every Copilot user without that file got injected guidance telling the agent to *proactively offer* to set up an irrelevant `~/.claude/settings.json` entry. Repro in the issue.

Gate the nudge with `if (!isCodex && !isCopilot)` so it only fires for Claude Code. The flag-write and ruleset injection are untouched — Copilot still gets the ponytail ruleset, just not the bogus statusline nudge.

- `hooks/ponytail-activate.js`: import `isCopilot`, exclude it from the statusline block
- tests: assert Copilot SessionStart output no longer contains the nudge, and that Claude Code with no statusline configured still gets it

`node --test tests/*.test.js` passes (51).