### PR TITLE
fix: bump @modelcontextprotocol/sdk to ^1.26.0 (CVE-2026-25536)

### DIFF
--- a/ponytail-mcp/package.json
+++ b/ponytail-mcp/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "scripts": { "test": "node --test ./test/*.test.js" },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.19.0",
+    "@modelcontextprotocol/sdk": "^1.26.0",
     "zod": "^3.23.0"
   }
 }


### PR DESCRIPTION
Bumps from ^1.19.0 to ^1.26.0. Fixes CVE-2026-25536 (cross-client data leak) and CVE-2025-66414 (missing DNS rebinding protection).

Closes #199.