### PR TITLE
Add Modern Web Guidance as an optional examples/ note for web tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,8 @@ With ponytail:
 
 More survivors in [examples/](examples/).
 
+> **Pairs well with** [Modern Web Guidance](https://github.com/GoogleChrome/modern-web-guidance) for web work: ponytail decides *whether* to lean on the platform, MWG is how the agent looks up *which* native feature does the job. See [examples/web-platform-lookup.md](examples/web-platform-lookup.md).
+
 ## Numbers
 
 The honest measurement is a real agent doing real work: a headless Claude Code session editing [tiangolo's full-stack-fastapi-template](https://github.com/fastapi/full-stack-fastapi-template) (a real FastAPI + React repo), scored on the `git diff` it leaves behind. Twelve feature tickets, the same agent with and without the skill, n=4, Haiku 4.5.

--- a/examples/web-platform-lookup.md
+++ b/examples/web-platform-lookup.md
@@ -1,0 +1,69 @@
+# Web Platform Lookup
+
+**Task:** "Add a modal dialog that closes when you click the backdrop."
+
+Rung 3 of the ladder is "native platform feature covers it?" On web work the
+trap is that the agent forgets what the platform already does (a date input,
+dialog, popover, view transition, container query) and reaches for a library.
+When a web task turns on whether the platform covers it and the optional
+[Modern Web Guidance](https://github.com/GoogleChrome/modern-web-guidance)
+`modern-web` CLI is on hand, rung 3 gets a lookup:
+`modern-web search "modal dialog light dismiss"`. Not installed? Skip it, the
+ladder runs fine without it. This is a lookup, not part of the always-on
+ruleset.
+
+## Without Ponytail
+
+```bash
+npm install @radix-ui/react-dialog
+```
+
+```jsx
+import * as Dialog from "@radix-ui/react-dialog";
+
+export default function Modal({ open, onOpenChange, children }) {
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="overlay" />
+        <Dialog.Content className="content">
+          {children}
+          <Dialog.Close className="close">×</Dialog.Close>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}
+```
+
+A dependency, a portal, an overlay node, and controlled open state, to put a
+box on top with a backdrop.
+
+## With Ponytail
+
+`modern-web search "modal dialog light dismiss"` →
+`modern-web retrieve light-dismiss-a-dialog`. The platform has it:
+
+```html
+<!-- ponytail: <dialog> + closedby, browser does the backdrop, focus trap, and Esc -->
+<dialog closedby="any">
+  <p>...</p>
+</dialog>
+```
+
+```js
+document.querySelector("dialog").showModal();
+```
+
+**1 dependency + portal/overlay machinery → 0 dependencies + a `<dialog>`.**
+The `::backdrop` is free, focus is trapped and restored for you, `Esc` closes
+it, and `closedby="any"` adds click-outside dismissal. The browser team did the
+work.
+
+## The point
+
+MWG suggests the cutting edge, ponytail keeps only the rung that holds. The
+lookup found `light-dismiss-a-dialog`; the ladder took it because it deletes a
+dependency. The same search would have offered scroll-driven animations and
+view transitions for other tasks, and the ladder would have skipped them when
+the task didn't need them. Lookup, not license.


### PR DESCRIPTION
Surfaces Modern Web Guidance as the rung-3 lookup for web work, kept entirely out of the always-on core skill per maintainer feedback.

- examples/web-platform-lookup.md: a <dialog closedby> vs Radix before/after in the date-picker.md style, carrying the lookup mechanic, the feature-type list, and the "optional, skip if the CLI isn't installed" framing.
- README.md: one "Pairs well with" line by the existing Caveman cross-reference, pointing at the example.

SKILL.md is left byte-identical to upstream, so the always-on ruleset stays lean and self-contained and there is no skill mirror to regenerate. check-rule-copies.js passes; the only test failure is the environmental pandas CSV check documented in the README.