### PR TITLE
fix(opencode): stop exporting parseCommandFile from plugin module

### DIFF
--- a/.opencode/plugins/ponytail-frontmatter.cjs
+++ b/.opencode/plugins/ponytail-frontmatter.cjs
@@ -1,0 +1,23 @@
+'use strict';
+
+// ponytail command-file frontmatter parser.
+//
+// Pulled out of ponytail.mjs so the plugin module's only top-level export is
+// the plugin function itself. OpenCode's legacy plugin loader (the one that
+// runs before v1 plugins are detected) treats every function exported from a
+// plugin module as a plugin; calling the frontmatter parser as one threw
+// "path must be a string or a file descriptor" because it got the plugin
+// context object as its first argument. Keeping the parser in its own module
+// leaves exactly one plugin-shaped export on ponytail.mjs.
+
+function parseCommandFile(filePath) {
+  const fs = require('fs');
+  const content = fs.readFileSync(filePath, 'utf8');
+  // Tolerate CRLF: a Windows checkout (autocrlf) delivers \r\n, npm ships \n.
+  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
+  if (!match) return null;
+  const description = match[1].match(/description:\s*(.+)/)?.[1]?.trim();
+  return { description, template: match[2].trim() };
+}
+
+module.exports = { parseCommandFile };

--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -21,6 +21,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const { getPonytailInstructions } = require('../../hooks/ponytail-instructions');
 const { getDefaultMode, normalizePersistedMode } = require('../../hooks/ponytail-config');
+const { parseCommandFile } = require('./ponytail-frontmatter.cjs');
 
 // OpenCode has no flag-file convention of its own; keep mode beside its config.
 const statePath = path.join(
@@ -40,15 +41,6 @@ function readMode() {
 function writeMode(mode) {
   fs.mkdirSync(path.dirname(statePath), { recursive: true });
   fs.writeFileSync(statePath, mode);
-}
-
-export function parseCommandFile(filePath) {
-  const content = fs.readFileSync(filePath, 'utf8');
-  // Tolerate CRLF: a Windows checkout (autocrlf) delivers \r\n, npm ships \n.
-  const match = content.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n([\s\S]*)$/);
-  if (!match) return null;
-  const description = match[1].match(/description:\s*(.+)/)?.[1]?.trim();
-  return { description, template: match[2].trim() };
 }
 
 export default async ({ client } = {}) => {

--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -23,7 +23,11 @@ test.before(async () => {
   const url = pathToFileURL(path.join(__dirname, '..', '.opencode', 'plugins', 'ponytail.mjs'));
   const mod = await import(url);
   loadPlugin = mod.default;
-  parseCommandFile = mod.parseCommandFile;
+  // The frontmatter parser used to be exported from the plugin module itself.
+  // OpenCode's legacy loader treats every exported function as a plugin and
+  // tried to invoke it with the plugin context object, which crashed. The
+  // parser now lives in its own .cjs sibling; require it directly.
+  parseCommandFile = require(path.join(__dirname, '..', '.opencode', 'plugins', 'ponytail-frontmatter.cjs')).parseCommandFile;
 });
 
 function transform(hooks) {


### PR DESCRIPTION
OpenCode's legacy plugin loader iterates every exported function in a plugin module and tries to invoke each one with the plugin context object. `parseCommandFile` was exported alongside the default plugin function, so the loader called it with an object instead of a file path and crashed with *"path must be a string or a file descriptor"* before any hook ran, which aborted the whole plugin load (v4.8.3, observed on OpenCode 1.17.9).

## Repro

```json
// ~/.config/opencode/opencode.jsonc
{ "plugin": ["@dietrichgebert/ponytail"] }
```

```
opencode run "test" --print-logs
# ERROR  failed to load plugin  path=@dietrichgebert/ponytail
#        error="path must be a string or a file descriptor"
```

No hooks fire, no commands register, the plugin is silently dead.

## Fix

Move the frontmatter parser out of the plugin module into its own .cjs sibling. The plugin module now exposes exactly one top-level export (the default plugin function); the loader has nothing else to mis-invoke.

- `.opencode/plugins/ponytail-frontmatter.cjs` (new) — the parser, same regex, same CRLF tolerance
- `.opencode/plugins/ponytail.mjs` — drops the named `parseCommandFile` export, requires the sibling via the existing `createRequire` bridge
- `tests/opencode-plugin.test.js` — requires the sibling directly; existing frontmatter tests are unchanged in intent

## Verification

```
node --test tests/opencode-plugin.test.js
# 6 pass, 0 fail

node -e "import('./.opencode/plugins/ponytail.mjs').then(m => console.log(Object.keys(m)))"
# [ 'default' ]
```

(`npm test`'s CSV row fails on this machine because pandas isn't installed; the same test fails on `main` without these changes, so it's pre-existing and unrelated.)