### PR TITLE
feat: OpenCode per-session mode (/ponytail-session, /ponytail-status)

### DIFF
--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -14,8 +14,8 @@ code is the code never written.
 ## Persistence
 
 ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
-unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
-Switch: `/ponytail lite|full|ultra`.
+unsure. Off: `/ponytail off`, "stop ponytail", or "normal mode". Default: **full**.
+Switch: `/ponytail off|lite|full|ultra`.
 
 ## The ladder
 
@@ -86,7 +86,7 @@ test, YAGNI applies to tests too.
 ## Boundaries
 
 Ponytail governs what you build, not how you talk (pair with Caveman for
-terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+terse prose). `/ponytail off`, "stop ponytail", or "normal mode": revert. Level persists until
 changed or session end.
 
 The shortest path to done is the right path.

--- a/.opencode/command/ponytail-session.md
+++ b/.opencode/command/ponytail-session.md
@@ -1,0 +1,5 @@
+---
+description: Switch ponytail intensity for current session only (lite/full/ultra/off)
+---
+
+Switch to ponytail $ARGUMENTS mode for the current OpenCode session only. If no level specified, use full. Do not persist this mode or write `.ponytail-active`. Lazy senior dev mode, before any code: does it need to exist at all (YAGNI)? Does the standard library do it? A native platform feature? Can it be one line? Build the minimum that works. No unrequested abstractions, no avoidable dependencies, no boilerplate. Mark intentional simplifications with a ponytail: comment.

--- a/.opencode/command/ponytail-status.md
+++ b/.opencode/command/ponytail-status.md
@@ -1,0 +1,5 @@
+---
+description: Show the current session's effective ponytail status
+---
+
+Show the current ponytail status for this OpenCode session. Report the global mode, the session override if present, the effective mode, and the source. Do not change any mode, do not write any flag files, and do not persist anything.

--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -11,11 +11,16 @@ import { createRequire } from 'module';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // The shared instruction builder is CommonJS; bridge to it from this ES module.
 const require = createRequire(import.meta.url);
 const { getPonytailInstructions } = require('../../hooks/ponytail-instructions');
 const { getDefaultMode, normalizePersistedMode } = require('../../hooks/ponytail-config');
