### PR TITLE
fix: make shared hooks parse in PowerShell

### DIFF
--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\" || exit 0",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"; exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\" }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "command -v node >/dev/null 2>&1 && node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\" || exit 0",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"; exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\" }",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -18,6 +18,8 @@ const HOST_PLUGIN_MANIFESTS = [
 ];
 // cmd.exe variable syntax (%FOO%); PowerShell leaves it literal, breaking the path.
 const CMD_VAR_SYNTAX = /%[A-Za-z_][A-Za-z0-9_]*%/;
+// PowerShell 5.1 rejects these POSIX shell guards when a host runs `command`.
+const POSIX_GUARD_SYNTAX = /\bcommand\s+-v\b|&&|\|\||>\/dev\/null|2>&1/;
 // Pull the hooks/<script> a command launches, so we can check it exists.
 const HOOK_SCRIPT = /hooks[\\/]([\w.-]+\.(?:js|mjs|cjs|ps1|sh))/;
 
@@ -37,6 +39,26 @@ test('every commandWindows uses PowerShell $env: syntax, not cmd.exe %VAR%', () 
   assert.ok(windowsCommands.length > 0, 'expected at least one commandWindows entry');
   for (const cmd of windowsCommands) {
     assert.doesNotMatch(cmd, CMD_VAR_SYNTAX, `commandWindows uses cmd.exe %VAR% (breaks under PowerShell): ${cmd}`);
+  }
+});
+
+test('shared hook commands avoid POSIX-only guard syntax', () => {
+  const commands = commandHooks()
+    .map((h) => h.command)
+    .filter(Boolean);
+  assert.ok(commands.length > 0, 'expected at least one shared command entry');
+  for (const cmd of commands) {
+    assert.doesNotMatch(cmd, POSIX_GUARD_SYNTAX, `command uses POSIX-only guard syntax: ${cmd}`);
+  }
+});
+
+test('shared hook commands keep lifecycle hooks non-blocking', () => {
+  const commands = commandHooks()
+    .map((h) => h.command)
+    .filter(Boolean);
+  assert.ok(commands.length > 0, 'expected at least one shared command entry');
+  for (const cmd of commands) {
+    assert.match(cmd, /;\s*exit 0$/, `command must exit successfully if node or the hook script fails: ${cmd}`);
   }
 });
 


### PR DESCRIPTION
## Summary
Fixes #247. The Claude/Codex shared hook commands used POSIX-only guard syntax (`command -v`, `/dev/null`, `&&`, `||`). When a Windows host ignores `commandWindows` and runs `command` in Windows PowerShell 5.1, PowerShell rejects that syntax before the hook can run.

## Fix
- Replace the POSIX guard in both shared commands with `node "..."; exit 0`, which parses in POSIX shells and PowerShell 5.1.
- Keep `commandWindows` unchanged for hosts that honor the Windows-specific command.
- Add Windows hook regression checks that ban POSIX-only guard syntax and keep lifecycle commands non-blocking.

## Verification
- `node --test tests/hooks-windows.test.js tests/hooks.test.js`
- `PATH="$PWD/.venv/bin:$PATH" npm test`
- `git diff --check`

Closes #247