### PR TITLE
fix(benchmark): reject --ollama-url without a host (follow-up to #274)

### DIFF
--- a/benchmarks/benchmark-local.py
+++ b/benchmarks/benchmark-local.py
@@ -154,6 +154,8 @@ def main():
     parsed_url = urllib.parse.urlparse(args.ollama_url)
     if parsed_url.scheme not in ("http", "https"):
         parser.error(f"Invalid --ollama-url scheme: '{parsed_url.scheme}'. Only 'http' and 'https' are supported.")
+    if not parsed_url.netloc:
+        parser.error(f"--ollama-url must include a host, e.g. http://localhost:11434 (got '{args.ollama_url}').")
 
     run(args.model, args.repeat, args.ollama_url)
 


### PR DESCRIPTION
Follow-up to #274 (which closed #166 by validating the `--ollama-url` scheme).

#274 checks the scheme but not the host, so a host-less URL like `http://` or `https://` passes validation and only fails later inside `urlopen()` with an opaque stack trace. When you closed my #212 you noted that version was *"slightly tighter — you also rejected URLs with no host"* — this adds exactly that, as a minimal **additive** check that leaves the existing scheme error untouched.

**Change:** one `if not parsed_url.netloc:` guard after the scheme check.

**Verified** (with `run()` stubbed, so no network):

| URL | Result |
|---|---|
| `http://localhost:11434` | ACCEPT |
| `https://ollama.example.com:443` | ACCEPT |
| `http://` , `https://` | REJECT — "must include a host" (new) |
| `file:///etc/passwd` , `localhost:11434` , `not-a-url` | REJECT — scheme error (unchanged) |

Stdlib-only; `npm test` unaffected (Python-only change).
