### PR TITLE
ux: make the ultra statusline badge stand out

### DIFF
--- a/hooks/ponytail-statusline.ps1
+++ b/hooks/ponytail-statusline.ps1
@@ -13,9 +13,12 @@ try {
 }
 
 $Esc = [char]27
+# ultra is the high-intensity mode; flag it amber so it stands out from the
+# default green. The level is still in the text, so color is a redundant cue.
+$Color = if ($Mode -eq "ultra") { "173" } else { "108" }
 if ([string]::IsNullOrEmpty($Mode) -or $Mode -eq "full") {
-    [Console]::Write("${Esc}[38;5;108m[PONYTAIL]${Esc}[0m")
+    [Console]::Write("${Esc}[38;5;${Color}m[PONYTAIL]${Esc}[0m")
 } else {
     $Suffix = $Mode.ToUpperInvariant()
-    [Console]::Write("${Esc}[38;5;108m[PONYTAIL:$Suffix]${Esc}[0m")
+    [Console]::Write("${Esc}[38;5;${Color}m[PONYTAIL:$Suffix]${Esc}[0m")
 }

--- a/hooks/ponytail-statusline.sh
+++ b/hooks/ponytail-statusline.sh
@@ -5,8 +5,14 @@ flag="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.ponytail-active"
 
 mode=$(head -n1 "$flag" | tr -d '[:space:]')
 
+# ultra is the high-intensity mode; flag it amber so it stands out from the
+# default green at a glance. The level is still in the text, so color is a
+# redundant cue, not the only one.
+color=108
+[ "$mode" = "ultra" ] && color=173
+
 if [ -z "$mode" ] || [ "$mode" = "full" ]; then
-    printf '\033[38;5;108m[PONYTAIL]\033[0m'
+    printf '\033[38;5;%sm[PONYTAIL]\033[0m' "$color"
 else
-    printf '\033[38;5;108m[PONYTAIL:%s]\033[0m' "$(printf '%s' "$mode" | tr '[:lower:]' '[:upper:]')"
+    printf '\033[38;5;%sm[PONYTAIL:%s]\033[0m' "$color" "$(printf '%s' "$mode" | tr '[:lower:]' '[:upper:]')"
 fi


### PR DESCRIPTION
The statusline badge renders every mode in the same green (`38;5;108`), so `ultra` looks identical to `lite`/`full` at a glance and you can only tell by reading the suffix. `ultra` is the high-intensity mode that deletes and challenges requirements, so it is the one worth noticing.

This gives the `ultra` badge an amber accent (`38;5;173`); every other mode is unchanged. The level is still spelled out in the badge text, so color is a redundant cue rather than the only signal (keeps it readable without color).

Both scripts updated and verified to emit `173` only for ultra and `108` everywhere else:

| mode | badge |
|------|-------|
| full | `[PONYTAIL]` (green) |
| lite | `[PONYTAIL:LITE]` (green) |
| ultra | `[PONYTAIL:ULTRA]` (amber) |
| review | `[PONYTAIL:REVIEW]` (green) |

The accent color is a one-token change if you would prefer a different shade. No behavior change beyond the color; the test suite stays green.