### PR TITLE
fix(benchmarks): make agentic fixture path portable via PONYTAIL_TMPL

### DIFF
--- a/benchmarks/agentic/README.md
+++ b/benchmarks/agentic/README.md
@@ -112,7 +112,8 @@ python complete.py --run runs/<stamp>  # completeness-score every workspace
 ## Reproduce
 
 Needs the `claude` CLI (this is the harness, no SDK), Python 3, an authenticated Claude Code, and a
-clone of the template at the pinned commit (point `_TMPL` in `tasks.py` at it):
+clone of the template at the pinned commit (set `PONYTAIL_TMPL` to its path, or drop it at
+`fixtures/full-stack-fastapi-template`):
 
 ```bash
 git clone https://github.com/fastapi/full-stack-fastapi-template

--- a/benchmarks/agentic/tasks.py
+++ b/benchmarks/agentic/tasks.py
@@ -25,7 +25,9 @@ from pathlib import Path
 
 # Real-repo fixture: tiangolo/full-stack-fastapi-template @ cd83fc1 (v0.10.0, MIT), cloned locally.
 # Reproduce: git clone https://github.com/tiangolo/full-stack-fastapi-template && git -C ... checkout cd83fc1
-_TMPL = r"D:\dev\fullstack-fastapi-template"
+# Point PONYTAIL_TMPL at your local clone, or drop it at fixtures/full-stack-fastapi-template
+# (run.py resolves a relative name under fixtures/). Mirrors the PONYTAIL_PLUGIN_DIR override.
+_TMPL = os.environ.get("PONYTAIL_TMPL", "full-stack-fastapi-template")
 
 # --- helpers ---
 _imp_n = 0


### PR DESCRIPTION
**Problem:** `benchmarks/agentic/tasks.py` hardcoded `_TMPL = r"D:\dev\fullstack-fastapi-template"` — a personal, absolute, Windows-only path. The agentic benchmark's *Reproduce* flow depends on `_TMPL`, so out of the box it points at a directory that exists on exactly one machine.

**Fix:** Resolve the fixture the same way the harness already resolves its plugin dir — an env override with a portable fallback:

```python
_TMPL = os.environ.get("PONYTAIL_TMPL", "full-stack-fastapi-template")
```

- `PONYTAIL_TMPL` mirrors the existing `PONYTAIL_PLUGIN_DIR` convention in `run.py` (`_plugin_dir`, *"env override wins"*).
- The relative fallback is resolved under `fixtures/` by `run.py`'s existing loader (`if not fx.is_absolute(): .../fixtures/<name>`), and matches the template dir name the README clones.
- Updated the *Reproduce* section to document `PONYTAIL_TMPL`.

**Scope / safety:** `run.py --selftest` skips `open` tasks — which are exactly the `_TMPL` consumers — so this cannot affect instrument validation. Confirmed `python run.py --selftest` still reports **"all instruments valid"**. One-line code change plus the matching doc line; no behavior change for anyone who already set the path.
