### PR TITLE
fix: add missing ponytail-audit and ponytail-debt to help SKILL.md

### DIFF
--- a/.openclaw/skills/ponytail-help/SKILL.md
+++ b/.openclaw/skills/ponytail-help/SKILL.md
@@ -26,6 +26,8 @@ Level sticks until changed or session end.
 |-------|---------|--------------|
 | **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
 | **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
+| **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit, ranked by impact. |
+| **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` shortcuts into a tracked debt ledger. |
 | **ponytail-gain** | `/ponytail-gain` | Measured-impact scoreboard: less code, less cost, more speed. |
 | **ponytail-help** | `/ponytail-help` | This card. |
 

--- a/skills/ponytail-help/SKILL.md
+++ b/skills/ponytail-help/SKILL.md
@@ -27,6 +27,8 @@ Level sticks until changed or session end.
 |-------|---------|--------------|
 | **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
 | **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
+| **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit, ranked by impact. |
+| **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` shortcuts into a tracked debt ledger. |
 | **ponytail-gain** | `/ponytail-gain` | Measured-impact scoreboard: less code, less cost, more speed. |
 | **ponytail-help** | `/ponytail-help` | This card. |
 


### PR DESCRIPTION
The help SKILL.md Skills table only listed 4 of the 6 shipped skills. Added `ponytail-audit` and `ponytail-debt` rows and rebuilt the OpenClaw skill artifact.