### PR TITLE
docs: align benchmark prerequisites with promptfoo's Node requirement

### DIFF
--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -83,7 +83,7 @@ Versus baseline, ponytail writes **80-94% less code**, costs **42-75% less**, an
 
 ### Prerequisites
 
-Running the benchmark requires **Python 3**, **pandas**, and **Node.js** (18+).
+Running the benchmark requires **Python 3**, **pandas**, and **Node.js ≥ 22.22.0** (promptfoo's engine constraint; see [Reproduce](#reproduce)).
 
 ## Notes
 


### PR DESCRIPTION
**What:** `benchmarks/README.md` states two different Node.js floors. The *Reproduce* section (Claude) requires **Node.js ≥ 22.22.0** (promptfoo's engine constraint), but the *Prerequisites* section said **Node.js (18+)**. A reader who follows Prerequisites installs Node 18, runs `npx promptfoo`, and hits promptfoo's engine error. The local Ollama path (`benchmark-local.py`) is pure Python and uses no Node, so 18+ had no basis either.

**Change:** One line: align the Prerequisites Node version with the requirement already stated above it (≥ 22.22.0), reusing the existing "promptfoo's engine constraint" wording and cross-linking to Reproduce. Docs-only, no code.

**Testing:** `npm test` is unaffected (docs-only); the suite passes the same with and without this change.
