### PR TITLE
feat(pi-extension): add status bar indicator for ponytail mode (closes #84)

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -56,6 +56,25 @@ export { writeDefaultMode };
 export default function ponytailExtension(pi) {
   let currentMode = DEFAULT_MODE;
   let configuredDefaultMode = getDefaultMode();
+  let isActive = false;
+  let lastCtx = null;
+
+  // -- Status bar --
+  function syncStatus(ctx) {
+    if (ctx) lastCtx = ctx;
+    const c = ctx || lastCtx;
+    if (!c?.ui?.setStatus) return;
+    const theme = c.ui.theme;
+    if (currentMode === "off") {
+      c.ui.setStatus("ponytail", "");
+      return;
+    }
+    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥" };
+    const icon = levelIcons[currentMode] || "";
+    const label = currentMode.toUpperCase();
+    const indicator = isActive ? theme.fg("accent", "●") : theme.fg("dim", "○");
+    c.ui.setStatus("ponytail", indicator + " 🐴 " + theme.fg("muted", "ponytail: ") + theme.fg("text", icon + " " + label));
+  }
 
   const setMode = (mode, ctx) => {
     const normalized = normalizePersistedMode(mode);
@@ -63,6 +82,7 @@ export default function ponytailExtension(pi) {
 
     currentMode = normalized;
     pi.appendEntry("ponytail-mode", { mode: normalized });
+    syncStatus(ctx);
     ctx?.ui?.notify?.(`Ponytail mode set to ${normalized}.`, "info");
   };
 
@@ -148,6 +168,18 @@ export default function ponytailExtension(pi) {
     const entries = ctx?.sessionManager?.getBranch?.() || ctx?.sessionManager?.getEntries?.() || [];
     configuredDefaultMode = getDefaultMode();
     currentMode = resolveSessionMode(entries, configuredDefaultMode);
+    syncStatus(ctx);
+    ctx?.ui?.notify?.(`Ponytail loaded: ${currentMode}`, "info");
+  });
+
+  pi.on("agent_start", async (_event, ctx) => {
+    isActive = true;
+    syncStatus(ctx);
+  });
+
+  pi.on("agent_end", async (_event, ctx) => {
+    isActive = false;
+    syncStatus(ctx);
   });
 
   pi.on("before_agent_start", async (event) => {


### PR DESCRIPTION
🎯 **What:** Adds a status bar indicator to the Pi extension to display the current Ponytail mode.
💡 **Why:** To provide clear, persistent visual feedback on the active Ponytail intensity level (lite, full, ultra) without requiring the user to run status commands.
✅ **Verification:** Verified `syncStatus` successfully updates the Pi UI's status line on mode changes, and accurately reflects `agent_start` and `agent_end` states. Passed existing test suite for the extension.
✨ **Result:** Users now see an inline indicator (e.g., `● 🐴 ponytail: ⚡ FULL`) directly within the Pi editor UI, vastly improving the usability of mode toggling.