### PR TITLE
fix: only delete ponytail's own statusLine.command not the whole key

### DIFF
--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -31,7 +31,7 @@ try {
   // "ponytail-statusline" gets removed wholesale. Parse out only ponytail's part
   // if combined statuslines become common.
   if (typeof cmd === 'string' && cmd.includes('ponytail-statusline')) {
-    delete settings.statusLine;
+    delete settings.statusLine.command;
     fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
     console.log(`Removed ponytail statusLine entry from ${settingsPath}`);
   }


### PR DESCRIPTION
Previously uninstall deleted the entire statusLine key when it found 'ponytail-statusline' in the command string. Combined statuslines (e.g. caveman+ponytail) would lose other plugins' statuslines. Now only deletes the command field.

Closes #374