### PR TITLE
release: 4.8.3

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ponytail",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "author": {
     "name": "Dietrich Gebert",
     "url": "https://github.com/DietrichGebert"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dietrichgebert/ponytail",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
   "keywords": ["opencode-plugin", "opencode", "ponytail", "pi-package", "pi", "skills"],
   "license": "MIT",

--- a/ponytail-mcp/package.json
+++ b/ponytail-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail-mcp",
-  "version": "4.8.2",
+  "version": "4.8.3",
   "description": "MCP server that serves Ponytail's lazy-senior-dev instructions as a prompt and a tool.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Bump all 6 version manifests 4.8.2 → 4.8.3 to release what landed on main since v4.8.2:

- feat: inject ponytail ruleset into subagents via SubagentStart hook (#254)
- docs: Korean README + en/es README npm/OpenCode fixes (#283, #285)

After merge, tagging `v4.8.3` fires `publish.yml` → OIDC publish to npm with provenance. I'll create the matching GitHub release after.

`check-versions.js`, `npm test` (61 + 15), `check-rule-copies.js` all green.