### PR TITLE
fix: add missing trailing period to review skill assertion

### DIFF
--- a/tests/hermes-plugin.test.js
+++ b/tests/hermes-plugin.test.js
@@ -147,7 +147,7 @@ print(json.dumps({'ctx': ctx}))
   const { ctx } = JSON.parse(output);
   assert.match(ctx, /PONYTAIL MODE ACTIVE — level: review/);
   assert.match(ctx, /Review diffs for unnecessary complexity/);
-  assert.match(ctx, /net: -<N> lines possible/);
+  assert.match(ctx, /net: -<N> lines possible\./);
   assert.doesNotMatch(ctx, /^---/);
 });
 


### PR DESCRIPTION
In `tests/hermes-plugin.test.js`, the regex for matching the review skill's net-lines output was missing the trailing period that actually exists in `skills/ponytail-review/SKILL.md`.

```diff
- assert.match(ctx, /net: -<N> lines possible/);
+ assert.match(ctx, /net: -<N> lines possible\./);
```

Closes #349