### PR TITLE
fix: add commands/ to npm package files array

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "AGENTS.md",
+    "commands/",
     "hooks/",
     "skills/",
     ".opencode/",


### PR DESCRIPTION
## Bug

`package.json` `files` array does not include `commands/`. The `commands/` directory contains TOML command files (`ponytail.toml`, `ponytail-review.toml`, etc.) needed by Gemini CLI and Claude Code.

When a user installs `@dietrichgebert/ponytail` from npm, `commands/` is excluded from the installed package, breaking both hosts.

## Fix

Add `commands/` to the `files` array in `package.json`.