### PR TITLE
fix(benchmark): add scheme validation to ollama-url (closes #166)

### DIFF
--- a/benchmarks/benchmark-local.py
+++ b/benchmarks/benchmark-local.py
@@ -15,6 +15,7 @@ import json
 import re
 import time
 import urllib.request
+import urllib.parse
 from pathlib import Path
 
 ROOT = Path(__file__).parent.parent
@@ -149,6 +150,11 @@ def main():
     parser.add_argument("--repeat",     type=int, default=1, help="Runs per cell; median reported (default: 1)")
     parser.add_argument("--ollama-url", default="http://localhost:11434", help="Ollama base URL")
     args = parser.parse_args()
+
+    parsed_url = urllib.parse.urlparse(args.ollama_url)
+    if parsed_url.scheme not in ("http", "https"):
+        parser.error(f"Invalid --ollama-url scheme: '{parsed_url.scheme}'. Only 'http' and 'https' are supported.")
+
     run(args.model, args.repeat, args.ollama_url)
 
 


### PR DESCRIPTION
🎯 **What:** Adds scheme validation to the `--ollama-url` parameter in `benchmark-local.py`.
💡 **Why:** To prevent arbitrary URI handling (such as `file://`, `ftp://`, or internal metadata endpoints) by ensuring only `http` and `https` schemes are accepted when connecting to Ollama.
✅ **Verification:** Ran `benchmark-local.py` with an invalid scheme like `ftp://127.0.0.1` and verified it throws an argparse error.
✨ **Result:** The benchmark script now strictly enforces HTTP/HTTPS for local connections, closing a minor security gap when executed in automated environments.