### PR TITLE
feat: add Aider support via .aider.conf.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,8 @@ ponytail-*.gif
 # Claude Code local settings (machine-specific permission grants)
 .claude/settings.local.json
 
+# Aider temp files / chat history
+.aider*
+
 # agentic benchmark workspaces (agent output, kept locally for inspection)
 benchmarks/agentic/runs/

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ It reuses this repo's `gemini-extension.json`. One difference: Antigravity conve
 
 Reads `AGENTS.md` from the project root, zero setup. Copy [`AGENTS.md`](AGENTS.md) to your project, or run `codewhale` from a checkout of this repo. That's it.
 
+### Aider
+
+Set `read: AGENTS.md` in [`.aider.conf.yml`](.aider.conf.yml) at your project root, or run `aider --read AGENTS.md`. The config file ships with this repo so it auto-loads when running aider in a ponytail checkout.
+
 ### OpenClaw
 
 ```bash
@@ -197,7 +201,7 @@ Active every session, with a handful of commands (see [Commands](#commands)). `/
 
 Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`.
 
-Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro, Zed, CodeWhale: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
+Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro, Zed, CodeWhale: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`.aider.conf.yml`](.aider.conf.yml), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
 
 Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kiro/steering/` in your project.
 

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -18,6 +18,7 @@ to load in a given agent.
 | Cline | `.clinerules/ponytail.md` | Project rule. |
 | GitHub Copilot | `.github/copilot-instructions.md` | Repository instruction file. |
 | GitHub Copilot CLI | `.github/plugin/`, `AGENTS.md`, `.github/copilot-instructions.md`, `~/.copilot/copilot-instructions.md` | Plugin-supported (`copilot plugin marketplace add DietrichGebert/ponytail` + `copilot plugin install ponytail@ponytail`). Fallback instruction mode remains: per-project from `AGENTS.md` or `.github/copilot-instructions.md`, or globally from `~/.copilot/copilot-instructions.md` (instruction-tier, no `/ponytail` levels or hooks). |
+| Aider | `.aider.conf.yml`, `AGENTS.md` | Set `read: AGENTS.md` in `.aider.conf.yml` at the project root, or run `aider --read AGENTS.md`. The config file ships with this repo. Instruction-tier. |
 | Antigravity | `AGENTS.md` | Reads `AGENTS.md` at the repo root as always-on rules (like `.cursorrules`/`CLAUDE.md`); `.agents/rules/` also works for workspace rules. Instruction-tier. |
 | CodeWhale | `AGENTS.md` | Reads `AGENTS.md` from the repo root as project instructions; also reads `CLAUDE.md` and `.claude/instructions.md` as fallbacks. Instruction-tier. |
 | VS Code + Codex extension | `AGENTS.md` | The Codex extension reads `AGENTS.md` (repo root, or `~/.codex/AGENTS.md` globally). Instruction-tier; the full Codex plugin row above adds `/ponytail` levels and hooks. |


### PR DESCRIPTION
Aider is listed in the README as an instruction-tier agent but had no dedicated config file. Adds .aider.conf.yml that points aider at the existing AGENTS.md ruleset, install section in README, portability table entry, and .gitignore for aider artifacts.
