### PR TITLE
fix: align all version manifests to 4.8.1 + guard against drift (#260, #262)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ponytail",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "author": {
     "name": "Dietrich Gebert",
     "url": "https://github.com/DietrichGebert"

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ponytail",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "author": {
     "name": "Dietrich Gebert",
     "url": "https://github.com/DietrichGebert"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,7 @@ name: test
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
 
 jobs:
@@ -24,6 +25,9 @@ jobs:
 
       - name: Check rule copies
         run: node scripts/check-rule-copies.js
+
+      - name: Check version consistency
+        run: node scripts/check-versions.js
 
       - name: Run tests
         run: npm test

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "contextFileName": "AGENTS.md"
 }

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.7.0",
+  "version": "4.8.0",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "0.1.0",
+  "version": "4.8.0",
   "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
   "keywords": ["pi-package", "pi", "skills", "ponytail"],
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
   "keywords": ["pi-package", "pi", "skills", "ponytail"],
   "license": "MIT",

--- a/ponytail-mcp/package.json
+++ b/ponytail-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail-mcp",
-  "version": "0.1.0",
+  "version": "4.8.0",
   "description": "MCP server that serves Ponytail's lazy-senior-dev instructions as a prompt and a tool.",
   "private": true,
   "type": "module",

--- a/ponytail-mcp/package.json
+++ b/ponytail-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail-mcp",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "MCP server that serves Ponytail's lazy-senior-dev instructions as a prompt and a tool.",
   "private": true,
   "type": "module",

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -1,0 +1,76 @@
+#!/usr/bin/env node
+// Version-consistency guard. Ponytail declares its version in six files across
+// four host ecosystems, and every release bumps all of them by hand.
+//
+// tests/gemini-extension.test.js already checks the four plugin manifests agree
+// with each other, but that can't catch the failure mode that shipped in v4.8.0:
+// every manifest stayed stale at 4.7.0 *together* while the release moved on, so
+// they "agreed" and the test passed (#260, #262). It also ignores the two
+// package.json files. This check closes both gaps:
+//   1. every version-bearing file must share one pinned X.Y.Z version, and
+//   2. on a release-tag CI run, that shared version must equal the tag.
+
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const PINNED_SEMVER = /^\d+\.\d+\.\d+$/;
+
+// Every file that declares the project version, and who reads it. Add new host
+// manifests here so a future ecosystem can't drift unnoticed.
+const VERSION_FILES = [
+  '.claude-plugin/plugin.json', // Claude Code plugin — what users install
+  '.codex-plugin/plugin.json',  // Codex plugin
+  '.github/plugin/plugin.json', // Copilot plugin
+  'gemini-extension.json',      // Gemini CLI extension
+  'package.json',               // pi-package / repo root
+  'ponytail-mcp/package.json',  // MCP server (private, internal-only)
+];
+
+function readVersion(relPath) {
+  try {
+    // Strip a UTF-8 BOM some Windows editors prepend (breaks JSON.parse).
+    const raw = fs.readFileSync(path.join(root, relPath), 'utf8').replace(/^\uFEFF/, '');
+    return JSON.parse(raw).version;
+  } catch (e) {
+    throw new Error(`${relPath}: ${e.message}`);
+  }
+}
+
+let failed = false;
+const versions = VERSION_FILES.map((relPath) => {
+  const version = readVersion(relPath);
+  if (typeof version !== 'string' || !PINNED_SEMVER.test(version)) {
+    console.error(`${relPath}: version must be a pinned X.Y.Z semver, got ${JSON.stringify(version)}`);
+    failed = true;
+  }
+  return [relPath, version];
+});
+
+// Every file must declare the same version.
+const distinct = [...new Set(versions.map(([, v]) => v))];
+if (distinct.length > 1) {
+  console.error('Version mismatch — every manifest must share one version:');
+  for (const [relPath, version] of versions) console.error(`  ${version}\t${relPath}`);
+  failed = true;
+}
+const shared = distinct.length === 1 ? distinct[0] : null;
+
+// On a release-tag push CI sets GITHUB_REF_TYPE=tag and GITHUB_REF_NAME=vX.Y.Z.
+// The shared version must equal the tag — this catches tagging a release whose
+// version files were never bumped, which mutual agreement alone cannot.
+if (shared && process.env.GITHUB_REF_TYPE === 'tag') {
+  const tag = process.env.GITHUB_REF_NAME || '';
+  const tagVersion = tag.replace(/^v/, '');
+  if (PINNED_SEMVER.test(tagVersion) && tagVersion !== shared) {
+    console.error(`release tag ${tag} does not match version ${shared}; bump the version files before tagging`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error('Align the version fields (see issue #260) so every manifest shares one version.');
+  process.exit(1);
+}
+
+console.log(`All ${VERSION_FILES.length} version files pinned at ${shared}.`);


### PR DESCRIPTION
## Problem

`v4.8.0` was released but the version was never bumped in the tree:

- The four plugin manifests (`.claude-plugin`, `.codex-plugin`, `.github/plugin`, `gemini-extension.json`) still read `4.7.0`.
- `package.json` and `ponytail-mcp/package.json` were still at the `0.1.0` npm-init default.

So the project advertised **three different versions at once** (`0.1.0` / `4.7.0` / `4.8.0`), Claude/Codex/Gemini reported `4.7.0` as latest even after updating, and users couldn't tell whether an update had taken.

- Fixes #260 (inconsistent versioning)
- Fixes #262 (the "how to update" confusion this caused)

## Fix

1. Set all six version-bearing files to **`4.8.1`**, so they ship as one clean, consistent release.
2. Add `scripts/check-versions.js`, wired into CI, so this cannot drift again:
   - every version file must share one pinned `X.Y.Z` version, and
   - on a release-tag run (`tags: ['v*']`), that shared version must equal the tag.

### Why 4.8.1 and not 4.8.0

`v4.8.0` is already a published tag pointing at the commit with the stale `4.7.0` manifests. Rather than rewrite a published tag, this ships the consistent versions as a fresh **`v4.8.1`** patch, so anyone updating lands on a fully consistent release with no surprises.

### Why the existing check didn't catch this

`tests/gemini-extension.test.js` already asserts the four plugin manifests agree with **each other**, but they were all stale at `4.7.0` *together*, so they agreed and the test passed. It also ignored the two `package.json` files. The new guard ties the version to the release tag and covers all six files, closing both gaps.

## Release plan

After merge: tag `v4.8.1` on the merge commit and publish the release. The CI version guard runs on the tag and will fail the release if anything is still out of sync.

## Verification

- `node scripts/check-versions.js` passes (all 6 at `4.8.1`); a simulated mismatched tag run fails as intended.
- `node scripts/check-rule-copies.js` still passes.
- Full `npm test`: the only failures are the two Python/pandas correctness tests, which fail locally only because this machine has no Python. They pass in CI (Ubuntu + Python 3.12 + `pip install pandas`) and are untouched by this change.
