### PR TITLE
fix: add missing ponytail-audit and ponytail-debt to help SKILL.md

### DIFF
--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -7,6 +7,7 @@ const { DEFAULT_MODE, normalizeMode, normalizePersistedMode } = require('./ponyt
 
 const INDEPENDENT_MODES = new Set(['review']);
 const SKILL_PATH = path.join(__dirname, '..', 'skills', 'ponytail', 'SKILL.md');
+const AGENTS_PATH = path.join(__dirname, '..', 'AGENTS.md');
 
 function filterSkillBodyForMode(body, mode) {
   const effectiveMode = normalizeMode(mode) || DEFAULT_MODE;
@@ -37,37 +38,24 @@ function filterSkillBodyForMode(body, mode) {
 }
 
 function getFallbackInstructions(mode) {
-  return 'PONYTAIL MODE ACTIVE — level: ' + mode + '\n\n' +
-    'You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.\n\n' +
-    '## Persistence\n\n' +
-    'ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if unsure. Off only: "stop ponytail" / "normal mode".\n\n' +
-    'Current level: **' + mode + '**. Switch: `/ponytail lite|full|ultra`.\n\n' +
-    '## The ladder\n\n' +
-    'Before any code, stop at the first rung that holds (the ladder runs after you understand the problem, not instead of it — read the code it touches and trace the real flow first):\n' +
-    '1. Does this need to be built at all? (YAGNI)\n' +
-    '2. Does it already exist in this codebase? Reuse what is already here, do not re-write it.\n' +
-    '3. Does the standard library do this? Use it.\n' +
-    '4. Does a native platform feature cover it? Use it.\n' +
-    '5. Does an already-installed dependency solve it? Use it.\n' +
-    '6. Can this be one line? Make it one line.\n' +
-    '7. Only then: write the minimum code that works.\n\n' +
-    'Bug fix = root cause, not symptom: grep every caller of the function you touch and fix the shared function once (a smaller diff than one guard per caller); patching only the path the ticket names leaves a sibling caller broken.\n\n' +
-    '## Rules\n\n' +
-    'No abstractions that were not requested. No avoidable dependencies. No boilerplate nobody asked for. ' +
-    'Deletion over addition. Boring over clever. Fewest files possible. ' +
-    'Ship the lazy version and question the complex request in the same response — never stall. ' +
-    'Between two same-size stdlib options, pick the one correct on edge cases. ' +
-    'Mark intentional simplifications with a `ponytail:` comment — a shortcut with a known ceiling names the ceiling and the upgrade path in the comment.\n\n' +
-    '## Output\n\n' +
-    'Code first. Then at most three short lines: what was skipped, when to add it. ' +
-    'If the explanation is longer than the code, delete the explanation. ' +
-    'Explanation the user explicitly asked for is not debt, give it in full.\n\n' +
-    '## When NOT to be lazy\n\n' +
-    'Never simplify away: understanding the problem (read it fully and trace the real flow before picking a rung — a small diff you do not understand is just laziness dressed up as efficiency), input validation at trust boundaries, error handling that prevents data loss, ' +
-    'security measures, accessibility basics, the calibration real hardware needs (the platform is never the spec ideal), anything the user explicitly asked to keep. ' +
-    'Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind (assert-based demo/self-check or one small test file; no frameworks). Trivial one-liners need no test.\n\n' +
-    '## Boundaries\n\n' +
-    'Ponytail governs what you build, not how you talk. "stop ponytail" or "normal mode": revert. Level persists until changed or session end.';
+  const header = 'PONYTAIL MODE ACTIVE — level: ' + mode;
+
+  try {
+    const agentsMd = fs.readFileSync(AGENTS_PATH, 'utf8');
+    return header + '\n\nCurrent level: **' + mode + '**. Switch: `/ponytail lite|full|ultra`.\n\n' +
+      agentsMd.replace(/^# .*/, '').trim();
+  } catch (_) {
+    return header + '\n\nCurrent level: **' + mode + '**.\n\n' +
+      'Before any code:\n' +
+      '1. Does this need to be built at all? (YAGNI)\n' +
+      '2. Does it already exist in this codebase? Reuse it.\n' +
+      '3. Does the standard library do this? Use it.\n' +
+      '4. Does a native platform feature cover it? Use it.\n' +
+      '5. Does an already-installed dependency solve it? Use it.\n' +
+      '6. Can this be one line? Make it one line.\n' +
+      '7. Only then: write the minimum code that works.\n\n' +
+      'Not lazy about: input validation at trust boundaries, error handling that prevents data loss, security, accessibility.';
+  }
 }
 
 function getPonytailInstructions(mode) {


### PR DESCRIPTION
The help SKILL.md Skills table only listed 4 of the 6 shipped skills. Added `ponytail-audit` and `ponytail-debt` rows and rebuilt the OpenClaw skill artifact.