### PR TITLE
feat: add publish-openclaw-skills.js to push skills to ClawHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ node scripts/check-rule-copies.js
 npm test
 ```
 
-The OpenClaw skill package (`.openclaw/skills/`) is generated from `skills/`; rerun `node scripts/build-openclaw-skills.js` after changing a skill, the test suite fails if it is stale.
+The OpenClaw skill package (`.openclaw/skills/`) is generated from `skills/`; rerun `node scripts/build-openclaw-skills.js` after changing a skill, the test suite fails if it is stale. To publish the skills to ClawHub, run `clawhub login` once, then `node scripts/publish-openclaw-skills.js` (it publishes all six at the `package.json` version; pass `--dry-run` to preview).
 
 The correctness benchmark spawns Python for email and CSV checks; `python3` is tried before `python`. CSV checks need `pandas` installed locally.
 

--- a/scripts/publish-openclaw-skills.js
+++ b/scripts/publish-openclaw-skills.js
@@ -1,0 +1,75 @@
+#!/usr/bin/env node
+// Publish the generated OpenClaw skills (.openclaw/skills/) to ClawHub.
+//
+// ClawHub does not sync from GitHub: each skill is pushed explicitly with the
+// clawhub CLI and carries its own version. This publishes every generated skill
+// in one pass, versioned from the repo's package.json so ClawHub tracks the repo
+// instead of drifting (the same drift that hit the plugin manifests in #260).
+//
+// Prereqs:
+//   - `clawhub login` once (registry auth persists)
+//   - skills must be current: run `node scripts/build-openclaw-skills.js` first
+//     if you changed a skill (CI fails if the committed copies are stale)
+//
+// Usage:
+//   node scripts/publish-openclaw-skills.js            # publish all as latest
+//   node scripts/publish-openclaw-skills.js --dry-run  # preview, upload nothing
+//   (any extra args are passed through to `clawhub skill publish`)
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const root = path.join(__dirname, '..');
+const skillsDir = path.join(root, '.openclaw', 'skills');
+
+const version = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8')).version;
+
+// Every generated skill dir with a SKILL.md is publishable. Reading the dir
+// (instead of a hardcoded list) covers whatever build-openclaw-skills emits,
+// with nothing to keep in sync.
+const slugs = fs.readdirSync(skillsDir, { withFileTypes: true })
+  .filter((e) => e.isDirectory() && fs.existsSync(path.join(skillsDir, e.name, 'SKILL.md')))
+  .map((e) => e.name)
+  .sort();
+
+if (slugs.length === 0) {
+  console.error(`No skills under ${path.relative(root, skillsDir)}; run build-openclaw-skills.js first.`);
+  process.exit(1);
+}
+
+// "ponytail-review" -> "Ponytail Review"
+const displayName = (slug) =>
+  slug.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
+
+// Minimal quoting that satisfies both POSIX sh and cmd.exe: only display names
+// (which contain a space) need wrapping; slugs, versions, paths, and flags don't.
+const quote = (a) => (/[^\w./-]/.test(a) ? `"${a}"` : a);
+
+const passthrough = process.argv.slice(2);
+const extra = passthrough.length ? ` (${passthrough.join(' ')})` : '';
+console.log(`Publishing ${slugs.length} skills to ClawHub at version ${version}${extra}:`);
+
+for (const slug of slugs) {
+  const args = [
+    'clawhub', 'skill', 'publish', `.openclaw/skills/${slug}`,
+    '--slug', slug,
+    '--name', displayName(slug),
+    '--version', version,
+    '--tag', 'latest',
+    ...passthrough,
+  ];
+  const cmdline = args.map(quote).join(' ');
+  console.log(`\n$ ${cmdline}`);
+  const res = spawnSync(cmdline, { stdio: 'inherit', cwd: root, shell: true });
+  if (res.status !== 0) {
+    console.error(
+      `\nPublish failed for "${slug}" (exit ${res.status}). ` +
+      `Check that the clawhub CLI is installed and you have run \`clawhub login\`, then re-run. ` +
+      `Skills already published in this run are unaffected.`,
+    );
+    process.exit(res.status || 1);
+  }
+}
+
+console.log(`\nDone. Published ${slugs.length} skills at ${version}.`);


### PR DESCRIPTION
## What

Adds `scripts/publish-openclaw-skills.js`, a one-pass publisher for the OpenClaw skills, plus a README line documenting it.

## Why

ClawHub does not pull from GitHub. Each skill is pushed explicitly with the `clawhub` CLI and carries its own version, so the published copies can drift from the repo, the same class of problem that hit the plugin manifests in #260. A single command keeps all six skills in sync.

## Details

- Reads the version from `package.json` (currently `4.8.1`), so ClawHub tracks the repo with nothing to hand-maintain.
- Discovers skills by reading `.openclaw/skills/` (no hardcoded list to drift), so it covers whatever `build-openclaw-skills.js` emits.
- Pushes each as `--tag latest`; passes extra flags such as `--dry-run` straight through.
- Fails safely and stops if the `clawhub` CLI is missing or you are not logged in. Already-published skills in a run are unaffected.

## Usage

```bash
clawhub login                                  # once
node scripts/publish-openclaw-skills.js        # publish all at the package.json version
node scripts/publish-openclaw-skills.js --dry-run
```

## Note

Not needed for v4.8.1 itself (that release was version-metadata only; the OpenClaw skill content did not change). This is for future releases, and for pushing the current skill content if your last ClawHub publish predates the v4.8.0 comprehension-first update.

Verified: `node --check` passes, and a dry run builds the correct six publish commands at version `4.8.1` with display names quoted correctly.
