### PR TITLE
docs: add Star History chart to end of READMEs

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -255,3 +255,13 @@ Ya sabes exactamente por qué.
 ## Licencia
 
 [MIT](LICENSE). La licencia más corta que funciona.
+
+## Historial de estrellas
+
+<a href="https://www.star-history.com/dietrichgebert/ponytail#history">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
+ </picture>
+</a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -275,3 +275,13 @@ OpenClaw 스킬 패키지(`.openclaw/skills/`)는 `skills/`에서 생성된다. 
 ## License
 
 [MIT](LICENSE). 돌아가는 가장 짧은 라이선스.
+
+## Star History
+
+<a href="https://www.star-history.com/dietrichgebert/ponytail#history">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
+ </picture>
+</a>

--- a/README.md
+++ b/README.md
@@ -286,3 +286,13 @@ You know exactly why.
 ## License
 
 [MIT](LICENSE). The shortest license that works.
+
+## Star History
+
+<a href="https://www.star-history.com/dietrichgebert/ponytail#history">
+ <picture>
+   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
+   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
+ </picture>
+</a>


### PR DESCRIPTION
## What

Appends a **Star History** section (star-history.com chart) to the end of all three READMEs — English, Spanish, and Korean.

- Uses `<picture>` with light/dark `<source>` variants so the chart adapts to the reader's color scheme.
- Heading follows each file's existing convention: translated in Spanish (`## Historial de estrellas`), kept in English for the main and Korean READMEs (the Korean README keeps all section headings in English, e.g. `## License`).

## Notes

- Chart endpoints verified live: both light and dark resolve to `HTTP 200`, `image/svg+xml` (~65 KB), so they render immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)