+
+const ponytailSkillsDir = path.resolve(__dirname, '../../skills');
 
 // OpenCode has no flag-file convention of its own; keep mode beside its config.
 const statePath = path.join(
@@ -23,6 +28,7 @@ const statePath = path.join(
   'opencode',
   '.ponytail-active',
 );
+const sessionModes = new Map();
 
 function readMode() {
   try {
@@ -37,15 +43,48 @@ function writeMode(mode) {
   fs.writeFileSync(statePath, mode);
 }
 
+function getStatus(sessionID) {
+  const globalMode = readMode();
+  const sessionMode = sessionID ? sessionModes.get(sessionID) : undefined;
+
+  return {
+    globalMode,
+    sessionMode,
+    effectiveMode: sessionMode ?? globalMode,
+    source: sessionMode ? 'session override' : 'global',
+  };
+}
+
+function formatStatus(sessionID) {
+  const status = getStatus(sessionID);
+
+  return [
+    `global: ${status.globalMode}`,
+    `session: ${status.sessionMode ?? 'none'}`,
+    `effective: ${status.effectiveMode}`,
+    `source: ${status.source}`,
+  ].join('\n');
+}
+
 export default async ({ client } = {}) => {
   const log = (level, message) => {
     try { client && client.app && client.app.log({ body: { service: 'ponytail', level, message } }); } catch (e) {}
   };
 
   return {
+    // Register skills directory so opencode discovers ponytail skills.
+    config: async (config) => {
+      config.skills = config.skills || {};
+      config.skills.paths = config.skills.paths || [];
+      if (!config.skills.paths.includes(ponytailSkillsDir)) {
+        config.skills.paths.push(ponytailSkillsDir);
+      }
+    },
+
     // Append the ruleset to the system prompt every turn.
-    'experimental.chat.system.transform': async (_input, output) => {
-      const mode = readMode();
+    'experimental.chat.system.transform': async (input, output) => {
+      const sessionMode = input.sessionID ? sessionModes.get(input.sessionID) : undefined;
+      const mode = sessionMode ?? readMode();
       if (mode === 'off') return;
       output.system.push(getPonytailInstructions(mode));
     },
@@ -54,8 +93,29 @@ export default async ({ client } = {}) => {
     // ponytail: mode applies from the next message, not the current one — the
     // transform reads the flag the command writes. Good enough; switch to a
     // synchronous store if same-turn switching ever matters.
-    'command.execute.before': async (input) => {
-      if (!input || input.command !== 'ponytail') return;
+    'command.execute.before': async (input, output) => {
+      if (!input) return;
+      if (input.command === 'ponytail-status') {
+        output.parts.push({ type: 'text', text: formatStatus(input.sessionID) });
+        log('info', 'ponytail status');
+        return;
+      }
+      if (input.command === 'ponytail-session') {
+        if (!input.sessionID) {
+          log('warn', 'ponytail-session missing sessionID');
+          return;
+        }
+        const rawMode = (input.arguments || '').trim();
+        const mode = rawMode ? normalizePersistedMode(rawMode) : getDefaultMode();
+        if (!mode) {
+          log('warn', 'ponytail-session invalid mode ' + rawMode);
+          return;
+        }
+        sessionModes.set(input.sessionID, mode);
+        log('info', 'ponytail session ' + mode);
+        return;
+      }
+      if (input.command !== 'ponytail') return;
       // `off` is persisted like any mode; the transform reads it and stays silent.
       const mode = normalizePersistedMode((input.arguments || '').trim()) || getDefaultMode();
       writeMode(mode);

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -22,8 +22,8 @@ code is the code never written.
 ## Persistence
 
 ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
-unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
-Switch: `/ponytail lite|full|ultra`.
+unsure. Off: `/ponytail off`, "stop ponytail", or "normal mode". Default: **full**.
+Switch: `/ponytail off|lite|full|ultra`.
 
 ## The ladder
 
@@ -94,7 +94,7 @@ test, YAGNI applies to tests too.
 ## Boundaries
 
 Ponytail governs what you build, not how you talk (pair with Caveman for
-terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+terse prose). `/ponytail off`, "stop ponytail", or "normal mode": revert. Level persists until
 changed or session end.
 
 The shortest path to done is the right path.

--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -24,9 +24,14 @@ test.before(async () => {
   loadPlugin = (await import(url)).default;
 });
 
-function transform(hooks) {
+function transform(hooks, input = { model: {} }) {
   const output = { system: [] };
-  return hooks['experimental.chat.system.transform']({ model: {} }, output).then(() => output.system);
+  return hooks['experimental.chat.system.transform'](input, output).then(() => output.system);
+}
+
+function executeCommand(hooks, input) {
+  const output = { parts: [] };
+  return hooks['command.execute.before'](input, output).then(() => output);
 }
 
 test('system.transform injects the ruleset at the default mode (full)', async () => {
@@ -40,7 +45,7 @@ test('system.transform injects the ruleset at the default mode (full)', async ()
 
 test('command.execute.before persists /ponytail ultra, transform follows it', async () => {
   const hooks = await loadPlugin({});
-  await hooks['command.execute.before']({ command: 'ponytail', arguments: 'ultra', sessionID: 's' });
+  await executeCommand(hooks, { command: 'ponytail', arguments: 'ultra', sessionID: 's' });
   assert.equal(fs.readFileSync(statePath, 'utf8'), 'ultra');
   const system = await transform(hooks);
   assert.match(system[0], /PONYTAIL MODE ACTIVE — level: ultra/);
@@ -48,17 +53,113 @@ test('command.execute.before persists /ponytail ultra, transform follows it', as
 
 test('/ponytail off persists off and transform injects nothing', async () => {
   const hooks = await loadPlugin({});
-  await hooks['command.execute.before']({ command: 'ponytail', arguments: 'off', sessionID: 's' });
+  await executeCommand(hooks, { command: 'ponytail', arguments: 'off', sessionID: 's' });
   assert.equal(fs.readFileSync(statePath, 'utf8'), 'off');
   const system = await transform(hooks);
   assert.deepEqual(system, []);
 });
 
+test('/ponytail-session full stays in memory and only affects its session', async () => {
+  try { fs.unlinkSync(statePath); } catch (e) {}
+  const hooks = await loadPlugin({});
+  await executeCommand(hooks, { command: 'ponytail-session', arguments: 'full', sessionID: 's' });
+  assert.equal(fs.existsSync(statePath), false);
+
+  const sessionSystem = await transform(hooks, { sessionID: 's', model: {} });
+  assert.equal(sessionSystem.length, 1);
+  assert.match(sessionSystem[0], /PONYTAIL MODE ACTIVE — level: full/);
+
+  await executeCommand(hooks, { command: 'ponytail', arguments: 'off', sessionID: 'other' });
+  const otherSystem = await transform(hooks, { sessionID: 'other', model: {} });
+  assert.deepEqual(otherSystem, []);
+
+  const noSessionSystem = await transform(hooks, { model: {} });
+  assert.deepEqual(noSessionSystem, []);
+});
+
+test('/ponytail-session off overrides a global full mode for that session only', async () => {
+  const hooks = await loadPlugin({});
+  await executeCommand(hooks, { command: 'ponytail', arguments: 'full', sessionID: 'global' });
+  await executeCommand(hooks, { command: 'ponytail-session', arguments: 'off', sessionID: 's' });
+
+  const sessionSystem = await transform(hooks, { sessionID: 's', model: {} });
+  assert.deepEqual(sessionSystem, []);
+
+  const otherSystem = await transform(hooks, { sessionID: 'other', model: {} });
+  assert.equal(otherSystem.length, 1);
+  assert.match(otherSystem[0], /PONYTAIL MODE ACTIVE — level: full/);
+});
+
 test('unrelated commands do not touch the flag', async () => {
   try { fs.unlinkSync(statePath); } catch (e) {}
   const hooks = await loadPlugin({});
-  await hooks['command.execute.before']({ command: 'commit', arguments: 'x', sessionID: 's' });
+  await executeCommand(hooks, { command: 'commit', arguments: 'x', sessionID: 's' });
   assert.equal(fs.existsSync(statePath), false);
+});
+
+test('/ponytail-status reports session override in output.parts and does not write the flag', async () => {
+  try { fs.unlinkSync(statePath); } catch (e) {}
+  const hooks = await loadPlugin({});
+  await executeCommand(hooks, { command: 'ponytail', arguments: 'off', sessionID: 'global' });
+  await executeCommand(hooks, { command: 'ponytail-session', arguments: 'full', sessionID: 's' });
+
+  const output = await executeCommand(hooks, { command: 'ponytail-status', arguments: '', sessionID: 's' });
+
+  assert.equal(fs.readFileSync(statePath, 'utf8'), 'off');
+  assert.deepEqual(output.parts, [{
+    type: 'text',
+    text: 'global: off\nsession: full\neffective: full\nsource: session override',
+  }]);
+});
+
+test('/ponytail-status reports global mode with no session override and does not create the flag', async () => {
+  try { fs.unlinkSync(statePath); } catch (e) {}
+  const hooks = await loadPlugin({});
+  await executeCommand(hooks, { command: 'ponytail', arguments: 'off', sessionID: 'global' });
+
+  const output = await executeCommand(hooks, { command: 'ponytail-status', arguments: '', sessionID: 'fresh-session' });
+
+  assert.equal(fs.readFileSync(statePath, 'utf8'), 'off');
+  assert.deepEqual(output.parts, [{
+    type: 'text',
+    text: 'global: off\nsession: none\neffective: off\nsource: global',
+  }]);
+});
+
+const expectedSkillsDir = path.resolve(__dirname, '..', 'skills');
+
+test('config hook registers ponytail skills dir when cfg is empty', async () => {
+  const hooks = await loadPlugin({});
+  const cfg = {};
+  await hooks.config(cfg);
+  assert.ok(Array.isArray(cfg.skills.paths));
+  assert.ok(cfg.skills.paths.includes(expectedSkillsDir));
+});
+
+test('config hook registers ponytail skills dir when cfg.skills has no paths', async () => {
+  const hooks = await loadPlugin({});
+  const cfg = { skills: {} };
+  await hooks.config(cfg);
+  assert.ok(Array.isArray(cfg.skills.paths));
+  assert.ok(cfg.skills.paths.includes(expectedSkillsDir));
+});
+
+test('config hook appends to existing paths without overwriting', async () => {
+  const hooks = await loadPlugin({});
+  const existing = ['/some/other/skills'];
+  const cfg = { skills: { paths: [...existing] } };
+  await hooks.config(cfg);
+  assert.deepEqual(cfg.skills.paths[0], existing[0]);
+  assert.ok(cfg.skills.paths.includes(expectedSkillsDir));
+});
+
+test('config hook does not duplicate ponytail skills dir', async () => {
+  const hooks = await loadPlugin({});
+  const cfg = { skills: { paths: [] } };
+  await hooks.config(cfg);
+  await hooks.config(cfg);
+  const ponytailPaths = cfg.skills.paths.filter(p => p === expectedSkillsDir);
+  assert.equal(ponytailPaths.length, 1);
 });
 
 test.after(() => fs.rmSync(tmp, { recursive: true, force: true }));


### PR DESCRIPTION
## What

Adds per-session mode switching to the OpenCode plugin — a session override
that lives in memory and never touches `.ponytail-active`.

## New commands

- `/ponytail-session <level>` — switch mode for the current session only (lite/full/ultra/off). No file writes.
- `/ponytail-status` — show global mode, session override, effective mode, and source.

## Changes

- `ponytail.mjs`: `sessionModes` Map, `getStatus()`/`formatStatus()` helpers, session-aware `system.transform` and `command.execute.before`
- `.opencode/command/ponytail-session.md` + `ponytail-status.md`: command definitions
- `skills/ponytail/SKILL.md` + `.openclaw` mirror: clarify `/ponytail off` syntax
- `tests/opencode-plugin.test.js`: session isolation tests