### PR TITLE
fix: add pi status hide config

### DIFF
--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -8,6 +8,8 @@
 //      - ~/.config/ponytail/config.json (macOS / Linux fallback)
 //      - %APPDATA%\ponytail\config.json (Windows fallback)
 //   3. 'full'
+//
+// Status indicator hiding uses PONYTAIL_HIDE_STATUS=1 or config.hideStatus=true.
 
 const fs = require('fs');
 const path = require('path');
@@ -95,13 +97,26 @@ function getDefaultMode() {
   return DEFAULT_MODE;
 }
 
+function getHideStatus() {
+  if (process.env.PONYTAIL_HIDE_STATUS === '1') return true;
+
+  try {
+    const config = JSON.parse(fs.readFileSync(getConfigPath(), 'utf8'));
+    return config.hideStatus === true;
+  } catch (e) {
+    return false;
+  }
+}
+
 function writeDefaultMode(mode) {
   const normalized = normalizeConfigMode(mode);
   if (!normalized) return null;
 
   const configPath = getConfigPath();
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
-  fs.writeFileSync(configPath, JSON.stringify({ defaultMode: normalized }, null, 2), 'utf8');
+  let config = {};
+  try { config = JSON.parse(fs.readFileSync(configPath, 'utf8')); } catch (e) {}
+  fs.writeFileSync(configPath, JSON.stringify({ ...config, defaultMode: normalized }, null, 2), 'utf8');
   return normalized;
 }
 
@@ -113,6 +128,7 @@ module.exports = {
   getConfigDir,
   getConfigPath,
   getClaudeDir,
+  getHideStatus,
   isShellSafe,
   normalizeMode,
   normalizeConfigMode,

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -4,6 +4,7 @@ const require = createRequire(import.meta.url);
 const {
   DEFAULT_MODE,
   getDefaultMode,
+  getHideStatus,
   normalizeMode,
   normalizeConfigMode,
   normalizePersistedMode,
@@ -56,6 +57,7 @@ export { writeDefaultMode };
 export default function ponytailExtension(pi) {
   let currentMode = DEFAULT_MODE;
   let configuredDefaultMode = getDefaultMode();
+  let hideStatus = getHideStatus();
   let isActive = false;
   let lastCtx = null;
 
@@ -63,6 +65,7 @@ export default function ponytailExtension(pi) {
   function syncStatus(ctx) {
     if (ctx) lastCtx = ctx;
     const c = ctx || lastCtx;
+    if (hideStatus) return;
     if (!c?.ui?.setStatus || !c.ui.theme?.fg) return;
     const theme = c.ui.theme;
     if (currentMode === "off") {
@@ -167,6 +170,7 @@ export default function ponytailExtension(pi) {
   pi.on("session_start", async (_event, ctx) => {
     const entries = ctx?.sessionManager?.getBranch?.() || ctx?.sessionManager?.getEntries?.() || [];
     configuredDefaultMode = getDefaultMode();
+    hideStatus = getHideStatus();
     currentMode = resolveSessionMode(entries, configuredDefaultMode);
     syncStatus(ctx);
     ctx?.ui?.notify?.(`Ponytail loaded: ${currentMode}`, "info");

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -43,13 +43,17 @@ function createCommandContext(overrides = {}) {
 function withTempConfig(fn) {
   const tempConfigHome = mkdtempSync(join(tmpdir(), "ponytail-test-"));
   const previousXdg = process.env.XDG_CONFIG_HOME;
+  const previousHideStatus = process.env.PONYTAIL_HIDE_STATUS;
   process.env.XDG_CONFIG_HOME = tempConfigHome;
+  delete process.env.PONYTAIL_HIDE_STATUS;
 
   return Promise.resolve()
     .then(fn)
     .finally(() => {
       if (previousXdg === undefined) delete process.env.XDG_CONFIG_HOME;
       else process.env.XDG_CONFIG_HOME = previousXdg;
+      if (previousHideStatus === undefined) delete process.env.PONYTAIL_HIDE_STATUS;
+      else process.env.PONYTAIL_HIDE_STATUS = previousHideStatus;
       rmSync(tempConfigHome, { recursive: true, force: true });
     });
 }
@@ -164,4 +168,21 @@ test("status bar stays silent when ui lacks a theme", async () => withTempConfig
   await events.get("agent_start")({}, ctx);
 
   assert.deepEqual(calls, []);
+}));
+
+test("status bar can be hidden while instructions stay active", async () => withTempConfig(async () => {
+  mkdirSync(join(process.env.XDG_CONFIG_HOME, "ponytail"), { recursive: true });
+  writeFileSync(join(process.env.XDG_CONFIG_HOME, "ponytail", "config.json"), JSON.stringify({ hideStatus: true }));
+  const { events } = createPiHarness();
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_color, text) => text } },
+  });
+
+  await events.get("session_start")({ reason: "startup" }, ctx);
+  await events.get("agent_start")({}, ctx);
+  const injected = await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx);
+
+  assert.deepEqual(statusWrites, []);
+  assert.match(injected.systemPrompt, /PONYTAIL MODE ACTIVE/);
 }));

--- a/pi-extension/test/helpers.test.js
+++ b/pi-extension/test/helpers.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -52,6 +52,10 @@ test("readDefaultMode and writeDefaultMode use XDG config path", () => {
     assert.equal(readDefaultMode(), "ultra");
     assert.ok(existsSync(configPath));
     assert.deepEqual(JSON.parse(readFileSync(configPath, "utf8")), { defaultMode: "ultra" });
+
+    writeFileSync(configPath, JSON.stringify({ defaultMode: "lite", hideStatus: true }));
+    assert.equal(writeDefaultMode("full"), "full");
+    assert.deepEqual(JSON.parse(readFileSync(configPath, "utf8")), { defaultMode: "full", hideStatus: true });
   } finally {
     if (previousXdg === undefined) delete process.env.XDG_CONFIG_HOME;
     else process.env.XDG_CONFIG_HOME = previousXdg;


### PR DESCRIPTION
## Summary
- Add `PONYTAIL_HIDE_STATUS=1` and `hideStatus: true` config support for the Pi status indicator.
- Keep mode tracking and instruction injection active when the indicator is hidden.
- Preserve `hideStatus` when updating the saved default mode.

## Testing
- [x] `npm test --prefix pi-extension`
- [x] `npm test`
- [x] `node scripts/check-rule-copies.js`
- [x] `node scripts/check-versions.js`
- [x] `git diff --check`

Closes #324
