### PR TITLE
[codex] harden benchmark subprocess execution

### DIFF
--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -6,7 +6,7 @@
 // Unlike loc.js (measurement-only), this one is a gate — a wrong answer is a
 // wrong answer regardless of how few lines produced it.
 
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
@@ -32,10 +32,12 @@ function identifyTask(task) {
   return null;
 }
 
-// Run a command, return { ok, stderr }.
-function exec(cmd, opts = {}) {
+const EXEC_TIMEOUT_MS = 20_000;
+
+// Run a command without a shell, return { ok, stderr }.
+function exec(cmd, args = [], opts = {}) {
   try {
-    execSync(cmd, { timeout: 10_000, encoding: 'utf8', stdio: 'pipe', ...opts });
+    execFileSync(cmd, args, { timeout: EXEC_TIMEOUT_MS, encoding: 'utf8', stdio: 'pipe', ...opts });
     return { ok: true, stderr: '' };
   } catch (e) {
     return { ok: false, stderr: (e.stderr || e.message || '').slice(0, 500) };
@@ -47,7 +49,7 @@ let pythonCmd;
 function python() {
   if (pythonCmd) return pythonCmd;
   for (const cmd of ['python3', 'python']) {
-    if (exec(`${cmd} -c "import sys"`).ok) {
+    if (exec(cmd, ['-c', 'import sys']).ok) {
       pythonCmd = cmd;
       return pythonCmd;
     }
@@ -118,7 +120,7 @@ if failures:
 print("PASS")
 `;
     const f = tmpFile('.py', harness);
-    const result = exec(`${python()} "${f}"`);
+    const result = exec(python(), [f]);
     fs.unlinkSync(f);
     if (result.ok) return { pass: true, reason: 'Email validator passes all checks' };
     return { pass: false, reason: result.stderr || 'Email validator failed' };
@@ -163,7 +165,7 @@ setTimeout(() => {
 }, 120);
 `;
     const f = tmpFile('.mjs', harness);
-    const result = exec(`node "${f}"`);
+    const result = exec('node', [f]);
     fs.unlinkSync(f);
     if (result.ok) return { pass: true, reason: 'Debounce passes all checks' };
     return { pass: false, reason: result.stderr || 'Debounce failed' };
@@ -212,7 +214,7 @@ else:
     sys.exit(1)
 `;
     const f = tmpFile('.py', harness);
-    const result = exec(`${python()} "${f}"`);
+    const result = exec(python(), [f]);
     try { fs.unlinkSync(f); } catch (e) {}
     try { fs.unlinkSync(csvPath); } catch (e) {}
     if (result.ok) return { pass: true, reason: 'CSV sum produces correct result (351)' };

--- a/benchmarks/robustness-audit.js
+++ b/benchmarks/robustness-audit.js
@@ -3,17 +3,23 @@
 // known-lazy-wrong reference so the instrument is verified before any API spend.
 //   node robustness-audit.js --selftest   # no API: prove every check is correct
 //   node robustness-audit.js              # baseline vs ponytail, gpt-5.4-mini, n=20
-const { execSync } = require('child_process');
+const { execFileSync } = require('child_process');
 const fs = require('fs');
 const os = require('os');
 const path = require('path');
+
+const EXEC_TIMEOUT_MS = 20_000;
+
+function exec(cmd, args = [], opts = {}) {
+  execFileSync(cmd, args, { timeout: EXEC_TIMEOUT_MS, ...opts });
+}
 
 // ponytail: probe once at load; mirrors correctness.js
 let pythonCmd;
 function python() {
   if (pythonCmd) return pythonCmd;
   for (const cmd of ['python3', 'python']) {
-    try { execSync(`${cmd} -c "import sys"`, { stdio: 'pipe' }); pythonCmd = cmd; return pythonCmd; }
+    try { exec(cmd, ['-c', 'import sys'], { stdio: 'pipe' }); pythonCmd = cmd; return pythonCmd; }
     catch (_) {}
   }
   return pythonCmd = 'python3';
@@ -124,22 +130,32 @@ function pyBlock(text) {
   return (py || m[0])[2];
 }
 
+function pyLiteral(value) {
+  if (Array.isArray(value)) return `[${value.map(pyLiteral).join(', ')}]`;
+  if (typeof value === 'string') return JSON.stringify(value);
+  if (typeof value === 'boolean') return value ? 'True' : 'False';
+  if (typeof value === 'number' && Number.isFinite(value)) return String(value);
+  if (value === null) return 'None';
+  throw new Error('unsupported Python literal value');
+}
+
 function checkPy(code, task) {
-  const harness = `import sys, json, inspect
+  const harness = `import sys
 ${code}
 TARGET = ${task.arity}
-names = json.loads(r'''${JSON.stringify(task.names)}''')
+names = ${pyLiteral(task.names)}
 fn = None
 for nm in names:
     if nm in dir() and callable(eval(nm)): fn = eval(nm); break
 if fn is None:
+    import inspect
     for nm, obj in list(globals().items()):
         if callable(obj) and not nm.startswith('_') and not inspect.isclass(obj):
             try:
                 if len(inspect.signature(obj).parameters) == TARGET: fn = obj; break
             except (ValueError, TypeError): pass
 if fn is None: print('NOFN'); sys.exit(1)
-cases = json.loads(r'''${JSON.stringify(task.cases)}''')
+cases = ${pyLiteral(task.cases)}
 for args, expected in cases:
     try: r = fn(*args)
     except Exception as e: print('EXC', args, e); sys.exit(1)
@@ -147,7 +163,7 @@ for args, expected in cases:
 print('PASS')`;
   const f = path.join(os.tmpdir(), `audit-${process.pid}-${Math.random().toString(36).slice(2)}.py`);
   fs.writeFileSync(f, harness);
-  try { execSync(`${python()} "${f}"`, { timeout: 10000, encoding: 'utf8', stdio: 'pipe' }); return true; }
+  try { exec(python(), [f], { encoding: 'utf8', stdio: 'pipe' }); return true; }
   catch (e) { return false; }
   finally { try { fs.unlinkSync(f); } catch (_) {} }
 }

--- a/hooks/copilot-hooks.json
+++ b/hooks/copilot-hooks.json
@@ -4,16 +4,16 @@
     "sessionStart": [
       {
         "type": "command",
-        "bash": "node \"${PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
-        "powershell": "node \"${PLUGIN_ROOT}\\hooks\\ponytail-activate.js\"",
+        "bash": "command -v node >/dev/null 2>&1 && node \"${PLUGIN_ROOT}/hooks/ponytail-activate.js\" || exit 0",
+        "powershell": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"${PLUGIN_ROOT}\\hooks\\ponytail-activate.js\" }",
         "timeoutSec": 5
       }
     ],
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": "node \"${PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
-        "powershell": "node \"${PLUGIN_ROOT}\\hooks\\ponytail-mode-tracker.js\"",
+        "bash": "command -v node >/dev/null 2>&1 && node \"${PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\" || exit 0",
+        "powershell": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"${PLUGIN_ROOT}\\hooks\\ponytail-mode-tracker.js\" }",
         "timeoutSec": 5
       }
     ]

--- a/tests/benchmark-exec.test.js
+++ b/tests/benchmark-exec.test.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+
+test('benchmark subprocesses avoid shell command strings', () => {
+  for (const rel of ['benchmarks/correctness.js', 'benchmarks/robustness-audit.js']) {
+    const src = fs.readFileSync(path.join(root, rel), 'utf8');
+    assert.doesNotMatch(src, /\bexecSync\s*\(/, `${rel} should use execFileSync with argv`);
+  }
+});

--- a/tests/copilot-plugin.test.js
+++ b/tests/copilot-plugin.test.js
@@ -31,3 +31,14 @@ test('copilot plugin command directory includes ponytail-debt', () => {
     );
   }
 });
+
+test('copilot hooks stay quiet when node is missing', () => {
+  const config = readJSON('hooks/copilot-hooks.json');
+  const hooks = Object.values(config.hooks).flat();
+
+  for (const hook of hooks) {
+    assert.match(hook.bash, /command -v node/);
+    assert.match(hook.bash, /\|\| exit 0/);
+    assert.match(hook.powershell, /Get-Command node/);
+  }
+});

--- a/tests/correctness.test.js
+++ b/tests/correctness.test.js
@@ -5,12 +5,19 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const { spawnSync } = require('node:child_process');
 const correctness = require('../benchmarks/correctness');
 
 // Helper: wrap code in a fenced block and call the assertion with task vars.
 function check(task, lang, code) {
   const output = '```' + lang + '\n' + code + '\n```';
   return correctness(output, { vars: { task } });
+}
+
+function hasPandas() {
+  const opts = { stdio: 'ignore', timeout: 2_000 };
+  return spawnSync('python3', ['-c', 'import pandas'], opts).status === 0 ||
+    spawnSync('python', ['-c', 'import pandas'], opts).status === 0;
 }
 
 // --- Email validator ---
@@ -74,7 +81,19 @@ test('debounce: immediate-call implementation fails', () => {
 
 // --- CSV sum ---
 
-test('csv: correct pandas one-liner passes', () => {
+test('csv: correct stdlib implementation passes', () => {
+  const result = check(
+    "Write Python code that reads sales.csv and sums the 'amount' column.",
+    'python',
+    `import csv
+with open('sales.csv', newline='') as f:
+    print(sum(float(row['amount']) for row in csv.DictReader(f)))`,
+  );
+  assert.equal(result.pass, true);
+  assert.equal(result.score, 1);
+});
+
+test('csv: correct pandas one-liner passes', { skip: !hasPandas() && 'pandas is not installed' }, () => {
   const result = check(
     "Write Python code that reads sales.csv and sums the 'amount' column.",
     'python',


### PR DESCRIPTION
## Summary

- run benchmark subprocess checks through `execFileSync` with argv instead of shell-built command strings
- make the CSV correctness test pass without requiring optional local pandas
- keep Copilot lifecycle hooks quiet when `node` is missing, matching the Claude/Codex hook behavior

## Why

The local correctness suite failed when pandas was not installed, even though pandas is documented as an optional local dependency for CSV checks. While investigating, the benchmark scripts also had avoidable shell command construction around generated temp files. This patch hardens those execution paths and adds regression coverage.

## Validation

- `rtk npm test`
- `rtk npm test --prefix ponytail-mcp`
- `rtk node scripts/check-rule-copies.js`
- `rtk node benchmarks/robustness-audit.js --selftest`
- `rtk git diff --check`
