### PR TITLE
fix(pi-extension): guard status bar render when ui lacks a theme

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -63,7 +63,7 @@ export default function ponytailExtension(pi) {
   function syncStatus(ctx) {
     if (ctx) lastCtx = ctx;
     const c = ctx || lastCtx;
-    if (!c?.ui?.setStatus) return;
+    if (!c?.ui?.setStatus || !c.ui.theme?.fg) return;
     const theme = c.ui.theme;
     if (currentMode === "off") {
       c.ui.setStatus("ponytail", "");

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -135,3 +135,33 @@ test("a request mentioning normal mode stays active", async () => withTempConfig
   const result = await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx);
   assert.match(result.systemPrompt, /PONYTAIL MODE ACTIVE/);
 }));
+
+test("status bar renders the mode and flips active on agent_start", async () => withTempConfig(async () => {
+  const { events } = createPiHarness();
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "ultra" } }] },
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_color, text) => text } },
+  });
+
+  await events.get("session_start")({ reason: "resume" }, ctx);
+  await events.get("agent_start")({}, ctx);
+
+  assert.equal(statusWrites.at(-2).key, "ponytail");
+  assert.match(statusWrites.at(-2).text, /○.*ULTRA/);
+  assert.match(statusWrites.at(-1).text, /●.*ULTRA/);
+}));
+
+test("status bar stays silent when ui lacks a theme", async () => withTempConfig(async () => {
+  const { events } = createPiHarness();
+  const calls = [];
+  const ctx = createCommandContext({
+    sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "ultra" } }] },
+    ui: { notify() {}, setStatus: (_key, text) => calls.push(text) }, // setStatus present, theme absent
+  });
+
+  await events.get("session_start")({ reason: "resume" }, ctx);
+  await events.get("agent_start")({}, ctx);
+
+  assert.deepEqual(calls, []);
+}));


### PR DESCRIPTION
Follow-up to #275 (the status bar from #84).

`syncStatus` guarded `setStatus` but used `theme.fg` unguarded, so a Pi host that exposes `setStatus` without a `theme` throws `TypeError: Cannot read properties of undefined (reading 'fg')` on `session_start` (and `agent_start`/`agent_end`/`setMode`). Real Pi provides both, so it never fired there. This closes the gap the existing `setStatus` guard already intended: the feature needs both, so lacking either it bails.

- `index.js`: require `setStatus` and `theme.fg` before rendering.
- tests: cover the render path (previously untested) and the theme-absent degradation (that test throws against the unfixed code).

`npm test` green.