### PR TITLE
fix: ignore invalid opencode mode arguments

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -92,7 +92,9 @@ export default async ({ client } = {}) => {
     'command.execute.before': async (input) => {
       if (!input || input.command !== 'ponytail') return;
       // `off` is persisted like any mode; the transform reads it and stays silent.
-      const mode = normalizePersistedMode((input.arguments || '').trim()) || getDefaultMode();
+      const args = (input.arguments || '').trim();
+      const mode = args ? normalizePersistedMode(args) : getDefaultMode();
+      if (!mode) return;
       writeMode(mode);
       log('info', 'ponytail ' + mode);
     },

--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -56,6 +56,13 @@ test('/ponytail off persists off and transform injects nothing', async () => {
   assert.deepEqual(system, []);
 });
 
+test('unsupported /ponytail arguments do not reset the current mode', async () => {
+  const hooks = await loadPlugin({});
+  fs.writeFileSync(statePath, 'ultra');
+  await hooks['command.execute.before']({ command: 'ponytail', arguments: 'status', sessionID: 's' });
+  assert.equal(fs.readFileSync(statePath, 'utf8'), 'ultra');
+});
+
 test('unrelated commands do not touch the flag', async () => {
   try { fs.unlinkSync(statePath); } catch (e) {}
   const hooks = await loadPlugin({});


### PR DESCRIPTION
## Summary
- keep the OpenCode `/ponytail` hook from resetting the saved mode when the argument is not a supported mode
- add a regression test so unsupported arguments leave the current mode untouched

## Testing
- [x] `node --test tests/opencode-plugin.test.js`
- [x] `node scripts/check-rule-copies.js`
- [x] `node scripts/check-versions.js`
- [x] `npm test`
- [x] `git diff --check`
