### PR TITLE
fix(pi-extension): preserve systemPrompt array instead of comma-collapsing it

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -152,6 +152,12 @@ export default function ponytailExtension(pi) {
 
   pi.on("before_agent_start", async (event) => {
     if (!currentMode || currentMode === "off") return;
-    return { systemPrompt: `${event.systemPrompt}\n\n${getPonytailInstructions(currentMode)}` };
+    const instructions = getPonytailInstructions(currentMode);
+    // Some hosts (e.g. Oh My Pi) pass systemPrompt as a string[]; others pass a
+    // string. Preserve the array's elements instead of stringifying it, which
+    // would comma-collapse the host's base prompt into a single section.
+    return Array.isArray(event.systemPrompt)
+      ? { systemPrompt: [...event.systemPrompt, instructions] }
+      : { systemPrompt: `${event.systemPrompt}\n\n${instructions}` };
   });
 }

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -77,6 +77,19 @@ test("/ponytail updates session mode and injects instructions", async () => with
   assert.ok(result.systemPrompt.includes("ultra"));
 }));
 
+test("array systemPrompt is preserved, not comma-collapsed", async () => withTempConfig(async () => {
+  const { events } = createPiHarness();
+  const ctx = createCommandContext();
+
+  await events.get("session_start")({ reason: "startup" }, ctx);
+
+  const result = await events.get("before_agent_start")({ systemPrompt: ["SECTION_A", "SECTION_B"] }, ctx);
+  assert.ok(Array.isArray(result.systemPrompt));
+  // Base sections stay as their own elements; instructions append as the last.
+  assert.deepEqual(result.systemPrompt.slice(0, 2), ["SECTION_A", "SECTION_B"]);
+  assert.ok(result.systemPrompt.at(-1).includes("PONYTAIL MODE ACTIVE"));
+}));
+
 test("session_start restores latest persisted mode", async () => withTempConfig(async () => {
   const { events } = createPiHarness();
   const ctx = createCommandContext({


### PR DESCRIPTION
## Problem

The pi extension's `before_agent_start` handler builds the injected prompt with a template string:

```js
return { systemPrompt: `${event.systemPrompt}\n\n${getPonytailInstructions(currentMode)}` };
```

Some hosts pass `event.systemPrompt` as a `string[]` rather than a `string` (e.g. [Oh My Pi](https://github.com/oh-my-pi), a pi fork — its `BeforeAgentStartEvent.systemPrompt` is typed `string[]`, and the runner accepts either a string or an array back). Interpolating an array stringifies it, joining the host's base-prompt sections with commas and collapsing them into one section. Ponytail's rules still get injected, but the host's base system prompt loses its section boundaries on every turn.

Repro (mirrors the host's merge): a base of `["SECTION_A", "SECTION_B", "SECTION_C"]` comes back as a single element beginning `"SECTION_A,SECTION_B,SECTION_C\n\nPONYTAIL MODE ACTIVE …"`.

## Fix

Guard on `Array.isArray` — append the instructions as a new element for array hosts, keep the existing string behavior otherwise:

```js
return Array.isArray(event.systemPrompt)
  ? { systemPrompt: [...event.systemPrompt, instructions] }
  : { systemPrompt: `${event.systemPrompt}\n\n${instructions}` };
```

The string path is untouched, so string hosts behave exactly as before.

## Tests

- Existing string-path tests are unchanged (they pass `{ systemPrompt: "BASE" }`).
- New regression test asserts an array input keeps its elements and appends the instructions as the last element.
- `node --test pi-extension/test/*.test.js` → 13/13 pass; `node scripts/check-rule-copies.js` clean.
