### PR TITLE
test: clean hooks temp dir on failure

### DIFF
--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -21,6 +21,14 @@ function run(script, env, input = '') {
 delete process.env.CLAUDE_CONFIG_DIR;
 
 const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-hooks-'));
+let cleanedTemp = false;
+function cleanupTemp() {
+  if (cleanedTemp) return;
+  cleanedTemp = true;
+  fs.rmSync(temp, { recursive: true, force: true });
+}
+process.once('exit', cleanupTemp);
+
 const home = path.join(temp, 'home');
 const pluginData = path.join(temp, 'plugin-data');
 fs.mkdirSync(home, { recursive: true });
@@ -155,5 +163,5 @@ assert.equal(
 output = JSON.parse(result.stdout);
 assert.deepEqual(output, {});
 
-fs.rmSync(temp, { recursive: true, force: true });
+cleanupTemp();
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
## Summary
- Register the hooks test temp directory cleanup with a process exit handler.
- Keep the explicit success-path cleanup, but make it idempotent.

## Root Cause
`tests/hooks.test.js` created a temp directory at module scope and only removed it at the end of the file. If an assertion failed before the final cleanup line, the temp directory could be left behind.

## Verification
- `node --test tests/hooks.test.js`
- `npm test`
- `git diff --check`

Closes #204