### PR TITLE
fix: keep OpenCode system prompt Qwen-compatible

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -82,7 +82,12 @@ export default async ({ client } = {}) => {
     'experimental.chat.system.transform': async (_input, output) => {
       const mode = readMode();
       if (mode === 'off') return;
-      output.system.push(getPonytailInstructions(mode));
+      const instructions = getPonytailInstructions(mode);
+      if (output.system.length) {
+        output.system[0] = `${output.system[0]}\n\n${instructions}`;
+      } else {
+        output.system.push(instructions);
+      }
     },
 
     // Persist `/ponytail <level>` so the next turn's injection follows it.

--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -26,8 +26,8 @@ test.before(async () => {
   parseCommandFile = mod.parseCommandFile;
 });
 
-function transform(hooks) {
-  const output = { system: [] };
+function transform(hooks, system = []) {
+  const output = { system: [...system] };
   return hooks['experimental.chat.system.transform']({ model: {} }, output).then(() => output.system);
 }
 
@@ -37,6 +37,15 @@ test('system.transform injects the ruleset at the default mode (full)', async ()
   const system = await transform(hooks);
   assert.equal(system.length, 1);
   assert.match(system[0], /PONYTAIL MODE ACTIVE — level: full/);
+  assert.match(system[0], /lazy senior developer/);
+});
+
+test('system.transform merges into the existing OpenCode system prompt', async () => {
+  try { fs.unlinkSync(statePath); } catch (e) {}
+  const hooks = await loadPlugin({});
+  const system = await transform(hooks, ['opencode baseline']);
+  assert.equal(system.length, 1);
+  assert.match(system[0], /^opencode baseline\n\nPONYTAIL MODE ACTIVE/);
   assert.match(system[0], /lazy senior developer/);
 });
 
@@ -54,6 +63,7 @@ test('/ponytail off persists off and transform injects nothing', async () => {
   assert.equal(fs.readFileSync(statePath, 'utf8'), 'off');
   const system = await transform(hooks);
   assert.deepEqual(system, []);
+  assert.deepEqual(await transform(hooks, ['opencode baseline']), ['opencode baseline']);
 });
 
 test('unrelated commands do not touch the flag', async () => {


### PR DESCRIPTION
## Summary
- Merge Ponytail's OpenCode instructions into the existing system prompt instead of appending a second system message.
- Preserve the no-baseline fallback and `/ponytail off` behavior.
- Add an OpenCode regression test that keeps the system array at one entry when OpenCode supplies a baseline prompt.

Closes #296

## Testing
- `node --test tests/opencode-plugin.test.js`
- `node scripts/check-rule-copies.js`
- `node scripts/check-versions.js`
- `git diff --check`
- `PATH="$PWD/.venv/bin:$PATH" npm test` (with pandas installed in a repo-local uv venv)