### PR TITLE
fix(instructions): add CJK context detection for Chinese/Japanese/Korean conversations

### DIFF
--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -36,7 +36,20 @@ function filterSkillBodyForMode(body, mode) {
     .join('\n');
 }
 
-function getFallbackInstructions(mode) {
+// CJK detection — Chinese, Japanese, Korean Unicode ranges.
+// In CJK contexts, some English-specific style rules don't apply.
+// We add a CJK-specific note to adjust behavior.
+const CJK_RE = /[一-鿿　-〿ぁ-ヶ가-힣]/;
+
+const CJK_NOTE = '\n\n## CJK Context\n\n' +
+  'CJK (Chinese/Japanese/Korean) text detected. Apply these adjustments:\n' +
+  '- Chinese has no articles — do not strip English articles in mixed text (e.g. "a LLM 模型" keeps "a")\n' +
+  '- "Short synonyms" rule applies to English only; CJK characters are already compact\n' +
+  '- Output brevity: 简短回答，不用敬语，不用客套话\n' +
+  '- Code rules (YAGNI, stdlib first, shortest diff) are language-agnostic — apply fully';
+
+function getFallbackInstructions(mode, hasCJK) {
+  const cjkSuffix = hasCJK ? CJK_NOTE : '';
   return 'PONYTAIL MODE ACTIVE — level: ' + mode + '\n\n' +
     'You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.\n\n' +
     '## Persistence\n\n' +
@@ -67,23 +80,26 @@ function getFallbackInstructions(mode) {
     'security measures, accessibility basics, the calibration real hardware needs (the platform is never the spec ideal), anything the user explicitly asked to keep. ' +
     'Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind (assert-based demo/self-check or one small test file; no frameworks). Trivial one-liners need no test.\n\n' +
     '## Boundaries\n\n' +
-    'Ponytail governs what you build, not how you talk. "stop ponytail" or "normal mode": revert. Level persists until changed or session end.';
+    'Ponytail governs what you build, not how you talk. "stop ponytail" or "normal mode": revert. Level persists until changed or session end.' +
+    cjkSuffix;
 }
 
-function getPonytailInstructions(mode) {
+function getPonytailInstructions(mode, inputText) {
   const configuredMode = normalizePersistedMode(mode) || DEFAULT_MODE;
+  const hasCJK = inputText ? CJK_RE.test(inputText) : false;
 
   if (INDEPENDENT_MODES.has(configuredMode)) {
-    return 'PONYTAIL MODE ACTIVE — level: ' + configuredMode + '. Behavior defined by /ponytail-' + configuredMode + ' skill.';
+    return 'PONYTAIL MODE ACTIVE — level: ' + configuredMode + '. Behavior defined by /ponytail-' + configuredMode + ' skill.' + (hasCJK ? CJK_NOTE : '');
   }
 
   const effectiveMode = normalizeMode(configuredMode) || DEFAULT_MODE;
 
   try {
     return 'PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' +
-      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode);
+      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode) +
+      (hasCJK ? CJK_NOTE : '');
   } catch (e) {
-    return getFallbackInstructions(effectiveMode);
+    return getFallbackInstructions(effectiveMode, hasCJK);
   }
 }
 


### PR DESCRIPTION
## Problem

Ponytail's style rules are designed for English-only conversations. In CJK (Chinese/Japanese/Korean) contexts:

1. **"Drop articles" is misleading** — Chinese has no articles, so the instruction can cause the model to strip English articles embedded in Chinese text (e.g. "a LLM 模型" → "LLM 模型"), losing semantic specificity
2. **"Short synonyms" only works in English** — CJK characters are already compact
3. **No CJK brevity guidance** — Chinese users get English examples that don't map to their language patterns

## Fix

Add CJK detection to `getPonytailInstructions()`. When CJK characters are detected in user input, append a CJK Context section:

```
## CJK Context
- Chinese has no articles — do not strip English articles in mixed text
- "Short synonyms" rule applies to English only; CJK characters are already compact
- Output brevity: 简短回答，不用敬语，不用客套话
- Code rules (YAGNI, stdlib first, shortest diff) are language-agnostic — apply fully
```

This mirrors the approach in caveman PR [#576](https://github.com/JuliusBrussee/caveman/pull/576) which adds CJK detection to the compression engine.

The `inputText` parameter to `getPonytailInstructions()` is optional — when not provided, behavior is unchanged (backward compatible).

Fixes #333