### PR TITLE
fix(benchmarks): strip block comments before counting LOC

### DIFF
--- a/benchmarks/loc.js
+++ b/benchmarks/loc.js
@@ -4,7 +4,9 @@
 module.exports = (output) => {
   const text = String(output || '');
   const blocks = [...text.matchAll(/```[a-zA-Z0-9_+-]*\n([\s\S]*?)```/g)].map((m) => m[1]);
-  const code = blocks.length ? blocks.join('\n') : text;
+  // Drop /* ... */ block comments before counting; the line filter below only
+  // caught `*`-aligned JSDoc, so plain block comments were miscounted as code.
+  const code = (blocks.length ? blocks.join('\n') : text).replace(/\/\*[\s\S]*?\*\//g, '');
   const loc = code
     .split('\n')
     .map((l) => l.trim())

--- a/benchmarks/loc.test.js
+++ b/benchmarks/loc.test.js
@@ -1,0 +1,22 @@
+// Regression guard for loc.js comment handling. Run: node loc.test.js
+const assert = require('assert');
+const loc = require('./loc.js');
+
+const score = (src) => loc(src).score;
+
+let pass = 0;
+const cases = [
+  // /* ... */ block comments must not count as code, whether or not the
+  // continuation lines are *-aligned (the old filter only caught JSDoc style).
+  ['plain block comment not counted', score('```js\nfunction f() {\n  /* explain\n     the rest */\n  return 1;\n}\n```'), 3],
+  ['jsdoc block comment not counted', score('```js\nfunction g() {\n  /*\n   * explain\n   */\n  return 2;\n}\n```'), 3],
+  ['inline block comment keeps its code line', score('```js\nconst x = 1; /* note */\nconst y = 2;\n```'), 2],
+  ['line comments still stripped', score('```js\n// header\nconst x = 1;\n```'), 1],
+  ['plain code unchanged', score('```js\nconst a = 1;\nconst b = 2;\n```'), 2],
+];
+for (const [name, got, want] of cases) {
+  assert.strictEqual(got, want, `FAILED: ${name} (got ${got}, want ${want})`);
+  console.log(`ok - ${name}`);
+  pass++;
+}
+console.log(`\n${pass}/${cases.length} passed`);


### PR DESCRIPTION
Fixes #231.

`loc.js` filtered comments line by line, so `/* ... */` block comments whose continuation lines are not `*`-aligned had their inner lines counted as code. A plain indented block comment scored higher than the same code written JSDoc-style:

```
function f() {        function f() {
  /* explain             /*
     the rest */          * explain
  return 1;               */
}                       return 1;
                      }
scores 5                scores 3   <- same code, different count
```

This strips `/* ... */` before the line count so both forms agree, and adds `benchmarks/loc.test.js` to lock it.

Why it matters: the over-count lands on whichever arm writes more block comments, which is the verbose baseline more often than ponytail, so it nudged the headline "less code" number in ponytail's favor. Small, but worth keeping honest.

Verified:
- indented and JSDoc block comments now both count 3
- inline `/* */`, `//`, and `#` line comments still handled
- plain code is unchanged

`node benchmarks/loc.test.js` passes (5/5); the main test suite is unaffected.