### PR TITLE
fix: add plugin.yaml and pi-extension/package.json to VERSION_FILES

### DIFF
--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
-// Version-consistency guard. Ponytail declares its version in seven files across
-// five host ecosystems, and every release bumps all of them by hand.
+// Version-consistency guard. Ponytail declares its version in nine files across
+// six host ecosystems, and every release bumps all of them by hand.
 //
 // tests/gemini-extension.test.js already checks the four plugin manifests agree
 // with each other, but that can't catch the failure mode that shipped in v4.8.0:
@@ -25,6 +25,8 @@ const VERSION_FILES = [
   '.github/plugin/plugin.json',  // Copilot plugin
   'gemini-extension.json',       // Gemini CLI extension
   'package.json',                // pi-package / repo root
+  'pi-extension/package.json',   // pi-agent harness extension
+  'plugin.yaml',                 // Hermes plugin manifest
   'ponytail-mcp/package.json',   // MCP server (private, internal-only)
 ];
 


### PR DESCRIPTION
These two version-bearing files were missing from the `check-versions.js` consistency check, creating the exact drift scenario that issues #260/#262 were filed for.

Changes:
- Add `plugin.yaml` (Hermes manifest) to `VERSION_FILES`
- Add `pi-extension/package.json` to `VERSION_FILES`
- Update comment count from 7 to 9 files

Closes #348