### PR TITLE
fix: add error handling to setMode + check all 6 copilot commands

### DIFF
--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -13,8 +13,12 @@ if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA;
 const statePath = path.join(stateDir, STATE_FILE);
 
 function setMode(mode) {
-  fs.mkdirSync(path.dirname(statePath), { recursive: true });
-  fs.writeFileSync(statePath, mode);
+  try {
+    fs.mkdirSync(path.dirname(statePath), { recursive: true });
+    fs.writeFileSync(statePath, mode);
+  } catch (e) {
+    // Fail silently rather than crash the hook
+  }
 }
 
 function clearMode() {

--- a/tests/copilot-plugin.test.js
+++ b/tests/copilot-plugin.test.js
@@ -13,6 +13,8 @@ const REQUIRED_COMMAND_FILES = [
   'ponytail-review.toml',
   'ponytail-audit.toml',
   'ponytail-debt.toml',
+  'ponytail-gain.toml',
+  'ponytail-help.toml',
 ];
 
 function readJSON(relPath) {


### PR DESCRIPTION
Two fixes:
- `hooks/ponytail-runtime.js`: wrap setMode writeFileSync in try/catch so disk full/permission errors don't crash the hook (Closes #378)
- `tests/copilot-plugin.test.js`: check all 6 TOML files, not just 4 (Closes #381)