### PR TITLE
fix: copilot-plugin test checks all 6 command files

### DIFF
--- a/tests/copilot-plugin.test.js
+++ b/tests/copilot-plugin.test.js
@@ -13,6 +13,8 @@ const REQUIRED_COMMAND_FILES = [
   'ponytail-review.toml',
   'ponytail-audit.toml',
   'ponytail-debt.toml',
+  'ponytail-gain.toml',
+  'ponytail-help.toml',
 ];
 
 function readJSON(relPath) {


### PR DESCRIPTION
Previously only checked 4 of 6 command files (missing ponytail-gain.toml and ponytail-help.toml). Now validates all 6.

Closes #381