### PR TITLE
feat: add system-wide install scripts (install.sh + install.js) for all 14 AI agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,50 @@ The most effort ponytail will ever ask of you:
 
 The Claude Code and Codex plugins run two tiny Node.js lifecycle hooks, so `node` needs to be on your PATH (note for Nix/nvm users: it must be on the non-interactive shell's PATH). If it isn't, the skills still work, the always-on activation just stays quiet instead of erroring on every prompt.
 
+### System-wide (auto-detect)
+
+Installs ponytail for every AI agent on your machine in one go. Auto-detects which agents are installed and creates symlinks for each one.
+
+```bash
+# Quick install (curl-pipe)
+curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | sh
+
+# Or from a local checkout:
+./install.sh --all
+```
+
+Per-agent install:
+
+```bash
+./install.sh --agent claude          # Claude Code only
+./install.sh --agent codex           # Codex only
+./install.sh --agent opencode        # OpenCode only
+./install.sh --agent cursor          # Cursor only
+./install.sh --agent copilot         # GitHub Copilot CLI only
+```
+
+Check status and uninstall:
+
+```bash
+./install.sh --list                  # Show what's installed and detected
+./install.sh --uninstall             # Remove all symlinks and hooks
+```
+
+Node.js version also available:
+
+```bash
+node install.js --list               # Status with colour output
+node install.js --dry-run --yes      # Preview without making changes
+node install.js --agent claude       # Install for specific agent
+node install.js --uninstall          # Remove everything
+```
+
+The install script copies ponytail's rules, hooks, and skills to `~/.config/ponytail/`, then creates symlinks to each agent's config directory. It also installs lifecycle hooks for Claude Code (session activation and mode tracking).
+
+**Detection sources:** binary in PATH, config directory, npm global packages, VS Code extensions, GitHub CLI extensions, Cargo packages, and common app paths. Run `install.sh --list` to see what was detected on your machine.
+
+---
+
 ### Claude Code
 
 ```
@@ -227,6 +271,13 @@ When changing the compact rule text, keep the agent copies aligned:
 ```bash
 node scripts/check-rule-copies.js
 npm test
+```
+
+The install scripts (`install.sh` and `install.js`) maintain the list of supported agents and their detection logic. After adding a new agent adapter, update both files:
+
+```bash
+node install.js --list     # Check detection works
+bash install.sh --list     # Bash version too
 ```
 
 The OpenClaw skill package (`.openclaw/skills/`) is generated from `skills/`; rerun `node scripts/build-openclaw-skills.js` after changing a skill, the test suite fails if it is stale.

--- a/install.js
+++ b/install.js
@@ -1,0 +1,681 @@
+#!/usr/bin/env node
+/**
+ * ponytail — System-wide installer for all agentic workflows (Node.js)
+ *
+ * Usage:
+ *   node install.js [options]
+ *
+ * Options:
+ *   --all                 Install for all detected agents (default)
+ *   --agent <name>        Install for a specific agent (repeatable)
+ *   --repo <path>         Path to ponytail repo (default: parent of this script)
+ *   --uninstall           Remove all ponytail symlinks and configs
+ *   --list                Show installation status for each agent
+ *   --dry-run             Show what would be done without doing it
+ *   --yes, -y             Non-interactive (skip prompts)
+ *   --help                Show this help
+ *
+ * Supported agents:
+ *   claude, codex, copilot, opencode, cursor, windsurf, cline,
+ *   kiro, openclaw, gemini, pi, antigravity, codewhale, kilo
+ */
+const { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync, readdirSync, statSync, copyFileSync, rmSync } = require("fs");
+const { homedir, platform, EOL } = require("os");
+const { join, dirname, basename, resolve, relative } = require("path");
+const { execSync } = require("child_process");
+
+const REPO_ROOT = resolve(__dirname);
+const CONFIG_DIR = join(homedir(), '.config', 'ponytail');
+
+const isWin = platform() === 'win32';
+
+// ANSI colors
+const C = {
+  reset: '\x1b[0m',
+  green: '\x1b[32m',
+  yellow: '\x1b[33m',
+  red: '\x1b[31m',
+  cyan: '\x1b[36m',
+  bold: '\x1b[1m',
+  dim: '\x1b[2m',
+  gray: '\x1b[90m',
+};
+
+function log(msg)   { console.log(`  ${C.green}✓${C.reset} ${msg}`); }
+function info(msg)  { console.log(`  ${C.cyan}→${C.reset} ${msg}`); }
+function warn(msg)  { console.error(`  ${C.yellow}⚠${C.reset} ${msg}`); }
+function err(msg)   { console.error(`  ${C.red}✗${C.reset} ${msg}`); }
+function hdr(msg)   { console.log(`\n${C.bold}${msg}${C.reset}\n  ${'─'.repeat(msg.length)}`); }
+
+// =========================================================================
+//  AGENT DEFINITIONS
+// =========================================================================
+const AGENTS = [
+  {
+    name: 'claude',
+    label: 'Claude Code',
+    detectDir: join(homedir(), '.claude'),
+    srcDir: '.claude-plugin',
+    linkPath: join(homedir(), '.claude', 'plugins', 'ponytail'),
+    detectLabel: 'binary/config/npm',
+  },
+  {
+    name: 'codex',
+    label: 'Codex',
+    detectDir: join(homedir(), '.codex'),
+    srcDir: '.codex-plugin',
+    linkPath: join(homedir(), '.codex', 'plugins', 'ponytail'),
+    detectLabel: 'binary/config',
+  },
+  {
+    name: 'copilot',
+    label: 'GitHub Copilot CLI',
+    detectDir: join(homedir(), '.copilot'),
+    srcDir: '.github/copilot-instructions.md',
+    linkPath: join(homedir(), '.copilot', 'copilot-instructions.md'),
+    detectLabel: 'binary/gh-ext/vscode-ext',
+  },
+  {
+    name: 'opencode',
+    label: 'OpenCode',
+    detectDir: join(homedir(), '.config', 'opencode'),
+    srcDir: '.opencode/plugins/ponytail.mjs',
+    linkPath: join(homedir(), '.config', 'opencode', 'plugins', 'ponytail.mjs'),
+    detectLabel: 'binary/config/npm',
+  },
+  {
+    name: 'cursor',
+    label: 'Cursor',
+    detectDir: join(homedir(), '.cursor'),
+    srcDir: '.cursor/rules/ponytail.mdc',
+    linkPath: join(homedir(), '.cursor', 'rules', 'ponytail.mdc'),
+    detectLabel: 'binary/config/app',
+  },
+  {
+    name: 'windsurf',
+    label: 'Windsurf',
+    detectDir: join(homedir(), '.windsurf'),
+    srcDir: '.windsurf/rules/ponytail.md',
+    linkPath: join(homedir(), '.windsurf', 'rules', 'ponytail.md'),
+    detectLabel: 'binary/config/app',
+  },
+  {
+    name: 'cline',
+    label: 'Cline / Roo Code',
+    detectDir: join(homedir(), '.clinerules'),
+    srcDir: '.clinerules/ponytail.md',
+    linkPath: join(homedir(), '.clinerules', 'ponytail.md'),
+    detectLabel: 'vscode-ext/config',
+  },
+  {
+    name: 'kiro',
+    label: 'Kiro',
+    detectDir: join(homedir(), '.kiro'),
+    srcDir: '.kiro/steering/ponytail.md',
+    linkPath: join(homedir(), '.kiro', 'steering', 'ponytail.md'),
+    detectLabel: 'binary/config/npm',
+  },
+  {
+    name: 'openclaw',
+    label: 'OpenClaw',
+    detectDir: join(homedir(), '.openclaw'),
+    srcDir: '.openclaw/skills',
+    linkPath: join(homedir(), '.openclaw', 'skills', 'ponytail'),
+    detectLabel: 'binary/config',
+  },
+  {
+    name: 'gemini',
+    label: 'Gemini CLI / Antigravity',
+    detectDir: join(homedir(), '.local', 'share', 'gemini'),
+    srcDir: 'gemini-extension.json',
+    linkPath: '',
+    detectLabel: 'binary/config',
+  },
+  {
+    name: 'pi',
+    label: 'Pi agent',
+    detectDir: join(homedir(), '.pi'),
+    srcDir: 'pi-extension',
+    linkPath: join(homedir(), '.pi', 'extensions', 'ponytail'),
+    detectLabel: 'binary/config/cargo',
+  },
+  {
+    name: 'antigravity',
+    label: 'Antigravity CLI',
+    detectDir: join(homedir(), '.agents'),
+    srcDir: '.agents/rules/ponytail.md',
+    linkPath: join(homedir(), '.agents', 'rules', 'ponytail.md'),
+    detectLabel: 'binary',
+  },
+  {
+    name: 'kilo',
+    label: 'Kilo Code',
+    detectDir: join(homedir(), '.kilocode'),
+    srcDir: '.kiro/steering/ponytail.md',
+    linkPath: join(homedir(), '.kilocode', 'rules', 'ponytail.md'),
+    detectLabel: 'vscode-ext/config',
+  },
+  {
+    name: 'codewhale',
+    label: 'CodeWhale',
+    detectDir: '/usr/local/bin/codewhale',
+    srcDir: 'AGENTS.md',
+    linkPath: '',
+    detectLabel: 'binary/npm',
+  },
+];
+
+// =============================================================================
+//  UTILITY FUNCTIONS
+// =============================================================================
+
+function detectAgent(agent) {
+  // Shared helpers
+  const binInPath = (name) => {
+    try { execSync(`command -v ${name}`, { stdio: 'ignore' }); return true; }
+    catch { return false; }
+  };
+  const npmGlobal = (pkg) => {
+    try {
+      if (!binInPath('npm')) return false;
+      execSync(`npm ls -g ${pkg}`, { stdio: 'ignore' });
+      return true;
+    } catch { return false; }
+  };
+  const vscodeExt = (pattern) => {
+    try {
+      if (!binInPath('code')) return false;
+      const out = execSync('code --list-extensions', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+      return new RegExp(pattern, 'i').test(out);
+    } catch { return false; }
+  };
+  const ghExt = (pattern) => {
+    try {
+      if (!binInPath('gh')) return false;
+      const out = execSync('gh extension list', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+      return new RegExp(pattern, 'i').test(out);
+    } catch { return false; }
+  };
+  const cargoPkg = (name) => {
+    try {
+      if (!binInPath('cargo')) return false;
+      const out = execSync('cargo install --list', { encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] });
+      return out.includes(name);
+    } catch { return false; }
+  };
+  const vscodeExtDir = (pattern) => {
+    for (const base of [join(homedir(), '.vscode', 'extensions'),
+                        join(homedir(), '.vscode-server', 'extensions'),
+                        join(homedir(), '.vscode-remote', 'extensions')]) {
+      try {
+        if (!existsSync(base)) continue;
+        const entries = readdirSync(base);
+        if (entries.some(e => pattern.test(e))) return true;
+      } catch {}
+    }
+    return false;
+  };
+
+  switch (agent.name) {
+    case 'claude':
+      return binInPath('claude') ||
+        existsSync(agent.detectDir) ||
+        npmGlobal('@anthropic-ai/claude-code') ||
+        existsSync('/usr/local/bin/claude') ||
+        existsSync('/opt/homebrew/bin/claude');
+
+    case 'codex':
+      return binInPath('codex') ||
+        existsSync(agent.detectDir) ||
+        existsSync(join(homedir(), '.config', 'codex'));
+
+    case 'copilot':
+      return binInPath('copilot') ||
+        existsSync(agent.detectDir) ||
+        ghExt('copilot') ||
+        vscodeExt('github.copilot');
+
+    case 'opencode':
+      return binInPath('opencode') ||
+        existsSync(join(homedir(), '.config', 'opencode', 'opencode.json')) ||
+        npmGlobal('opencode');
+
+    case 'cursor':
+      return binInPath('cursor') ||
+        existsSync(agent.detectDir) ||
+        existsSync('/usr/bin/cursor') ||
+        existsSync('/opt/cursor/cursor') ||
+        existsSync('/Applications/Cursor.app');
+
+    case 'windsurf':
+      return binInPath('windsurf') ||
+        existsSync(agent.detectDir) ||
+        existsSync('/Applications/Windsurf.app');
+
+    case 'cline':
+      return existsSync(agent.detectDir) ||
+        vscodeExt('saoudrizwan.claude-dev|cline') ||
+        vscodeExtDir(/claude-dev|cline/i);
+
+    case 'kiro':
+      return binInPath('kiro') ||
+        existsSync(agent.detectDir) ||
+        npmGlobal('kiro');
+
+    case 'openclaw':
+      return binInPath('clawhub');
+
+    case 'gemini':
+      return binInPath('gemini') ||
+        binInPath('agy') ||
+        npmGlobal('@google/gemini-cli');
+
+    case 'pi':
+      return binInPath('pi') ||
+        existsSync(agent.detectDir) ||
+        cargoPkg('pi-agent');
+
+    case 'antigravity':
+      return binInPath('agy') ||
+        existsSync('/usr/local/bin/agy') ||
+        existsSync('/opt/homebrew/bin/agy');
+
+    case 'kilo':
+      return vscodeExt('kilo') ||
+        vscodeExtDir(/kilo/i) ||
+        existsSync(join(agent.detectDir, 'rules.json')) ||
+        existsSync(join(agent.detectDir, 'config.json')) ||
+        existsSync(join(agent.detectDir, 'plugins'));
+
+    case 'codewhale':
+      return binInPath('codewhale') ||
+        existsSync('/usr/local/bin/codewhale') ||
+        existsSync('/opt/homebrew/bin/codewhale') ||
+        npmGlobal('codewhale');
+
+    default:
+      return existsSync(agent.detectDir);
+  }
+}
+
+function ensureRepo(repoPath) {
+  // Check if path is valid
+  const agentsMd = join(repoPath, 'AGENTS.md');
+  const pkgJson = join(repoPath, 'package.json');
+  if (existsSync(agentsMd) && existsSync(pkgJson)) {
+    info(`Using ponytail repo: ${repoPath}`);
+    return repoPath;
+  }
+  // Check CONFIG_DIR
+  if (existsSync(join(CONFIG_DIR, 'AGENTS.md'))) {
+    info(`Using existing install: ${CONFIG_DIR}`);
+    return CONFIG_DIR;
+  }
+  // Need to download
+  warn('Ponytail not found locally. Downloading...');
+  mkdirSync(CONFIG_DIR, { recursive: true });
+  try {
+    execSync('git clone --depth 1 https://github.com/DietrichGebert/ponytail.git /tmp/ponytail-install', { stdio: 'pipe' });
+    copyDirContents('/tmp/ponytail-install', CONFIG_DIR);
+    rmSync('/tmp/ponytail-install', { recursive: true, force: true });
+    log('Downloaded ponytail');
+    return CONFIG_DIR;
+  } catch {
+    try {
+      execSync('curl -fsSL https://github.com/DietrichGebert/ponytail/archive/refs/heads/main.tar.gz | tar -xz -C /tmp/ponytail-tar --strip-components=1', { stdio: 'pipe' });
+      copyDirContents('/tmp/ponytail-tar', CONFIG_DIR);
+      rmSync('/tmp/ponytail-tar', { recursive: true, force: true });
+      log('Downloaded ponytail');
+      return CONFIG_DIR;
+    } catch {
+      err('Failed to download ponytail. Specify --repo <path> or check network.');
+      process.exit(1);
+    }
+  }
+}
+
+function copyDirContents(src, dest) {
+  mkdirSync(dest, { recursive: true });
+  for (const entry of readdirSync(src)) {
+    const s = join(src, entry);
+    const d = join(dest, entry);
+    if (statSync(s).isDirectory()) {
+      copyDirContents(s, d);
+    } else {
+      copyFileSync(s, d);
+    }
+  }
+}
+
+function syncFiles(repoRoot) {
+  hdr('Syncing ponytail files');
+  mkdirSync(CONFIG_DIR, { recursive: true });
+
+  const items = [
+    'AGENTS.md', 'gemini-extension.json', 'package.json',
+    'hooks', 'skills', 'commands', 'docs', 'assets',
+    '.cursor', '.windsurf', '.clinerules', '.kiro',
+    '.openclaw', '.opencode', '.github', '.agents',
+    '.claude-plugin', '.codex-plugin', 'pi-extension',
+  ];
+
+  for (const item of items) {
+    const src = join(repoRoot, item);
+    const dest = join(CONFIG_DIR, item);
+    if (!existsSync(src)) continue;
+    if (statSync(src).isDirectory()) {
+      copyDirContents(src, dest);
+    } else {
+      mkdirSync(dirname(dest), { recursive: true });
+      copyFileSync(src, dest);
+    }
+  }
+  log('Files synced');
+}
+
+function symlinkAgent(agent, dryRun) {
+  const srcPath = join(CONFIG_DIR, agent.srcDir);
+  const linkPath = agent.linkPath;
+
+  if (!linkPath) {
+    // Special handling
+    if (agent.name === 'gemini') {
+      info(`Gemini: run "gemini extensions install https://github.com/DietrichGebert/ponytail"`);
+      return true;
+    }
+    if (agent.name === 'codewhale') {
+      info(`CodeWhale: copy AGENTS.md into your project root.`);
+      return true;
+    }
+    return true;
+  }
+
+  if (!existsSync(srcPath)) {
+    warn(`Source not found: ${srcPath}`);
+    return false;
+  }
+
+  if (dryRun) {
+    info(`[dry-run] Would symlink: ${srcPath} → ${linkPath}`);
+    return true;
+  }
+
+  try {
+    mkdirSync(dirname(linkPath), { recursive: true });
+    if (existsSync(linkPath)) {
+      rmSync(linkPath, { recursive: true, force: true });
+    }
+    // Use junction on Windows for dirs, symlink on Unix
+    if (isWin && statSync(srcPath).isDirectory()) {
+      execSync(`mklink /J "${linkPath}" "${srcPath}"`, { stdio: 'ignore' });
+    } else {
+      const rel = relative(dirname(linkPath), srcPath);
+      // Create relative symlink for portability
+      const target = rel.startsWith('.') ? rel : relative(dirname(linkPath), srcPath);
+      mkdirSync(dirname(linkPath), { recursive: true });
+      // On unix use symlink, on windows try symlink dir
+      execSync(`ln -sf "${target}" "${linkPath}"`);
+    }
+    log(`Linked: ${agent.label}`);
+    return true;
+  } catch (e) {
+    err(`Failed to symlink ${agent.label}: ${e.message}`);
+    return false;
+  }
+}
+
+function removeSymlink(agent) {
+  if (!agent.linkPath) return true;
+  if (!existsSync(agent.linkPath) && !isSymlink(agent.linkPath)) return true;
+  try {
+    rmSync(agent.linkPath, { recursive: true, force: true });
+    log(`Removed: ${agent.label}`);
+    return true;
+  } catch (e) {
+    warn(`Could not remove ${agent.linkPath}: ${e.message}`);
+    return false;
+  }
+}
+
+function isSymlink(p) {
+  try { return statSync(p).isSymbolicLink(); } catch { return false; }
+}
+
+function installHooks(dryRun) {
+  hdr('Installing lifecycle hooks');
+
+  // Claude Code
+  const claudeSettings = join(homedir(), '.claude', 'settings.json');
+  if (existsSync(claudeSettings)) {
+    info('Claude Code: adding hooks to settings.json');
+    if (!dryRun) {
+      try {
+        const raw = readFileSync(claudeSettings, 'utf8');
+        const s = JSON.parse(raw);
+        s.hooks = s.hooks || {};
+        s.hooks.SessionStart = s.hooks.SessionStart || [];
+        s.hooks.UserPromptSubmit = s.hooks.UserPromptSubmit || [];
+
+        const hasHooks = s.hooks.SessionStart.some(h =>
+          JSON.stringify(h).includes('ponytail')
+        );
+
+        if (!hasHooks) {
+          s.hooks.SessionStart.push({
+            matcher: 'startup|resume|clear|compact',
+            hooks: [{
+              type: 'command',
+              command: 'command -v node >/dev/null 2>&1 && node "${CLAUDE_CONFIG_DIR}/../plugins/ponytail/hooks/ponytail-activate.js" || exit 0',
+              timeout: 5,
+              statusMessage: 'Loading ponytail mode...',
+            }],
+          });
+          s.hooks.UserPromptSubmit.push({
+            hooks: [{
+              type: 'command',
+              command: 'command -v node >/dev/null 2>&1 && node "${CLAUDE_CONFIG_DIR}/../plugins/ponytail/hooks/ponytail-mode-tracker.js" || exit 0',
+              timeout: 5,
+              statusMessage: 'Tracking ponytail mode...',
+            }],
+          });
+          writeFileSync(claudeSettings, JSON.stringify(s, null, 2));
+          log('Claude Code hooks installed');
+        } else {
+          info('Claude Code hooks already present');
+        }
+      } catch (e) {
+        warn(`Failed to update Claude Code hooks: ${e.message}`);
+      }
+    }
+  }
+
+  // Codex
+  const codexPlugins = join(homedir(), '.codex', 'plugins', 'ponytail');
+  if (existsSync(join(homedir(), '.codex'))) {
+    if (!dryRun) {
+      try {
+        const src = join(CONFIG_DIR, '.codex-plugin');
+        if (existsSync(src)) {
+          mkdirSync(dirname(codexPlugins), { recursive: true });
+          if (!existsSync(codexPlugins)) {
+            const rel = relative(dirname(codexPlugins), src);
+            execSync(`ln -sf "${rel}" "${codexPlugins}"`);
+            log('Codex plugin linked');
+          }
+        }
+      } catch (e) {
+        warn(`Failed to link Codex plugin: ${e.message}`);
+      }
+    }
+  }
+}
+
+function removeHooks() {
+  hdr('Removing lifecycle hooks');
+  const claudeSettings = join(homedir(), '.claude', 'settings.json');
+  if (existsSync(claudeSettings)) {
+    try {
+      const raw = readFileSync(claudeSettings, 'utf8');
+      const s = JSON.parse(raw);
+      let changed = false;
+      for (const key of ['SessionStart', 'UserPromptSubmit']) {
+        const hooks = s.hooks?.[key] || [];
+        const filtered = hooks.filter(h => !JSON.stringify(h).includes('ponytail'));
+        if (filtered.length !== hooks.length) {
+          s.hooks[key] = filtered;
+          changed = true;
+        }
+      }
+      if (changed) {
+        writeFileSync(claudeSettings, JSON.stringify(s, null, 2));
+        log('Claude Code hooks removed');
+      }
+    } catch (e) {
+      warn(`Failed to update Claude hooks: ${e.message}`);
+    }
+  }
+}
+
+// =============================================================================
+//  MAIN CLI
+// =============================================================================
+function showHelp() {
+  const help = `
+${C.bold}ponytail — System-wide installer${C.reset}
+
+${C.bold}Usage:${C.reset}
+  node install.js [options]
+
+${C.bold}Options:${C.reset}
+  --all                 Install for all detected agents (default)
+  --agent <name>        Install for a specific agent (repeatable)
+  --repo <path>         Path to ponytail repo (default: parent of this script)
+  --uninstall           Remove all ponytail symlinks and configs
+  --list                Show installation status for each agent
+  --dry-run             Show what would be done without doing it
+  --yes, -y             Non-interactive (skip prompts)
+  --help                Show this help
+
+${C.bold}Supported agents:${C.reset}
+${AGENTS.map(a => `  ${a.name.padEnd(15)} ${a.label}`).join('\n')}
+`;
+  console.log(help);
+  process.exit(0);
+}
+
+function listStatus(repoRoot) {
+  hdr('Ponytail installation status');
+  console.log(`  Config dir: ${CONFIG_DIR}`);
+  console.log(`  Repo:        ${repoRoot}\n`);
+
+  for (const agent of AGENTS) {
+    const detected = detectAgent(agent) ? `${C.green}yes${C.reset}` : `${C.dim}no${C.reset}`;
+    let installed;
+    if (!agent.linkPath) {
+      installed = `${C.gray}N/A${C.reset}`;
+    } else if (isSymlink(agent.linkPath)) {
+      installed = `${C.green}symlink${C.reset}`;
+    } else if (existsSync(agent.linkPath)) {
+      installed = `${C.yellow}file${C.reset}`;
+    } else {
+      installed = `${C.dim}no${C.reset}`;
+    }
+    console.log(`  ${agent.label.padEnd(22)} detected: ${detected} (${agent.detectLabel})  installed: ${installed}`);
+  }
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  let doAll = false;
+  let doUninstall = false;
+  let doList = false;
+  let dryRun = false;
+  let interactive = true;
+  let repoPath = REPO_ROOT;
+  const targetAgents = [];
+
+  for (let i = 0; i < args.length; i++) {
+    switch (args[i]) {
+      case '--all': case '-a': doAll = true; break;
+      case '--agent': targetAgents.push(args[++i]); break;
+      case '--repo': repoPath = args[++i]; break;
+      case '--uninstall': doUninstall = true; break;
+      case '--list': case '--status': doList = true; break;
+      case '--dry-run': dryRun = true; break;
+      case '--yes': case '-y': interactive = false; break;
+      case '--help': case '-h': showHelp(); break;
+      default: err(`Unknown option: ${args[i]}`); showHelp();
+    }
+  }
+
+  // Resolve repo
+  repoPath = resolve(repoPath);
+
+  // --list
+  if (doList) {
+    listStatus(repoPath);
+    process.exit(0);
+  }
+
+  // --uninstall
+  if (doUninstall) {
+    hdr('Uninstalling ponytail');
+    for (const agent of AGENTS) {
+      removeSymlink(agent);
+    }
+    removeHooks();
+    log(`Config dir: ${CONFIG_DIR}`);
+    warn(`Run "rm -rf ${CONFIG_DIR}" to remove all ponytail files.`);
+    log('Uninstall complete');
+    process.exit(0);
+  }
+
+  // Ensure source files
+  repoPath = ensureRepo(repoPath);
+
+  // Sync files
+  if (!dryRun) {
+    syncFiles(repoPath);
+  } else {
+    info('[dry-run] Would sync files to ' + CONFIG_DIR);
+  }
+
+  // Determine agents
+  let agentsToInstall;
+  if (targetAgents.length > 0) {
+    agentsToInstall = AGENTS.filter(a => targetAgents.includes(a.name));
+    const unknown = targetAgents.filter(t => !AGENTS.find(a => a.name === t));
+    if (unknown.length > 0) {
+      warn(`Unknown agents: ${unknown.join(', ')}`);
+    }
+  } else {
+    agentsToInstall = AGENTS;
+  }
+
+  // Install for each agent
+  hdr('Installing agent integrations');
+  for (const agent of agentsToInstall) {
+    const detected = detectAgent(agent);
+    if (!detected && interactive) {
+      warn(`${agent.label}: not detected. Use --yes to skip detection.`);
+      continue;
+    }
+    symlinkAgent(agent, dryRun);
+  }
+
+  // Install hooks
+  installHooks(dryRun);
+
+  // Summary
+  console.log('\n─── Done ───');
+  console.log(`  Config: ${CONFIG_DIR}`);
+  console.log(`  Restart your agents to apply ponytail.\n`);
+  console.log(`  ${C.bold}Commands:${C.reset}`);
+  console.log('  /ponytail [lite|full|ultra|off]  — Set mode');
+  console.log('  /ponytail-review                  — Review diff for over-engineering');
+  console.log('  /ponytail-gain                    — Show token savings\n');
+  console.log(`  See status:  node install.js --list`);
+  console.log(`  Uninstall:   node install.js --uninstall`);
+}
+
+main();

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,573 @@
+#!/usr/bin/env bash
+# =============================================================================
+# ponytail — System-wide installer for all agentic workflows
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | sh
+#   ./install.sh --all
+#   ./install.sh --agent claude
+#   ./install.sh --uninstall
+#   ./install.sh --list
+#
+# Options:
+#   --all              Install for all agents (default when no --agent given)
+#   --agent <name>     Install for a specific agent (repeatable)
+#   --repo <path>      Path to local ponytail repo (default: script's parent dir)
+#   --uninstall        Remove ponytail config and symlinks
+#   --list             Show installation status per agent
+#   --yes, -y          Non-interactive
+#   --help             Show this help
+#
+# Supported agents:
+#   claude codex copilot opencode cursor windsurf cline
+#   kiro openclaw gemini pi antigravity codewhale kilo
+# =============================================================================
+
+set -euo pipefail
+
+SCRIPT_NAME=$(basename "$0")
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# --- Defaults ----------------------------------------------------------------
+REPO_ROOT="$SCRIPT_DIR"
+CONFIG_DIR="${HOME}/.config/ponytail"
+AGENTS=()
+DO_ALL=false
+DO_UNINSTALL=false
+DO_LIST=false
+INTERACTIVE=true
+
+# --- Colors ------------------------------------------------------------------
+if [[ -t 1 ]]; then
+  BOLD='\033[1m'
+  DIM='\033[2m'
+  GREEN='\033[0;32m'
+  YELLOW='\033[0;33m'
+  RED='\033[0;31m'
+  CYAN='\033[0;36m'
+  GRAY='\033[0;90m'
+  NC='\033[0m'
+else
+  BOLD=''; DIM=''; GREEN=''; YELLOW=''; RED=''; CYAN=''; GRAY=''; NC=''
+fi
+
+# --- Help --------------------------------------------------------------------
+show_help() {
+  sed -n '2,/^---/p' "$0" | sed 's/^# //; s/^#$//; s/^#//' | head -n -1
+  exit 0
+}
+
+# --- Logging -----------------------------------------------------------------
+log()  { echo -e "  ${GREEN}✓${NC} $1"; }
+info() { echo -e "  ${CYAN}→${NC} $1"; }
+warn() { echo -e "  ${YELLOW}⚠${NC} $1" >&2; }
+error(){ echo -e "  ${RED}✗${NC} $1" >&2; }
+header(){ echo -e "\n${BOLD}$1${NC}"; echo "  $(printf '─%.0s' $(seq 1 ${#1}))"; }
+
+# -----------------------------------------------------------------------
+#  AGENT DEFINITIONS
+#  Each entry: name:label:detect_check:src_subdir:link_target
+#    detect_check   - path or command that indicates this agent exists
+#    src_subdir     - relative path under REPO_ROOT to symlink
+#    link_target    - where to place the symlink (absolute)
+# -----------------------------------------------------------------------
+
+# -----------------------------------------------------------------------
+#  AGENT DEFINITIONS
+#  Each entry: name:label:detect_fn:src_rel:link_target:detect_label
+#    detect_fn    = shell function that returns 0 if agent is installed
+#    src_rel      = relative path under REPO_ROOT / CONFIG_DIR to symlink
+#    link_target  = where to create the symlink (empty = special handling)
+#    detect_label = human-readable detection source (shown in --list)
+# -----------------------------------------------------------------------
+
+# ---- Detection helpers -------------------------------------------------------
+# Each returns 0 (found) or 1 (not found). Used by detect_agent().
+
+detect_claude() {
+  command -v claude &>/dev/null && return 0
+  [[ -d "${HOME}/.claude" ]] && return 0
+  command -v npm &>/dev/null && npm ls -g @anthropic-ai/claude-code &>/dev/null 2>&1 && return 0
+  [[ -f "${HOME}/.local/bin/claude" || -f "/usr/local/bin/claude" || -f "/opt/homebrew/bin/claude" ]] && return 0
+  return 1
+}
+
+detect_codex() {
+  command -v codex &>/dev/null && return 0
+  [[ -d "${HOME}/.codex" || -d "${HOME}/.config/codex" ]] && return 0
+  command -v npm &>/dev/null && npm ls -g @openai/codex &>/dev/null 2>&1 && return 0
+  return 1
+}
+
+detect_copilot() {
+  command -v copilot &>/dev/null && return 0
+  [[ -d "${HOME}/.copilot" ]] && return 0
+  # GitHub CLI extension
+  command -v gh &>/dev/null && gh extension list 2>/dev/null | grep -qi copilot && return 0
+  # VS Code extension
+  command -v code &>/dev/null && code --list-extensions 2>/dev/null | grep -qi github.copilot && return 0
+  return 1
+}
+
+detect_opencode() {
+  command -v opencode &>/dev/null && return 0
+  [[ -f "${HOME}/.config/opencode/opencode.json" ]] && return 0
+  command -v npm &>/dev/null && npm ls -g opencode &>/dev/null 2>&1 && return 0
+  return 1
+}
+
+detect_cursor() {
+  command -v cursor &>/dev/null && return 0
+  [[ -d "${HOME}/.cursor" ]] && return 0
+  # Flatpak / AppImage
+  [[ -f "/usr/bin/cursor" || -f "/opt/cursor/cursor" ]] && return 0
+  # macOS .app
+  [[ -d "/Applications/Cursor.app" ]] && return 0
+  return 1
+}
+
+detect_windsurf() {
+  command -v windsurf &>/dev/null && return 0
+  [[ -d "${HOME}/.windsurf" ]] && return 0
+  [[ -d "/Applications/Windsurf.app" ]] && return 0
+  return 1
+}
+
+detect_cline() {
+  [[ -d "${HOME}/.clinerules" ]] && return 0
+  # VS Code extension
+  command -v code &>/dev/null && code --list-extensions 2>/dev/null | grep -qiE "saoudrizwan.claude-dev|cline" && return 0
+  # Check common VS Code extension dirs
+  for extdir in "${HOME}/.vscode/extensions" "${HOME}/.vscode-server/extensions" "${HOME}/.vscode-remote/extensions"; do
+    [[ -d "$extdir" ]] && ls "$extdir" 2>/dev/null | grep -qi "claude-dev\|cline" && return 0
+  done
+  return 1
+}
+
+detect_kiro() {
+  command -v kiro &>/dev/null && return 0
+  [[ -d "${HOME}/.kiro" ]] && return 0
+  command -v npm &>/dev/null && npm ls -g kiro &>/dev/null 2>&1 && return 0
+  return 1
+}
+
+detect_openclaw() {
+  command -v clawhub &>/dev/null && return 0
+  # Config dir alone may be a stray; look for a binary or active agent config
+  [[ -x "${HOME}/.openclaw/clawhub" ]] && return 0
+  return 1
+}
+
+detect_gemini() {
+  command -v gemini &>/dev/null && return 0
+  command -v agy &>/dev/null && return 0
+  command -v npm &>/dev/null && npm ls -g @google/gemini-cli &>/dev/null 2>&1 && return 0
+  return 1
+}
+
+detect_pi() {
+  command -v pi &>/dev/null && return 0
+  [[ -d "${HOME}/.pi" ]] && return 0
+  command -v cargo &>/dev/null && cargo install --list 2>/dev/null | grep -qi "pi-agent" && return 0
+  return 1
+}
+
+detect_antigravity() {
+  command -v agy &>/dev/null && return 0
+  [[ -f "/usr/local/bin/agy" || -f "/opt/homebrew/bin/agy" ]] && return 0
+  return 1
+}
+
+detect_kilo() {
+  command -v code &>/dev/null && code --list-extensions 2>/dev/null | grep -qi "kilo" && return 0
+  for extdir in "${HOME}/.vscode/extensions" "${HOME}/.vscode-server/extensions"; do
+    [[ -d "$extdir" ]] && ls "$extdir" 2>/dev/null | grep -qi "kilo" && return 0
+  done
+  # Only match if it has Kilo Code's own config, not a stray rtk-rules.md
+  [[ -f "${HOME}/.kilocode/rules.json" || -f "${HOME}/.kilocode/config.json" || -d "${HOME}/.kilocode/plugins" ]] && return 0
+  return 1
+}
+
+detect_codewhale() {
+  command -v codewhale &>/dev/null && return 0
+  [[ -f "/usr/local/bin/codewhale" || -f "/opt/homebrew/bin/codewhale" ]] && return 0
+  command -v npm &>/dev/null && npm ls -g codewhale &>/dev/null 2>&1 && return 0
+  return 1
+}
+
+# ---- Agent definitions using detect functions --------------------------------
+AGENT_DEFS=(
+  "claude:Claude Code:detect_claude:.claude-plugin:${HOME}/.claude/plugins/ponytail:binary/config"
+  "codex:Codex:detect_codex:.codex-plugin:${HOME}/.codex/plugins/ponytail:binary/config"
+  "copilot:GitHub Copilot:detect_copilot:.github/copilot-instructions.md:${HOME}/.copilot/copilot-instructions.md:binary/gh-ext/vscode-ext"
+  "opencode:OpenCode:detect_opencode:.opencode/plugins/ponytail.mjs:${HOME}/.config/opencode/plugins/ponytail.mjs:binary/config/npm"
+  "cursor:Cursor:detect_cursor:.cursor/rules/ponytail.mdc:${HOME}/.cursor/rules/ponytail.mdc:binary/config/app"
+  "windsurf:Windsurf:detect_windsurf:.windsurf/rules/ponytail.md:${HOME}/.windsurf/rules/ponytail.md:binary/config/app"
+  "cline:Cline:detect_cline:.clinerules/ponytail.md:${HOME}/.clinerules/ponytail.md:vscode-ext/config"
+  "kiro:Kiro:detect_kiro:.kiro/steering/ponytail.md:${HOME}/.kiro/steering/ponytail.md:binary/config/npm"
+  "openclaw:OpenClaw:detect_openclaw:.openclaw/skills:${HOME}/.openclaw/skills/ponytail:binary/config"
+  "gemini:Gemini CLI:detect_gemini:gemini-extension.json::binary/config"
+  "pi:Pi agent:detect_pi:pi-extension:${HOME}/.pi/extensions/ponytail:binary/config/cargo"
+  "antigravity:Antigravity:detect_antigravity:.agents/rules/ponytail.md:${HOME}/.agents/rules/ponytail.md:binary"
+  "kilo:Kilo Code:detect_kilo:.kiro/steering/ponytail.md:${HOME}/.kilocode/rules/ponytail.md:vscode-ext/config"
+  "codewhale:CodeWhale:detect_codewhale:AGENTS.md::binary/npm"
+)
+
+# ---- Source the ponytail files (copy or git clone) -------------------------
+ensure_source() {
+  local SOURCE_DIR="$1"
+  if [[ -d "$SOURCE_DIR/.git" ]] && [[ -f "$SOURCE_DIR/AGENTS.md" ]]; then
+    REPO_ROOT="$SOURCE_DIR"
+    info "Using local ponytail repo: $REPO_ROOT"
+    return 0
+  fi
+
+  # Not a valid repo — check if CONFIG_DIR has files
+  if [[ -f "$CONFIG_DIR/AGENTS.md" ]]; then
+    REPO_ROOT="$CONFIG_DIR"
+    info "Using existing ponytail install: $CONFIG_DIR"
+    return 0
+  fi
+
+  # Need to download
+  mkdir -p "$CONFIG_DIR"
+  if command -v git &>/dev/null; then
+    warn "ponytail not found — cloning to $CONFIG_DIR..."
+    git clone --depth 1 https://github.com/DietrichGebert/ponytail.git "$CONFIG_DIR" 2>/dev/null || {
+      error "Failed to clone ponytail. Check network or specify --repo"
+      exit 1
+    }
+    REPO_ROOT="$CONFIG_DIR"
+  elif command -v curl &>/dev/null; then
+    warn "ponytail not found — downloading tarball..."
+    curl -fsSL "https://github.com/DietrichGebert/ponytail/archive/refs/heads/main.tar.gz" | tar -xz -C "$CONFIG_DIR" --strip-components=1 2>/dev/null || {
+      error "Failed to download ponytail. Check network or specify --repo"
+      exit 1
+    }
+    REPO_ROOT="$CONFIG_DIR"
+  else
+    error "Need git or curl to download ponytail. Install one or specify --repo"
+    exit 1
+  fi
+}
+
+# ---- Update local file tree from REPO_ROOT ---------------------------------
+sync_files() {
+  mkdir -p "$CONFIG_DIR"
+  header "Syncing ponytail files to $CONFIG_DIR"
+
+  # Core files
+  for f in AGENTS.md gemini-extension.json package.json; do
+    if [[ -f "$REPO_ROOT/$f" ]]; then
+      cp "$REPO_ROOT/$f" "$CONFIG_DIR/$f" 2>/dev/null || true
+    fi
+  done
+
+  # Directories to mirror
+  for d in hooks skills commands docs assets; do
+    if [[ -d "$REPO_ROOT/$d" ]]; then
+      mkdir -p "$CONFIG_DIR/$d"
+      cp -r "$REPO_ROOT/$d"/* "$CONFIG_DIR/$d"/ 2>/dev/null || true
+    fi
+  done
+
+  # Hidden agent dirs
+  for d in .cursor .windsurf .clinerules .kiro .openclaw .opencode .github .agents; do
+    if [[ -d "$REPO_ROOT/$d" ]]; then
+      mkdir -p "$CONFIG_DIR/$d"
+      cp -r "$REPO_ROOT/$d"/* "$CONFIG_DIR/$d"/ 2>/dev/null || true
+    fi
+  done
+
+  log "Files synced"
+}
+
+# ---- Install for one agent --------------------------------------------------
+install_agent() {
+  local name="$1"
+  local def
+  local label detect_fn src_rel link_target detect_label
+
+  for entry in "${AGENT_DEFS[@]}"; do
+    if [[ "${entry%%:*}" == "$name" ]]; then
+      def="$entry"
+      break
+    fi
+  done
+
+  if [[ -z "$def" ]]; then
+    error "Unknown agent: $name. Supported: claude codex copilot opencode cursor windsurf cline kiro openclaw gemini pi antigravity codewhale kilo"
+    return 1
+  fi
+
+  # Parse: name:label:detect_fn:src_rel:link_target:detect_label
+  local rest="${def#*:}"
+  label="${rest%%:*}"
+  rest="${rest#*:}"
+  detect_fn="${rest%%:*}"
+  rest="${rest#*:}"
+  src_rel="${rest%%:*}"
+  rest="${rest#*:}"
+  link_target="${rest%%:*}"
+  detect_label="${rest#*:}"
+
+  echo
+  info "Installing for $label..."
+
+  # Check if agent is installed using the dedicated detect function
+  if ! "$detect_fn" &>/dev/null; then
+    if [[ "$INTERACTIVE" == "true" ]]; then
+      warn "$label not detected ($detect_label) — skipping"
+      return 0
+    else
+      info "$label not detected — creating config anyway"
+    fi
+  fi
+
+  local src_path="$CONFIG_DIR/$src_rel"
+  local link_path="$link_target"
+
+  # If no explicit link_target specified (e.g. gemini), use plugin install
+  if [[ -z "$link_path" ]]; then
+    case "$name" in
+      gemini)
+        if command -v gemini &>/dev/null; then
+          info "Installing Gemini extension..."
+          gemini extensions install "https://github.com/DietrichGebert/ponytail" 2>/dev/null || warn "Gemini extension install failed — try manually: gemini extensions install https://github.com/DietrichGebert/ponytail"
+        fi
+        return 0
+        ;;
+      codewhale)
+        info "CodeWhale reads AGENTS.md from project root. Copy AGENTS.md into your project."
+        return 0
+        ;;
+    esac
+    return 0
+  fi
+
+  # Ensure parent dir exists
+  mkdir -p "$(dirname "$link_path")"
+
+  # Remove existing (file, dir, or broken symlink)
+  if [[ -L "$link_path" ]] || [[ -e "$link_path" ]]; then
+    rm -rf "$link_path"
+  fi
+
+  # Create symlink
+  ln -sf "$src_path" "$link_path"
+  log "Linked $src_rel → $link_path"
+}
+
+# ---- Install hooks for Claude Code / Codex ---------------------------------
+install_hooks() {
+  header "Installing lifecycle hooks"
+
+  # Claude Code
+  local claude_settings="${HOME}/.claude/settings.json"
+  local codex_settings="${HOME}/.codex/settings.json"
+
+  if [[ -f "$claude_settings" ]]; then
+    info "Claude Code: adding hooks to settings.json..."
+    local tempfile
+    tempfile=$(mktemp)
+    # Use python for safe JSON manipulation
+    python3 -c "
+import json, sys
+with open('$claude_settings') as f:
+    s = json.load(f)
+s.setdefault('hooks', {})
+s['hooks']['SessionStart'] = s['hooks'].get('SessionStart', [])
+s['hooks']['UserPromptSubmit'] = s['hooks'].get('UserPromptSubmit', [])
+# Check if already installed
+already = any('ponytail' in str(h) for h in s['hooks']['SessionStart'])
+if not already:
+    s['hooks']['SessionStart'].append({
+        'matcher': 'startup|resume|clear|compact',
+        'hooks': [{
+            'type': 'command',
+            'command': 'command -v node >/dev/null 2>&1 && node \"${CLAUDE_CONFIG_DIR}/../plugins/ponytail/hooks/ponytail-activate.js\" || exit 0',
+            'timeout': 5,
+            'statusMessage': 'Loading ponytail mode...'
+        }]
+    })
+    s['hooks']['UserPromptSubmit'].append({
+        'hooks': [{
+            'type': 'command',
+            'command': 'command -v node >/dev/null 2>&1 && node \"${CLAUDE_CONFIG_DIR}/../plugins/ponytail/hooks/ponytail-mode-tracker.js\" || exit 0',
+            'timeout': 5,
+            'statusMessage': 'Tracking ponytail mode...'
+        }]
+    })
+    with open('$claude_settings', 'w') as f:
+        json.dump(s, f, indent=2)
+    print('hooks added')
+else:
+    print('hooks already present')
+" 2>/dev/null && log "Claude Code hooks installed" || warn "Failed to install Claude Code hooks"
+  fi
+
+  # Codex - similar approach
+  if [[ -d "${HOME}/.codex/plugins" ]] && [[ -d "$CONFIG_DIR/.codex-plugin" ]]; then
+    local codex_plugin_dir="${HOME}/.codex/plugins/ponytail"
+    mkdir -p "$(dirname "$codex_plugin_dir")"
+    if [[ ! -L "$codex_plugin_dir" ]]; then
+      ln -sf "$CONFIG_DIR/.codex-plugin" "$codex_plugin_dir"
+      log "Codex plugin symlinked"
+    fi
+  fi
+}
+
+# ---- Remove all symlinks ----------------------------------------------------
+uninstall_all() {
+  header "Uninstalling ponytail"
+
+  for entry in "${AGENT_DEFS[@]}"; do
+    local name="${entry%%:*}"
+    local rest="${entry#*:}"
+    local label="${rest%%:*}"
+    local link_target
+    link_target="$(echo "$rest" | cut -d: -f5)"
+
+    if [[ -z "$link_target" ]]; then
+      continue
+    fi
+
+    if [[ -L "$link_target" ]]; then
+      rm -f "$link_target"
+      log "Removed symlink: $link_target"
+    fi
+  done
+
+  # Remove Claude Code hooks
+  local claude_settings="${HOME}/.claude/settings.json"
+  if [[ -f "$claude_settings" ]]; then
+    python3 -c "
+import json
+with open('$claude_settings') as f:
+    s = json.load(f)
+changed = False
+for hook_key in ['SessionStart', 'UserPromptSubmit']:
+    hooks = s.get('hooks', {}).get(hook_key, [])
+    s['hooks'][hook_key] = [h for h in hooks if 'ponytail' not in str(h)]
+    if len(s['hooks'][hook_key]) != len(hooks):
+        changed = True
+if changed:
+    with open('$claude_settings', 'w') as f:
+        json.dump(s, f, indent=2)
+    print('hooks removed')
+else:
+    print('no ponytail hooks found')
+" 2>/dev/null && log "Claude Code hooks removed" || true
+  fi
+
+  # Ask about CONFIG_DIR
+  if [[ -d "$CONFIG_DIR" ]]; then
+    echo
+    info "Config dir: $CONFIG_DIR"
+    warn "Run 'rm -rf $CONFIG_DIR' to remove all ponytail files."
+  fi
+
+  log "Uninstall complete"
+}
+
+# ---- List installation status -----------------------------------------------
+list_status() {
+  header "Ponytail installation status"
+  echo "  Config dir: ${CONFIG_DIR}"
+  echo "  Repo:        ${REPO_ROOT}"
+  echo
+
+  for entry in "${AGENT_DEFS[@]}"; do
+    local name="${entry%%:*}"
+    local rest="${entry#*:}"
+    local label="${rest%%:*}"
+    rest="${rest#*:}"
+    local detect_fn="${rest%%:*}"
+    rest="${rest#*:}"
+    local src_rel="${rest%%:*}"
+    rest="${rest#*:}"
+    local link_target="${rest%%:*}"
+
+    local detected="" installed=""
+    "$detect_fn" &>/dev/null && detected="${GREEN}yes${NC}" || detected="${DIM}no${NC}"
+
+    if [[ -L "$link_target" ]]; then
+      installed="${GREEN}symlink${NC}"
+    elif [[ -z "$link_target" ]]; then
+      installed="${GRAY}N/A${NC}"
+    else
+      installed="${DIM}no${NC}"
+    fi
+
+    printf "  %-22s detected: %-6s  installed: %s\n" "$label" "$detected" "$installed"
+  done
+}
+
+# ---- Main -------------------------------------------------------------------
+main() {
+  # Parse args
+  while [[ $# -gt 0 ]]; do
+    case "$1" in
+      --all|-a) DO_ALL=true ;;
+      --agent) shift; AGENTS+=("$1") ;;
+      --repo) shift; REPO_ROOT="$1" ;;
+      --uninstall) DO_UNINSTALL=true ;;
+      --list|--status) DO_LIST=true ;;
+      --yes|-y) INTERACTIVE=false ;;
+      --help|-h) show_help ;;
+      *) error "Unknown option: $1"; show_help ;;
+    esac
+    shift
+  done
+
+  # --list only
+  if [[ "$DO_LIST" == "true" ]]; then
+    ensure_source "$REPO_ROOT"
+    list_status
+    exit 0
+  fi
+
+  # --uninstall
+  if [[ "$DO_UNINSTALL" == "true" ]]; then
+    uninstall_all
+    exit 0
+  fi
+
+  # Ensure we have the source files
+  ensure_source "$REPO_ROOT"
+
+  # Sync files
+  sync_files
+
+  # Determine which agents to install
+  if [[ ${#AGENTS[@]} -gt 0 ]]; then
+    :
+  elif [[ "$DO_ALL" == "true" ]] || [[ ${#AGENTS[@]} -eq 0 ]]; then
+    # Default: install for all agents
+    for entry in "${AGENT_DEFS[@]}"; do
+      AGENTS+=("${entry%%:*}")
+    done
+  fi
+
+  # Install for each agent
+  for agent in "${AGENTS[@]}"; do
+    install_agent "$agent"
+  done
+
+  # Install hooks
+  install_hooks
+
+  echo
+  header "Done"
+  echo "  Restart your agents to apply ponytail."
+  echo "  Config: $CONFIG_DIR"
+  echo
+  echo "  ${BOLD}Commands:${NC}"
+  echo "  /ponytail [lite|full|ultra|off]  — Set mode"
+  echo "  /ponytail-review                  — Review diff for over-engineering"
+  echo
+  echo "  To see status:  $SCRIPT_NAME --list"
+  echo "  To uninstall:   $SCRIPT_NAME --uninstall"
+}
+
+main "$@"


### PR DESCRIPTION
## Описание

Два новых скрипта для system-wide установки ponytail на все AI-агенты одной командой:

### install.sh (573 строк)
- Можно пускать через `curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | sh`
- Флаги: `--all`, `--agent <name>`, `--list`, `--uninstall`, `--repo <path>`, `--yes`
- Автоопределение установленных агентов (8 методов: binary, config dir, npm global, VS Code ext, gh ext, cargo, macOS .app, common paths)
- Создаёт симлинки в конфиги агентов → `~/.config/ponytail/`
- Устанавливает lifecycle hooks для Claude Code

### install.js (681 строк)
- Node.js версия с `--dry-run`, `--yes`, цветным выводом
- `node install.js --list` — просмотр статуса
- `node install.js --dry-run --yes` — preview без изменений
- Та же логика детектирования, платформонезависимая

### Что ещё
- Обновлён README.md: новый раздел "System-wide (auto-detect)" в Install + заметка в Development
- Детектирование 14 агентов: claude, codex, copilot, opencode, cursor, windsurf, cline, kiro, openclaw, gemini, pi, antigravity, kilocode, codewhale

Closes #??