### PR TITLE
Add Devin CLI plugin configuration

### DIFF
--- a/.devin-plugin/plugin.json
+++ b/.devin-plugin/plugin.json
@@ -1,0 +1,13 @@
+{
+  "name": "ponytail",
+  "version": "4.8.3",
+  "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
+  "author": {
+    "name": "Dietrich Gebert",
+    "url": "https://github.com/DietrichGebert"
+  },
+  "homepage": "https://github.com/DietrichGebert/ponytail",
+  "repository": "https://github.com/DietrichGebert/ponytail",
+  "license": "MIT",
+  "keywords": ["yagni", "minimalism", "code-review", "productivity"]
+}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
   <img src="https://img.shields.io/github/stars/DietrichGebert/ponytail?style=flat-square&color=111111&label=stars" alt="Stars">
   <img src="https://img.shields.io/github/v/release/DietrichGebert/ponytail?style=flat-square&color=111111&label=release" alt="Release">
   <img src="https://img.shields.io/npm/v/@dietrichgebert/ponytail?style=flat-square&color=111111&label=npm" alt="npm">
-  <img src="https://img.shields.io/badge/works%20with-14%20agents-111111?style=flat-square" alt="Works with 14 agents">
+  <img src="https://img.shields.io/badge/works%20with-15%20agents-111111?style=flat-square" alt="Works with 15 agents">
   <img src="https://img.shields.io/badge/license-MIT-111111?style=flat-square" alt="MIT license">
 </p>
 
@@ -217,6 +217,14 @@ Swival also reads `AGENTS.md` from the project root and `~/.config/swival/AGENTS
 
 On the command line, use a `$` prefix to explicitly activate a skill. For example: `$ponytail-review`.
 
+### Devin CLI
+
+```bash
+devin plugins install DietrichGebert/ponytail
+```
+
+Installs ponytail as a Devin plugin; skills are available as `/ponytail:ponytail`, `/ponytail:ponytail-review`, and so on.
+
 ### OpenClaw
 
 ```bash
@@ -247,6 +255,7 @@ Which files map to which agent: [Agent portability](docs/agent-portability.md).
 |------|---------|
 | Claude Code | `/plugin remove ponytail` |
 | Codex | `codex plugin remove ponytail` |
+| Devin CLI | `devin plugins remove ponytail` |
 | Pi agent | `pi uninstall ponytail` |
 | Cursor / Windsurf / Cline / etc. | Delete the copied rule file |
 
@@ -263,7 +272,7 @@ These remove the plugin's own files. They leave behind a small amount of state p
 | `/ponytail-gain` | Show the measured impact scoreboard (less code, less cost, more speed) from the benchmark. |
 | `/ponytail-help` | Quick reference for the commands above. |
 
-Commands need a skill-capable host (Claude Code, Codex, OpenCode, Gemini, pi, Swival). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
+Commands need a skill-capable host (Claude Code, Codex, Devin CLI, OpenCode, Gemini, pi, Swival). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
 
 ## Development
 

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Version-consistency guard. Ponytail declares its version in six files across
-// four host ecosystems, and every release bumps all of them by hand.
+// Version-consistency guard. Ponytail declares its version in seven files across
+// five host ecosystems, and every release bumps all of them by hand.
 //
 // tests/gemini-extension.test.js already checks the four plugin manifests agree
 // with each other, but that can't catch the failure mode that shipped in v4.8.0:
@@ -19,12 +19,13 @@ const PINNED_SEMVER = /^\d+\.\d+\.\d+$/;
 // Every file that declares the project version, and who reads it. Add new host
 // manifests here so a future ecosystem can't drift unnoticed.
 const VERSION_FILES = [
-  '.claude-plugin/plugin.json', // Claude Code plugin — what users install
-  '.codex-plugin/plugin.json',  // Codex plugin
-  '.github/plugin/plugin.json', // Copilot plugin
-  'gemini-extension.json',      // Gemini CLI extension
-  'package.json',               // pi-package / repo root
-  'ponytail-mcp/package.json',  // MCP server (private, internal-only)
+  '.claude-plugin/plugin.json',  // Claude Code plugin — what users install
+  '.codex-plugin/plugin.json',   // Codex plugin
+  '.devin-plugin/plugin.json',   // Devin CLI plugin
+  '.github/plugin/plugin.json',  // Copilot plugin
+  'gemini-extension.json',       // Gemini CLI extension
+  'package.json',                // pi-package / repo root
+  'ponytail-mcp/package.json',   // MCP server (private, internal-only)
 ];
 
 function readVersion(relPath) {


### PR DESCRIPTION
Add Devin CLI plugin manifest

Adds `.devin-plugin/plugin.json` so the plugin can be installed with `devin plugins install DietrichGebert/ponytail`. The skills/ directory is already at the repo root, which is exactly where Devin expects it.

Registers the new manifest in `scripts/check-versions.js` so it stays in sync with every other host manifest on release.

Updates README: install/uninstall instructions, badge (14 → 15 agents), and Devin added to the skill-capable hosts list in Commands.