### PR TITLE
test: simplify hooks temp-dir cleanup to a one-line exit handler

### DIFF
--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -21,13 +21,8 @@ function run(script, env, input = '') {
 delete process.env.CLAUDE_CONFIG_DIR;
 
 const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-hooks-'));
-let cleanedTemp = false;
-function cleanupTemp() {
-  if (cleanedTemp) return;
-  cleanedTemp = true;
-  fs.rmSync(temp, { recursive: true, force: true });
-}
-process.once('exit', cleanupTemp);
+// Runs on normal exit and on assertion-throw exit; force makes it idempotent.
+process.on('exit', () => fs.rmSync(temp, { recursive: true, force: true }));
 
 const home = path.join(temp, 'home');
 const pluginData = path.join(temp, 'plugin-data');
@@ -163,5 +158,4 @@ assert.equal(
 output = JSON.parse(result.stdout);
 assert.deepEqual(output, {});
 
-cleanupTemp();
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
## Summary
Follow-up to #213. That fix guarded the temp-dir cleanup with a `cleanedTemp` flag, a named `cleanupTemp()` function, and `process.once`, plus an explicit end-of-file call.

`fs.rmSync(temp, { force: true })` already no-ops on a missing path (that is what `force` does), so the idempotency machinery guards against a harmless double-call. This collapses it to a single `process.on('exit')` handler and drops the trailing call.

Net: 2 insertions, 8 deletions, same behavior.

## Verification
- `node --test tests/*.test.js`: 56 pass, 0 fail, exit 0.
- Exit-handler cleanup on assertion failure confirmed separately (the handler fires on an assert-throw exit, and `force` makes it idempotent).

Refs #204