### PR TITLE
feat: scope npm package as @dietrichgebert/ponytail

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -7,7 +7,7 @@
 // source of truth.
 //
 // OpenCode loads this as a server plugin — add it to your opencode.json:
-//   { "plugin": ["opencode-ponytail"] }
+//   { "plugin": ["@dietrichgebert/ponytail"] }
 
 import { createRequire } from 'module';
 import fs from 'fs';

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ pi install git:github.com/DietrichGebert/ponytail
 Add to `opencode.json`:
 
 ```json
-{ "plugin": ["opencode-ponytail"] }
+{ "plugin": ["@dietrichgebert/ponytail"] }
 ```
 
 Run from a checkout instead (the plugin reuses `hooks/` and `skills/`):

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "opencode-ponytail",
+  "name": "@dietrichgebert/ponytail",
   "version": "4.8.1",
   "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
   "keywords": ["opencode-plugin", "opencode", "ponytail", "pi-package", "pi", "skills"],


### PR DESCRIPTION
## Why
`opencode-ponytail` on npm is owned by a third-party account (the #197 author published it under his own npm user). Publishing under a scope you own removes that dependency and the supply-chain risk, and `@dietrichgebert/ponytail` matches your GitHub handle + repo name.

## Changes
- `package.json` name → `@dietrichgebert/ponytail`
- README OpenCode install snippet → `{ "plugin": ["@dietrichgebert/ponytail"] }`
- plugin header comment → same

`publishConfig.access: public` is already set (required for scoped public packages). No version change — still 4.8.1.

## Remaining before a release (separate step)
1. Add npm automation token as repo secret `NPM_TOKEN`
2. Bump all 6 version files to 4.8.2, push tag `v4.8.2` (v4.8.1 already tagged) → `publish.yml` ships it with provenance

## Checks
`npm test` (61 + 15), `check-versions.js`, `check-rule-copies.js` all green locally.