### PR TITLE
fix(benchmarks): validate --ollama-url scheme in benchmark-local.py

### DIFF
--- a/benchmarks/benchmark-local.py
+++ b/benchmarks/benchmark-local.py
@@ -15,6 +15,7 @@ import json
 import re
 import time
 import urllib.request
+from urllib.parse import urlparse
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
@@ -149,6 +150,9 @@ def main():
     parser.add_argument("--repeat",     type=int, default=1, help="Runs per cell; median reported (default: 1)")
     parser.add_argument("--ollama-url", default="http://localhost:11434", help="Ollama base URL")
     args = parser.parse_args()
+    parsed = urlparse(args.ollama_url)
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        parser.error("--ollama-url must be an http(s) URL, e.g. http://localhost:11434")
     run(args.model, args.repeat, args.ollama_url)
 
 


### PR DESCRIPTION
Closes #166.

**Problem:** `benchmark-local.py` passes `--ollama-url` straight into `urllib.request.urlopen()` with no scheme check, so non-HTTP schemes (`file://`, `ftp://`, `gopher://`, …) are accepted — the arbitrary-URI footgun #166 describes.

**Fix:** Validate the URL once in `main()` and reject anything that isn't an `http`/`https` URL with a host, via `parser.error()` (clean argparse exit 2). No behavior change for legitimate use — the default `http://localhost:11434` and remote `https://…` Ollama hosts still work.

**Verified** (with `run()` stubbed, so no network):

| URL | Result |
|---|---|
| `http://localhost:11434` | ACCEPT |
| `https://ollama.example.com` | ACCEPT |
| `file:///etc/passwd` | REJECT (exit 2) |
| `ftp://evil/x` | REJECT (exit 2) |
| `gopher://x/` | REJECT (exit 2) |
| `localhost:11434` (no scheme) | REJECT (exit 2) |
| `http://` (no host) | REJECT (exit 2) |
| `not-a-url` | REJECT (exit 2) |

Stdlib-only (`urllib.parse.urlparse`); `npm test` unaffected.
