### PR TITLE
Add Claude Code .md slash commands so /ponytail* works in Claude Code

### DIFF
--- a/commands/ponytail-audit.md
+++ b/commands/ponytail-audit.md
@@ -1,0 +1,5 @@
+---
+description: Audit the whole repo for over-engineering, what can be deleted
+---
+
+Audit the entire repository for over-engineering only, not correctness. Scan the whole tree, not a diff. One line per finding, ranked biggest cut first: <tag> <what to cut>. <replacement>. [path]. Tags: delete (dead code/speculative feature), stdlib (reinvented standard library), native (dependency doing what the platform does), yagni (abstraction with one implementation), shrink (same logic, fewer lines). End with the net lines and dependencies removable. If nothing to cut: 'Lean already. Ship.'

--- a/commands/ponytail-debt.md
+++ b/commands/ponytail-debt.md
@@ -1,0 +1,5 @@
+---
+description: Harvest ponytail: comments into a tracked debt ledger
+---
+
+Harvest every `ponytail:` comment in this repository into a debt ledger so deferrals do not rot into 'later means never'. Grep the whole tree for comment markers (grep -rnE '(#|//) ?ponytail:' ., skipping node_modules/.git/build output). One row per marker, grouped by file: <file>:<line> — <what was simplified>. ceiling: <the limit named in the comment>. upgrade: <the trigger to revisit>. Tag any marker that names no upgrade path or trigger as no-trigger, those rot silently. End with the count of markers and how many lack a trigger. If none: 'No ponytail: debt. Clean ledger.' Report only, change nothing.

--- a/commands/ponytail-gain.md
+++ b/commands/ponytail-gain.md
@@ -1,0 +1,5 @@
+---
+description: Show ponytail's measured impact scoreboard (less code, cost, time)
+---
+
+Show the ponytail gain scoreboard. One shot, change nothing: do not switch mode, write flag files, or persist anything. Render the published benchmark medians (5 everyday tasks; models Haiku, Sonnet, Opus; source benchmarks/ and the README) as plain ASCII bars: Lines of code, no-skill 100% vs ponytail 6-20% (down 80-94%); Cost, no-skill 100% vs ponytail 23-53% (down 47-77%); Speed, ponytail 3-6x faster. The bar length shows the measured range, the label carries the exact figure. These are benchmark medians, not this repo. NEVER print a per-repo savings number: the unbuilt version was never written, so there is no real baseline to subtract from in a live repo. For real per-repo figures, point to /ponytail-debt (the counted shortcut ledger) and /ponytail-audit (what is still cuttable). Report only.

--- a/commands/ponytail-help.md
+++ b/commands/ponytail-help.md
@@ -1,0 +1,5 @@
+---
+description: Quick reference for ponytail levels, skills, and commands
+---
+
+Show the ponytail quick reference. One shot, change nothing: do not switch mode, write flag files, or persist anything. Levels: /ponytail lite (build what's asked, name the lazier alternative in one line), /ponytail (full, the default ladder: YAGNI then stdlib then native then one line then minimum), /ponytail ultra (deletion before addition, challenges the requirement before building). Commands: /ponytail-review (over-engineering review of the current changes), /ponytail-audit (whole-repo over-engineering audit), /ponytail-debt (harvest ponytail: comments into a tracked ledger), /ponytail-gain (measured-impact scoreboard from the benchmark), /ponytail-help (this card). Deactivate with 'stop ponytail', 'normal mode', or /ponytail off; resume anytime with /ponytail. Default mode is full; change it with the PONYTAIL_DEFAULT_MODE environment variable (off|lite|full|ultra) or a config file at ~/.config/ponytail/config.json (Windows: %APPDATA%\ponytail\config.json) with {"defaultMode": "lite"}. Resolution order: env var, then config file, then full.

--- a/commands/ponytail-review.md
+++ b/commands/ponytail-review.md
@@ -1,0 +1,5 @@
+---
+description: Review changes for over-engineering, what can be deleted
+---
+
+Review the current code changes for over-engineering only, not correctness. One line per finding: L<line>: <tag> <what to cut>. <replacement>. Tags: delete (dead code/speculative feature), stdlib (reinvented standard library), native (dependency doing what the platform does), yagni (abstraction with one implementation), shrink (same logic, fewer lines). End with the net lines removable. If nothing to cut: 'Lean already. Ship.'

--- a/commands/ponytail.md
+++ b/commands/ponytail.md
@@ -1,0 +1,6 @@
+---
+description: Switch ponytail intensity level (lite/full/ultra/off)
+argument-hint: "[lite|full|ultra|off]"
+---
+
+Switch to ponytail $ARGUMENTS mode. If no level specified, use full. Lazy senior dev mode, before any code: does it need to exist at all (YAGNI)? Does the standard library do it? A native platform feature? Can it be one line? Build the minimum that works. No unrequested abstractions, no avoidable dependencies, no boilerplate. Mark intentional simplifications with a `ponytail:` comment.


### PR DESCRIPTION
## Problem

Installed ponytail into the **Claude Code extension for VS Code** (v4.7.0) and the `/ponytail*` slash commands never showed up. The skills (`skills/*/SKILL.md`) and hooks load fine — it's specifically the slash commands that are missing.

Root cause: Claude Code only discovers slash commands from **`commands/*.md`** (Markdown + YAML frontmatter). The repo's `commands/*.toml` files are the Codex/opencode/Gemini format, which Claude Code doesn't parse — so `/ponytail`, `/ponytail-review`, `/ponytail-audit`, `/ponytail-debt`, `/ponytail-gain`, and `/ponytail-help` never register there. (This is a Claude Code behavior, not a VS Code one — it'll be the same in the CLI; VS Code is just where I hit it.)

## Change

Add six `commands/*.md` files mirroring the existing `.toml` set 1:1 — same `description` and prompt for each, with `{{args}}` → `$ARGUMENTS` for the level switch. Purely additive: the skills, hooks, and `.toml` commands are untouched, so nothing changes for Codex/opencode/Gemini users.

After this, the commands appear in Claude Code's `/` menu and run the same prompts they do elsewhere.

## Notes

- Kept it minimal and in the spirit of the project — thin wrappers, no new docs or deps.
- Verified locally: dropping these `.md` files in makes the commands resolve in Claude Code.
- Separately, I hit a broken install where the plugin cache dir was empty (no files copied), which also blocks the skills/hooks — but that looked like a local install glitch (Claude Code extension in VS Code) rather than a repo issue, so it's out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)