### PR TITLE
fix(hooks): interpolate settingsPath in statusline nudge (closes #255)

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -66,7 +66,7 @@ if (!isCodex && !isCopilot) try {
       output += "\n\n" +
         "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode " +
         "(e.g. [PONYTAIL], [PONYTAIL:ULTRA]). It is not configured yet. " +
-        "To enable, add this to ~/.claude/settings.json: " +
+        `To enable, add this to ${settingsPath}: ` +
         statusLineSnippet + " " +
         "Proactively offer to set this up for the user on first interaction.";
     } else {
@@ -76,7 +76,7 @@ if (!isCodex && !isCopilot) try {
         "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode. " +
         "Its install path contains characters unsafe to embed in a shell command, so configure it manually: " +
         "add a statusLine command of type \"command\" that runs " + scriptName +
-        " from the plugin's hooks directory to ~/.claude/settings.json, quoting/escaping the path for your shell. " +
+        ` from the plugin's hooks directory to ${settingsPath}, quoting/escaping the path for your shell. ` +
         "Proactively offer to set this up for the user on first interaction.";
     }
   }

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -114,6 +114,8 @@ assert.equal(
 );
 
 // CLAUDE_CONFIG_DIR overrides ~/.claude for the flag file (issue #34).
+// The statusline nudge must also reference the resolved settings path, not the
+// hardcoded ~/.claude/settings.json literal (issue #255 / #250).
 const home2 = path.join(temp, 'home2');
 fs.mkdirSync(home2, { recursive: true });
 const customConfigDir = path.join(temp, 'custom-claude');
@@ -133,6 +135,20 @@ assert.equal(
   false,
   'flag must not land in ~/.claude when CLAUDE_CONFIG_DIR is set',
 );
+// The nudge text must reference the resolved settings path (customConfigDir/settings.json)
+// and must NOT contain the hardcoded ~/.claude/settings.json (issue #255).
+const customSettingsPath = path.join(customConfigDir, 'settings.json');
+assert.match(
+  result.stdout,
+  new RegExp(customSettingsPath.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')),
+  'statusline nudge must reference CLAUDE_CONFIG_DIR/settings.json, not ~/.claude/settings.json',
+);
+assert.doesNotMatch(
+  result.stdout,
+  /~\/.claude\/settings\.json/,
+  'statusline nudge must not contain hardcoded ~/.claude/settings.json when CLAUDE_CONFIG_DIR is set',
+);
+
 
 const copilotData = path.join(temp, 'copilot-data');
 const codexData = path.join(temp, 'codex-data-shadow');


### PR DESCRIPTION
🎯 **What:** Replaces the two hardcoded `~/.claude/settings.json` strings in the statusline setup nudge with the already-computed `settingsPath` variable, which correctly resolves `CLAUDE_CONFIG_DIR`.

💡 **Why:** When `CLAUDE_CONFIG_DIR` is set to a custom location, `ponytail-activate.js` already reads the flag file and detects the missing statusline from the correct directory — but then told the user (and the agent) to edit `~/.claude/settings.json`, which Claude Code is not reading. This caused the statusline to silently never activate for any user with a custom config dir.

✅ **Verification:** Extended the existing `CLAUDE_CONFIG_DIR` test block in `tests/hooks.test.js` with two new assertions: one that confirms the resolved `settingsPath` appears in the nudge output, and one that confirms the hardcoded `~/.claude/settings.json` literal does not. All 60 of 61 tests pass; the single remaining failure is the pre-existing `csv: correct pandas one-liner passes` test which requires `pandas` and was already failing on `main` before this change.

✨ **Result:** Users with `CLAUDE_CONFIG_DIR` set now receive a nudge pointing at the correct settings file, so the statusline can actually be configured and activated.