### PR TITLE
fix: handle /ponytail:review (colon form) for review mode

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -21,7 +21,7 @@ process.stdin.on('end', () => {
 
       let mode = null;
 
-      if (cmd === '/ponytail-review' || cmd === '/ponytail:ponytail-review') {
+      if (cmd === '/ponytail-review' || cmd === '/ponytail:review') {
         mode = 'review';
       } else if (cmd === '/ponytail' || cmd === '/ponytail:ponytail') {
         if (arg === 'lite') mode = 'lite';


### PR DESCRIPTION
Previously '/ponytail:review' fell through to getDefaultMode() instead of activating review mode — the condition checked for '/ponytail:ponytail-review' (wrong pattern, also unreachable). Now correctly matches '/ponytail:review'.

Also removes the unreachable `/ponytail:ponytail-review` disjunct that could never be matched.

Closes #361