### PR TITLE
fix: point statusline setup nudge at CLAUDE_CONFIG_DIR/settings.json

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -66,7 +66,7 @@ if (!isCodex && !isCopilot) try {
       output += "\n\n" +
         "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode " +
         "(e.g. [PONYTAIL], [PONYTAIL:ULTRA]). It is not configured yet. " +
-        "To enable, add this to ~/.claude/settings.json: " +
+        "To enable, add this to " + settingsPath + ": " +
         statusLineSnippet + " " +
         "Proactively offer to set this up for the user on first interaction.";
     } else {
@@ -76,7 +76,7 @@ if (!isCodex && !isCopilot) try {
         "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode. " +
         "Its install path contains characters unsafe to embed in a shell command, so configure it manually: " +
         "add a statusLine command of type \"command\" that runs " + scriptName +
-        " from the plugin's hooks directory to ~/.claude/settings.json, quoting/escaping the path for your shell. " +
+        " from the plugin's hooks directory to " + settingsPath + ", quoting/escaping the path for your shell. " +
         "Proactively offer to set this up for the user on first interaction.";
     }
   }

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -128,6 +128,19 @@ assert.equal(
   false,
   'flag must not land in ~/.claude when CLAUDE_CONFIG_DIR is set',
 );
+// The statusline setup nudge must point at CLAUDE_CONFIG_DIR/settings.json, not
+// ~/.claude/settings.json — otherwise it sends users to the wrong file. Native
+// Claude Code receives the nudge as raw stdout (no JSON wrapper).
+const nudgeContext = result.stdout;
+assert.match(nudgeContext, /STATUSLINE SETUP NEEDED/);
+assert.ok(
+  nudgeContext.includes(path.join(customConfigDir, 'settings.json')),
+  'statusline nudge must reference CLAUDE_CONFIG_DIR/settings.json',
+);
+assert.ok(
+  !nudgeContext.includes('~/.claude/settings.json'),
+  'statusline nudge must not hardcode ~/.claude/settings.json when CLAUDE_CONFIG_DIR is set',
+);
 
 const copilotData = path.join(temp, 'copilot-data');
 const codexData = path.join(temp, 'codex-data-shadow');


### PR DESCRIPTION
## What

The statusline setup nudge in `ponytail-activate.js` hardcoded `~/.claude/settings.json`. When `CLAUDE_CONFIG_DIR` is set, settings live elsewhere, so the nudge pointed at the wrong file.

## How

Use the already-resolved `settingsPath` (honors `CLAUDE_CONFIG_DIR` via `getClaudeDir()`) in both nudge branches. Test asserts the nudge references `CLAUDE_CONFIG_DIR/settings.json` and not `~/.claude/settings.json`.

`npm test` passes.

Closes #255