### PR TITLE
fix: align plugin.yaml author field with package.json

### DIFF
--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,7 +1,7 @@
 name: ponytail
 version: 4.8.3
 description: Lazy senior dev mode for Hermes Agent, always-on context, bundled skills, and slash commands.
-author: Salaamdev
+author: Dietrich Gebert
 provides_hooks:
   - pre_llm_call
   - pre_gateway_dispatch


### PR DESCRIPTION
The `plugin.yaml` had `author: Salaamdev` while `package.json` has `"author": { "name": "Dietrich Gebert" }`. This aligns the two.

Closes #343