### PR TITLE
ci: publish via npm trusted publishing (OIDC), drop NPM_TOKEN

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,8 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: '22'
-          registry-url: 'https://registry.npmjs.org'
-      - run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22 ships npm 10.
+      - run: npm install -g npm@latest
+      # No token: id-token: write above lets npm authenticate via OIDC, and
+      # provenance is attached automatically. access set in publishConfig.
+      - run: npm publish


### PR DESCRIPTION
Switches the release workflow to npm **Trusted Publishing** (OIDC) instead of a long-lived `NPM_TOKEN` secret.

## Changes to `publish.yml`
- Drop `NODE_AUTH_TOKEN`/`secrets.NPM_TOKEN` and the `registry-url` auth setup — OIDC handles auth via the existing `id-token: write` permission
- Add `npm install -g npm@latest` — trusted publishing needs npm >= 11.5.1; Node 22 ships npm 10
- `npm publish` (provenance is attached automatically under OIDC; access comes from `publishConfig`)

## Before the first release (npm side, not in this repo)
npm can't OIDC-publish a package that doesn't exist yet ([npm/cli#8544](https://github.com/npm/cli/issues/8544)), so:
1. **One-time bootstrap**: `npm login` then `npm publish --access public` locally to create `@dietrichgebert/ponytail` on npm
2. Configure the trusted publisher at npmjs.com → package **Settings → Trusted Publisher**: org `DietrichGebert`, repo `ponytail`, workflow `publish.yml`, action `npm publish`
3. After that, every `v*` tag publishes via OIDC with provenance — no token

Note: `publish.yml` only runs on tag pushes, so this can't be exercised by CI until the first `v4.8.2` tag.