### PR TITLE
fix: handle stdin error in ponytail-mode-tracker to avoid uncaught crash

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -6,6 +6,7 @@ const { getDefaultMode, isDeactivationCommand } = require('./ponytail-config');
 const { clearMode, setMode, writeHookOutput } = require('./ponytail-runtime');
 
 let input = '';
+process.stdin.on('error', () => process.exit(0)); // broken pipe / parent crash: exit clean, never block session
 process.stdin.on('data', chunk => { input += chunk; });
 process.stdin.on('end', () => {
   try {


### PR DESCRIPTION
## Problem

Fixes #147

`hooks/ponytail-mode-tracker.js` registers `stdin.on('data')` and `stdin.on('end')` with no `stdin.on('error')` handler.

When stdin closes abnormally (broken pipe, parent process crash), Node emits an unhandled error event on the stream. Without a listener this becomes an uncaught exception, crashing the hook process with a non-zero exit code and blocking the session.

## Fix

One line added before the data/end listeners:

```js
process.stdin.on('error', () => process.exit(0)); // broken pipe / parent crash: exit clean, never block session
```

`process.exit(0)` keeps the hook contract: always exit cleanly, never block session start.

## Verification

- All 56 existing tests pass
- Manually verified: spawning the hook with `stdio: ['ignore', ...]` (simulates broken/missing stdin) now exits 0 with no stderr, instead of crashing