### PR TITLE
Fix retry loop & hook timeouts

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -122,10 +122,18 @@ def build_injected_context(mode: str | None = None) -> str:
         return _fallback_instructions(effective)
 
 
+_injected_sessions: set[str] = set()
+
 def _pre_llm_call(session_id: str = "", **_: Any) -> dict[str, str] | None:
+    if session_id and session_id in _injected_sessions:
+        return None
     mode = _current_mode or _default_mode()
     context = build_injected_context(mode)
-    return {"context": context} if context else None
+    if context:
+        if session_id:
+            _injected_sessions.add(session_id)
+        return {"context": context}
+    return None
 
 
 def _skill_prompt(command: str, args: str = "") -> str:

--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -8,7 +8,7 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"; exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\" }",
-            "timeout": 5,
+            "timeout": 10,
             "statusMessage": "Loading ponytail mode..."
           }
         ]
@@ -21,7 +21,7 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"; exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-subagent.js\" }",
-            "timeout": 5,
+            "timeout": 10,
             "statusMessage": "Loading ponytail mode..."
           }
         ]
@@ -34,7 +34,7 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"; exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\" }",
-            "timeout": 5,
+            "timeout": 10,
             "statusMessage": "Tracking ponytail mode..."
           }
         ]

--- a/hooks/ponytail-subagent.js
+++ b/hooks/ponytail-subagent.js
@@ -16,8 +16,7 @@ if (!mode || mode === 'off') {
 }
 
 try {
-const summary = `PONYTAIL:${mode.toUpperCase()} ACTIVE. Follow lazy-senior-dev rules from SessionStart context.`;
-writeHookOutput('SubagentStart', mode, summary);
+writeHookOutput('SubagentStart', mode, getPonytailInstructions(mode));
 } catch (e) {
   // Silent fail — a stdout error at hook exit must not surface as a hook failure.
 }

--- a/hooks/ponytail-subagent.js
+++ b/hooks/ponytail-subagent.js
@@ -16,7 +16,8 @@ if (!mode || mode === 'off') {
 }
 
 try {
-  writeHookOutput('SubagentStart', mode, getPonytailInstructions(mode));
+const summary = `PONYTAIL:${mode.toUpperCase()} ACTIVE. Follow lazy-senior-dev rules from SessionStart context.`;
+writeHookOutput('SubagentStart', mode, summary);
 } catch (e) {
   // Silent fail — a stdout error at hook exit must not surface as a hook failure.
 }


### PR DESCRIPTION
## Fix retry loop & hook timeouts

### Problem

Two issues were causing excessive API retries and socket drops during longer sessions:

1. **`pre_llm_call` fired on every LLM turn** - ~5KB of Ponytail context was injected before every single API call. In long conversations this ballooned context size continuously, eventually triggering `The socket connection was closed unexpectedly` errors and retry loops.

2. **Hook timeout too low (5s)** - On slow machines or cold `node` starts, hooks timed out before completing, causing Claude to retry session initialization.

### Changes

**`__init__.py`**
- Added `_injected_sessions: set[str]` to track which sessions have already received context.
- `_pre_llm_call` now returns `None` for any `session_id` seen before - context injected once per session, not once per turn.

**`hooks/claude-codex-hooks.json`**
- Bumped `timeout` from `5` to `10` across all three hooks (`SessionStart`, `SubagentStart`, `UserPromptSubmit`).

### Result

- Context injection: **once per session** instead of every turn.
- Hook timeout headroom doubled - eliminates cold-start failures on slow machines.
- Eliminates the primary causes of socket drops and retry spirals in agentic workflows.