### PR TITLE
fix: add 'review' to RUNTIME_MODES so normalizeMode accepts it

### DIFF
--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -15,7 +15,7 @@ const os = require('os');
 
 const DEFAULT_MODE = 'full';
 const VALID_MODES = ['off', 'lite', 'full', 'ultra', 'review'];
-const RUNTIME_MODES = ['off', 'lite', 'full', 'ultra'];
+const RUNTIME_MODES = ['off', 'lite', 'full', 'ultra', 'review'];
 
 function normalizeMode(mode) {
   if (typeof mode !== 'string') return null;


### PR DESCRIPTION
Previously VALID_MODES included 'review' but RUNTIME_MODES did not. Setting PONYTAIL_DEFAULT_MODE=review passed config validation but normalizeMode('review') returned null, silently falling back to 'full'. Now 'review' is consistently accepted in both contexts.

Closes #377