### PR TITLE
fix: add main and exports to ponytail-mcp/package.json

### DIFF
--- a/ponytail-mcp/package.json
+++ b/ponytail-mcp/package.json
@@ -2,6 +2,10 @@
   "name": "ponytail-mcp",
   "version": "4.8.3",
   "description": "MCP server that serves Ponytail's lazy-senior-dev instructions as a prompt and a tool.",
+  "main": "./index.js",
+  "exports": {
+    ".": "./index.js"
+  },
   "private": true,
   "type": "module",
   "license": "MIT",


### PR DESCRIPTION
Adds proper `main` and `exports` field so the MCP server package can be imported via npm module resolution.

Closes #390