### PR TITLE
test: run ponytail-mcp suite under root npm test (wire MCP tests into CI)

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,10 +5,11 @@
   "keywords": ["pi-package", "pi", "skills", "ponytail"],
   "license": "MIT",
   "scripts": {
-    "test": "node --test tests/*.test.js && npm test --prefix pi-extension"
+    "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix ponytail-mcp"
   },
   "pi": {
     "extensions": ["./pi-extension/index.js"],
     "skills": ["./skills"]
   }
 }
+


### PR DESCRIPTION
## What

Add `npm test --prefix ponytail-mcp` to the root `test` script so the MCP server's tests run under a single `npm test` (and therefore in CI).

```diff
-    "test": "node --test tests/*.test.js && npm test --prefix pi-extension"
+    "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix ponytail-mcp"
```

## Why

`ponytail-mcp/test/instructions.test.js` (3 tests covering `resolveMode`, `buildInstructions`, and the `MODES` contract) is not referenced by the root `package.json`, the CI workflow, or any build script. The MCP server's mode-resolution logic is currently the only source surface with no CI coverage — a regression there ships silently.

## Why it's safe (no CI changes needed)

The MCP test imports only Node built-ins and `../instructions.js`, which in turn `require`s pure CJS modules from `hooks/`. It does **not** import `@modelcontextprotocol/sdk` or `zod` — those load only when the server process itself runs (`index.js`). So the suite runs with **zero `node_modules` installed**, matching the dependency-free model of the existing root and `pi-extension` suites. No `npm install --prefix ponytail-mcp` step is required in CI.

Verified locally: `node --test ponytail-mcp/test/*.test.js` → 3 passing, with `ponytail-mcp/node_modules` absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
