### PR TITLE
doc: add missing codex plugin installation command

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -111,6 +111,7 @@ La app de escritorio no tiene el comando `/plugin`. Instálala desde la interfaz
 
 ```bash
 codex plugin marketplace add DietrichGebert/ponytail
+codex plugin add ponytail@ponytail
 codex
 ```
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,7 @@ The desktop app has no `/plugin` command. Install it from the UI instead: Custom
 
 ```bash
 codex plugin marketplace add DietrichGebert/ponytail
+codex plugin add ponytail@ponytail
 codex
 ```
 


### PR DESCRIPTION
After adding the marketplace, you need to issue another command to actually install the plugin.