### PR TITLE
fix: remove false claim that pi-extension exposes ponytail: skill aliases

### DIFF
--- a/after-install.md
+++ b/after-install.md
@@ -19,4 +19,4 @@ Commands:
 - `/ponytail-gain`
 - `/ponytail-help`
 
-Bundled skills are available as `ponytail:ponytail`, `ponytail:ponytail-review`, `ponytail:ponytail-audit`, `ponytail:ponytail-debt`, `ponytail:ponytail-gain`, and `ponytail:ponytail-help`.
+Commands are available as the slash commands listed above (e.g. /ponytail, /ponytail-review).


### PR DESCRIPTION
The pi-extension only registers slash commands (e.g. /ponytail), not skill-style aliases (ponytail:ponytail). The claim in after-install.md was inaccurate.

Closes #364