### PR TITLE
docs: clarify uninstall run-order + statusLine ceiling (#226)

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Which files map to which agent: [Agent portability](docs/agent-portability.md).
 | Pi agent | `pi uninstall ponytail` |
 | Cursor / Windsurf / Cline / etc. | Delete the copied rule file |
 
-These remove the plugin's own files. They leave behind a small amount of state ponytail writes outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` (from this repo, or wherever it was installed) to clean those up too. It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched.
+These remove the plugin's own files. They leave behind a small amount of state ponytail writes outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` to clean those up too. **Run it before the host remove command above** — the script is itself a plugin file, so removing the plugin first deletes it (or run it from a separate clone of this repo). It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched.
 
 ## Commands
 

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -26,6 +26,10 @@ try {
   const raw = fs.readFileSync(settingsPath, 'utf8').replace(/^\uFEFF/, '');
   const settings = JSON.parse(raw);
   const cmd = settings.statusLine && settings.statusLine.command;
+  // ponytail: substring-match the script name, then drop the whole statusLine
+  // key. A combined statusline (e.g. caveman+ponytail) whose command contains
+  // "ponytail-statusline" gets removed wholesale. Parse out only ponytail's part
+  // if combined statuslines become common.
   if (typeof cmd === 'string' && cmd.includes('ponytail-statusline')) {
     delete settings.statusLine;
     fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');


### PR DESCRIPTION
Follow-up polish to #228 (issue #226). Two minor findings from review of the merged uninstall script.

## Changes

1. **README ordering.** `scripts/uninstall.js` is itself a plugin file, so running the host's `remove`/`uninstall` command first deletes it. README now says to run the cleanup script **before** the host remove command (or from a separate clone).

2. **statusLine match ceiling.** Added a `ponytail:` comment on the match in `uninstall.js`: it substring-matches `ponytail-statusline` and deletes the whole `statusLine` key, so a combined (e.g. caveman+ponytail) statusline gets removed wholesale. Upgrade path noted in the comment. Also added the missing trailing newline.

No behavior change to the script's happy path. `tests/uninstall.test.js` still passes (1 test, exit 0).