### PR TITLE
Split 2 plugin install commands in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ The Claude Code and Codex plugins run two tiny Node.js lifecycle hooks, so `node
 
 ```
 /plugin marketplace add DietrichGebert/ponytail
+```
+```
 /plugin install ponytail@ponytail
 ```
 


### PR DESCRIPTION
Allows users to use the copy button to the left on the 2 individual cmds If you copy them together, the command fails