### PR TITLE
fix(benchmarks): match CRLF code fences in loc.js

### DIFF
--- a/benchmarks/loc.js
+++ b/benchmarks/loc.js
@@ -3,7 +3,9 @@
 // Recorded as the `code_loc` metric per arm (always passes; it is a measurement, not a gate).
 module.exports = (output) => {
   const text = String(output || '');
-  const blocks = [...text.matchAll(/```[a-zA-Z0-9_+-]*\n([\s\S]*?)```/g)].map((m) => m[1]);
+  // \r? so CRLF fences match too; without it, CRLF output finds no block and
+  // the whole response (prose included) gets counted. Mirrors correctness.js.
+  const blocks = [...text.matchAll(/```[a-zA-Z0-9_+-]*\r?\n([\s\S]*?)```/g)].map((m) => m[1]);
   // Drop /* ... */ block comments before counting; the line filter below only
   // caught `*`-aligned JSDoc, so plain block comments were miscounted as code.
   const code = (blocks.length ? blocks.join('\n') : text).replace(/\/\*[\s\S]*?\*\//g, '');

--- a/benchmarks/loc.test.js
+++ b/benchmarks/loc.test.js
@@ -13,6 +13,8 @@ const cases = [
   ['inline block comment keeps its code line', score('```js\nconst x = 1; /* note */\nconst y = 2;\n```'), 2],
   ['line comments still stripped', score('```js\n// header\nconst x = 1;\n```'), 1],
   ['plain code unchanged', score('```js\nconst a = 1;\nconst b = 2;\n```'), 2],
+  // CRLF-fenced output must still find the block, not fall back to the whole text.
+  ['crlf fences count only the code', score('Here:\r\n```js\r\nconst a = 1;\r\nconst b = 2;\r\n```\r\nDone.'), 2],
 ];
 for (const [name, got, want] of cases) {
   assert.strictEqual(got, want, `FAILED: ${name} (got ${got}, want ${want})`);


### PR DESCRIPTION
Fixes #339.

`loc.js` extracts code blocks with `/```[a-zA-Z0-9_+-]*
([\s\S]*?)```/g` — no `?` before the `
`, so a CRLF fence (` ```js
 `) never matches. With no block found it falls back to counting the entire response, prose and fence lines included.

`correctness.js` already handles this with `?
`, so on CRLF input the LOC metric and the correctness gate disagree. This aligns `loc.js` with it.

Before:
```
loc(lf)              -> 2   (correct)
loc(lf as CRLF)      -> 6   (counts prose + fences)
```
After: both score 2.

Added a CRLF case to `benchmarks/loc.test.js` (now 6/6). LF input is unaffected; one-token regex change.