### PR TITLE
fix: statusline setup nudge honors CLAUDE_CONFIG_DIR

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -66,7 +66,7 @@ if (!isCodex && !isCopilot) try {
       output += "\n\n" +
         "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode " +
         "(e.g. [PONYTAIL], [PONYTAIL:ULTRA]). It is not configured yet. " +
-        "To enable, add this to ~/.claude/settings.json: " +
+        "To enable, add this to " + settingsPath + ": " +
         statusLineSnippet + " " +
         "Proactively offer to set this up for the user on first interaction.";
     } else {
@@ -76,7 +76,7 @@ if (!isCodex && !isCopilot) try {
         "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode. " +
         "Its install path contains characters unsafe to embed in a shell command, so configure it manually: " +
         "add a statusLine command of type \"command\" that runs " + scriptName +
-        " from the plugin's hooks directory to ~/.claude/settings.json, quoting/escaping the path for your shell. " +
+        " from the plugin's hooks directory to " + settingsPath + ", quoting/escaping the path for your shell. " +
         "Proactively offer to set this up for the user on first interaction.";
     }
   }

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -133,6 +133,12 @@ assert.equal(
   false,
   'flag must not land in ~/.claude when CLAUDE_CONFIG_DIR is set',
 );
+// The statusline setup nudge must point at the configured settings.json, not a
+// hardcoded ~/.claude (issue #250).
+assert.ok(
+  result.stdout.includes(path.join(customConfigDir, 'settings.json')),
+  'statusline nudge must reference the CLAUDE_CONFIG_DIR settings.json',
+);
 
 const copilotData = path.join(temp, 'copilot-data');
 const codexData = path.join(temp, 'codex-data-shadow');


### PR DESCRIPTION
Fixes #250.

#34 made `ponytail-activate.js` detect a missing statusline in `getClaudeDir()/settings.json` (so it honors `CLAUDE_CONFIG_DIR`), but the user-facing setup nudge still hardcoded `~/.claude/settings.json` in both branches:

- shell-safe: `"To enable, add this to ~/.claude/settings.json: "`
- manual/shell-unsafe: `"...to ~/.claude/settings.json, quoting/escaping the path for your shell."`

So when `CLAUDE_CONFIG_DIR` points elsewhere, ponytail correctly notices the missing statusline in the custom dir, then tells the user (and the agent) to write the config into `~/.claude/settings.json` — the wrong file. The badge never activates and the agent edits a file Claude Code is not reading.

This points the nudge at the `settingsPath` the hook already computes, so it matches where the statusline is actually detected. Sibling to the read-path fix in #154.

Verified: extended the existing `CLAUDE_CONFIG_DIR` test to assert the nudge references `<CLAUDE_CONFIG_DIR>/settings.json`. Full suite green; no behavior change when `CLAUDE_CONFIG_DIR` is unset (nudge then resolves to the home `~/.claude/settings.json` path as before).