### PR TITLE
feat(adapters): add Kilo Code VS Code extension support

### DIFF
--- a/.kilocode/rules/ponytail.md
+++ b/.kilocode/rules/ponytail.md
@@ -1,0 +1,30 @@
+# Ponytail, lazy senior dev mode
+
+You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+
+Before writing any code, stop at the first rung that holds:
+
+1. Does this need to be built at all? (YAGNI)
+2. Does it already exist in this codebase? Reuse the helper, util, or pattern that's already here, don't re-write it.
+3. Does the standard library already do this? Use it.
+4. Does a native platform feature cover it? Use it.
+5. Does an already-installed dependency solve it? Use it.
+6. Can this be one line? Make it one line.
+7. Only then: write the minimum code that works.
+
+The ladder runs after you understand the problem, not instead of it: read the task and the code it touches, trace the real flow end to end, then climb.
+
+Bug fix = root cause, not symptom: a report names a symptom. Grep every caller of the function you touch and fix the shared function once — one guard there is a smaller diff than one per caller, and patching only the path the ticket names leaves a sibling caller still broken.
+
+Rules:
+
+- No abstractions that weren't explicitly requested.
+- No new dependency if it can be avoided.
+- No boilerplate nobody asked for.
+- Deletion over addition. Boring over clever. Fewest files possible.
+- Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Question complex requests: "Do you actually need X, or does Y cover it?"
+- Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
+- Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path.
+
+Not lazy about: understanding the problem (read it fully and trace the real flow before picking a rung, a small diff you don't understand is just laziness dressed up as efficiency), input validation at trust boundaries, error handling that prevents data loss, security, accessibility, the calibration real hardware needs (the platform is never the spec ideal, a clock drifts, a sensor reads off), anything explicitly requested. Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind, the smallest thing that fails if the logic breaks (an assert-based demo/self-check or one small test file; no frameworks, no fixtures). Trivial one-liners need no test.

--- a/README.md
+++ b/README.md
@@ -271,7 +271,9 @@ Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`l
 
 While active, the ruleset is also injected into every subagent spawned via the Agent tool. To scope that to specific agent types (say, keep it off read-only search agents), set the `PONYTAIL_SUBAGENT_MATCHER` env var to a regex tested against the subagent's `agent_type`. It is unanchored and case-insensitive: `explore|general` matches either, `^general$` is exact, and plugin agent types look like `plugin:name`. Unset means inject into every subagent (the default); an invalid regex, or a subagent whose type the platform doesn't report, also falls back to injecting.
 
-Cursor, Windsurf, Cline, GitHub Copilot Chat (the VS Code, JetBrains, and Visual Studio editor extension, not the standalone Copilot CLI covered under [Install](#install)), Aider, Kiro, Zed, CodeWhale, Swival, Qoder: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/), [`.qoder/rules/`](.qoder/rules/)).
+Cursor, Windsurf, Cline, Kilo Code, GitHub Copilot Chat (the VS Code, JetBrains, and Visual Studio editor extension, not the standalone Copilot CLI covered under [Install](#install)), Aider, Kiro, Zed, CodeWhale, Swival, Qoder: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.kilocode/rules/`](.kilocode/rules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/), [`.qoder/rules/`](.qoder/rules/)).
+
+Kilo Code: copy `.kilocode/rules/ponytail.md` to `~/.kilocode/rules/` (global) or `.kilocode/rules/` in your project.
 
 Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kiro/steering/` in your project.
 
@@ -311,7 +313,7 @@ These remove the plugin's own files. They leave behind a small amount of state p
 | `/ponytail-gain` | Show the measured impact scoreboard (less code, less cost, more speed) from the benchmark. |
 | `/ponytail-help` | Quick reference for the commands above. |
 
-Commands need a skill-capable host (Claude Code, Codex, Devin CLI, OpenCode, Gemini, pi, Swival, Hermes Agent, Qoder, Grok Build). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
+Commands need a skill-capable host (Claude Code, Codex, Devin CLI, OpenCode, Gemini, pi, Swival, Hermes Agent, Qoder, Grok Build). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Kilo Code, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
 
 ## Development
 

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -18,6 +18,7 @@ to load in a given agent.
 | Cursor | `.cursor/rules/ponytail.mdc` | Always-on project rule. |
 | Windsurf | `.windsurf/rules/ponytail.md` | Project rule. |
 | Cline | `.clinerules/ponytail.md` | Project rule. |
+| Kilo Code (VS Code) | `.kilocode/rules/ponytail.md` | Project rule. Copy to `~/.kilocode/rules/` for global. Instruction-tier. |
 | GitHub Copilot | `.github/copilot-instructions.md` | Repository instruction file. |
 | GitHub Copilot CLI | `.github/plugin/`, `AGENTS.md`, `.github/copilot-instructions.md`, `~/.copilot/copilot-instructions.md` | Plugin-supported (`copilot plugin marketplace add DietrichGebert/ponytail` + `copilot plugin install ponytail@ponytail`). Fallback instruction mode remains: per-project from `AGENTS.md` or `.github/copilot-instructions.md`, or globally from `~/.copilot/copilot-instructions.md` (instruction-tier, no `/ponytail` levels or hooks). |
 | Antigravity | `AGENTS.md` | Reads `AGENTS.md` at the repo root as always-on rules (like `.cursorrules`/`CLAUDE.md`); `.agents/rules/` also works for workspace rules. Instruction-tier. |

--- a/scripts/check-rule-copies.js
+++ b/scripts/check-rule-copies.js
@@ -20,6 +20,7 @@ const copies = [
   ['.cursor/rules/ponytail.mdc', stripFrontmatter],
   ['.windsurf/rules/ponytail.md', text => text.trim()],
   ['.clinerules/ponytail.md', text => text.trim()],
+  ['.kilocode/rules/ponytail.md', text => text.trim()],
   ['.agents/rules/ponytail.md', text => text.trim()],
   ['.qoder/rules/ponytail.md', text => text.trim()],
   ['.github/copilot-instructions.md', text => text.trim()],

--- a/tests/kilocode-adapter.test.js
+++ b/tests/kilocode-adapter.test.js
@@ -1,0 +1,27 @@
+#!/usr/bin/env node
+// Issue #300: Kilo Code VS Code extension adapter. Verifies the rule file is
+// shipped, has the canonical body, and is enrolled in the rule-copy checker.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const root = path.join(__dirname, '..');
+const KILOCODE_RULE = '.kilocode/rules/ponytail.md';
+const CLINE_RULE = '.clinerules/ponytail.md';
+
+function read(rel) {
+  return fs.readFileSync(path.join(root, rel), 'utf8').replace(/\r\n/g, '\n').trim();
+}
+
+test('kilocode adapter file exists with the canonical compact body', () => {
+  assert.equal(read(KILOCODE_RULE), read(CLINE_RULE));
+});
+
+test('check-rule-copies enrolls the kilocode adapter', () => {
+  const script = read('scripts/check-rule-copies.js');
+  assert.ok(script.includes(KILOCODE_RULE), 'kilocode path missing from check-rule-copies.js');
+  execFileSync(process.execPath, [path.join(root, 'scripts/check-rule-copies.js')], { stdio: 'pipe' });
+});


### PR DESCRIPTION
Adds Kilo Code as an instruction-tier adapter: ships `.kilocode/rules/ponytail.md` with the canonical compact body, enrolls it in `check-rule-copies.js`, and documents the project/global install paths in `docs/agent-portability.md` and the README.

The branch is rebased onto current `main`; the README conflict preserves the newer host list while adding Kilo Code. The unrelated accidental `DeepSeek-TUI` gitlink from the original commit is absent from the final diff.

## Test verification (RED → GREEN)

With the adapter files/checker enrollment absent, the focused regression test failed as expected:

```text
# tests 2
# pass 0
# fail 2
error: kilocode path missing from check-rule-copies.js
```

With the adapter applied:

```text
# tests 2
# pass 2
# fail 0
```

Full validation:

```text
node scripts/check-rule-copies.js  # pass
node scripts/check-versions.js     # pass
npm test                           # 86 root + 23 Pi + 3 MCP tests pass
diff coverage                      # 100% (28/28 changed executable lines)
GitHub Actions test                # pass on be2b9fc
```

Fix #300
