### PR TITLE
fix: add 'rate limiting' to identifyTask for correctness gate

### DIFF
--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -28,7 +28,7 @@ function identifyTask(task) {
   if (t.includes('debounce')) return 'debounce';
   if (t.includes('csv') && t.includes('sum')) return 'csv';
   if (t.includes('countdown') && t.includes('react')) return 'countdown';
-  if (t.includes('rate limit') || t.includes('rate-limit')) return 'ratelimit';
+  if (t.includes('rate limit') || t.includes('rate-limit') || t.includes('rate limiting')) return 'ratelimit';
   return null;
 }
 


### PR DESCRIPTION
The benchmark prompt uses 'rate limiting' (with ING) but identifyTask only checked 'rate limit' and 'rate-limit'. The correctness gate was silently skipped for rate limit tasks.

Closes #372