### PR TITLE
check-rule-copies: pin the reuse rung as an invariant

### DIFF
--- a/scripts/check-rule-copies.js
+++ b/scripts/check-rule-copies.js
@@ -41,6 +41,7 @@ for (const [relPath, normalize] of copies) {
 // a rule's wording trips this, which is the reminder to propagate it everywhere.
 // Upgrade path: generate the copies from SKILL.md if this ever misses a real drift.
 const INVARIANTS = [
+  'in this codebase',                      // ladder rung: reuse what already exists (#217)
   'naive heuristic',                       // ceiling-comment rule
   'ONE runnable check',                    // test reflex
   'flimsier algorithm',                    // robust-variant rule


### PR DESCRIPTION
The reuse rung added in #253 ("Already in this codebase? Reuse it, don't re-write it.") is load-bearing now, but it is not in the INVARIANTS list in `check-rule-copies.js`. So a future reword could silently drop it from SKILL.md or AGENTS.md without tripping the check.

This pins it with the substring "in this codebase" (present in both files' rung 2), the same way the safety carve-outs are pinned. Check still passes (9 invariants).