### PR TITLE
fix: correct relative import paths for npm-installed opencode plugin

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -19,8 +19,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // The shared instruction builder is CommonJS; bridge to it from this ES module.
 const require = createRequire(import.meta.url);
-const { getPonytailInstructions } = require('../../hooks/ponytail-instructions');
-const { getDefaultMode, normalizePersistedMode } = require('../../hooks/ponytail-config');
+const { getPonytailInstructions } = require('../hooks/ponytail-instructions');
+const { getDefaultMode, normalizePersistedMode } = require('../hooks/ponytail-config');
 
 // OpenCode has no flag-file convention of its own; keep mode beside its config.
 const statePath = path.join(


### PR DESCRIPTION
In `.opencode/plugins/ponytail.mjs`, the require paths used `../../hooks/` which resolves outside the package root when installed via npm. Changed to `../hooks/` which works in both checkout and npm-install contexts.