### PR TITLE
docs: add Zed to the agent portability table

### DIFF
--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -22,6 +22,7 @@ to load in a given agent.
 | CodeWhale | `AGENTS.md` | Reads `AGENTS.md` from the repo root as project instructions; also reads `CLAUDE.md` and `.claude/instructions.md` as fallbacks. Instruction-tier. |
 | VS Code + Codex extension | `AGENTS.md` | The Codex extension reads `AGENTS.md` (repo root, or `~/.codex/AGENTS.md` globally). Instruction-tier; the full Codex plugin row above adds `/ponytail` levels and hooks. |
 | Kiro | `.kiro/steering/ponytail.md` | Steering rule; copy globally or into a project. |
+| Zed | `AGENTS.md` | Auto-includes `AGENTS.md` from the worktree root as one of its default rule files for the Agent Panel. Instruction-tier. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 
 ## Adapter Rule


### PR DESCRIPTION
The README lists Zed in the instruction-tier agents and points readers to `docs/agent-portability.md` as the canonical file mapping ("Which files map to which agent"), but that table has no Zed row.

Zed auto-includes `AGENTS.md` from the worktree root as one of its default rule files for the Agent Panel ([Zed rules docs](https://zed.dev/docs/ai/rules)), so it is instruction-tier like Antigravity and CodeWhale. Added a matching row so the table agrees with the README.

Docs only, no behavior change. `node scripts/check-rule-copies.js` and the test suite stay green.