### PR TITLE
feat: add Kiro global install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,15 +241,22 @@ clawhub install ponytail
 
 Installs ponytail as an OpenClaw skill from ClawHub; the review, audit, debt, gain, and help skills install the same way (`clawhub install ponytail-review`, and so on). OpenClaw applies it on coding tasks and also exposes it as a `/ponytail` command. Without ClawHub, copy [`.openclaw/skills/ponytail`](.openclaw/skills/) into `~/.openclaw/skills/`.
 
+### Kiro
+
+```bash
+git clone https://github.com/DietrichGebert/ponytail.git
+./ponytail/scripts/install-kiro.sh
+```
+
+Symlinks `.kiro/steering/ponytail.md` into `~/.kiro/steering/` so the ruleset loads globally in every Kiro session. Updates come from `git pull` in the cloned repo. To install per-project instead, copy `.kiro/steering/ponytail.md` into your project's `.kiro/steering/` directory.
+
 That was it. He'd be proud. He won't say it.
 
 Active every session, with a handful of commands (see [Commands](#commands)). `/ponytail ultra` exists for when the codebase has wronged you personally. Startup and mode-change text shows the current mode.
 
 Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`.
 
-Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro, Zed, CodeWhale, Swival: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
-
-Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kiro/steering/` in your project.
+Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Zed, CodeWhale, Swival: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md)).
 
 GitHub Copilot CLI fallback (instruction-only mode): it reads `AGENTS.md` and `.github/copilot-instructions.md` in a project, or copy the rules into `~/.copilot/copilot-instructions.md` to run ponytail in every project. This path keeps always-on guidance, but does not add plugin mode switches or hooks.
 
@@ -265,6 +272,7 @@ Which files map to which agent: [Agent portability](docs/agent-portability.md).
 | Codex | `codex plugin remove ponytail` |
 | Devin CLI | `devin plugins remove ponytail` |
 | Pi agent | `pi uninstall ponytail` |
+| Kiro | `rm ~/.kiro/steering/ponytail.md` |
 | Cursor / Windsurf / Cline / etc. | Delete the copied rule file |
 
 These remove the plugin's own files. They leave behind a small amount of state ponytail writes outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` to clean those up too. **Run it before the host remove command above** — the script is itself a plugin file, so removing the plugin first deletes it (or run it from a separate clone of this repo). It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched.

--- a/scripts/install-kiro.sh
+++ b/scripts/install-kiro.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Ponytail — Kiro global install script
+# Symlinks the steering file so `git pull` keeps it current.
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+KIRO_STEERING_DIR="$HOME/.kiro/steering"
+SOURCE_FILE="$REPO_DIR/.kiro/steering/ponytail.md"
+TARGET_FILE="$KIRO_STEERING_DIR/ponytail.md"
+
+if [[ ! -f "$SOURCE_FILE" ]]; then
+  echo "Error: $SOURCE_FILE not found. Are you running this from the ponytail repo?" >&2
+  exit 1
+fi
+
+mkdir -p "$KIRO_STEERING_DIR"
+
+if [[ -L "$TARGET_FILE" ]]; then
+  existing=$(readlink "$TARGET_FILE")
+  if [[ "$existing" == "$SOURCE_FILE" ]]; then
+    echo "Already installed (symlink points to this repo). Nothing to do."
+    exit 0
+  fi
+  echo "Replacing existing symlink ($existing) → $SOURCE_FILE"
+  rm "$TARGET_FILE"
+elif [[ -f "$TARGET_FILE" ]]; then
+  echo "Replacing existing file with symlink → $SOURCE_FILE"
+  rm "$TARGET_FILE"
+fi
+
+ln -s "$SOURCE_FILE" "$TARGET_FILE"
+echo "Installed: $TARGET_FILE → $SOURCE_FILE"
+echo ""
+echo "To update: git pull in $REPO_DIR"
+echo "To uninstall: rm $TARGET_FILE"


### PR DESCRIPTION
Adds `scripts/install-kiro.sh` — a one-command installer for the Kiro IDE.

## What it does

Symlinks `.kiro/steering/ponytail.md` from a local clone into `~/.kiro/steering/` so the ruleset loads globally in every Kiro session.

- Idempotent (re-running is a no-op if already linked)
- Updates come from `git pull` — no stale copies
- Uninstall: `rm ~/.kiro/steering/ponytail.md`

## Usage

```bash
git clone https://github.com/DietrichGebert/ponytail.git
./ponytail/scripts/install-kiro.sh
```

Follows the same pattern as the existing Kiro guidance in the README (copy to `~/.kiro/steering/`) but automates it with a symlink for easier maintenance.