### PR TITLE
fix: add commands/ to npm files array; align gemini-extension.test.js…

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "files": [
     "AGENTS.md",
+    "commands/",
     "hooks/",
     "skills/",
     ".opencode/",

--- a/tests/gemini-extension.test.js
+++ b/tests/gemini-extension.test.js
@@ -20,7 +20,10 @@ const VERSIONED_MANIFESTS = [
   'gemini-extension.json',
   '.claude-plugin/plugin.json',
   '.codex-plugin/plugin.json',
+  '.devin-plugin/plugin.json',
   '.github/plugin/plugin.json',
+  'package.json',
+  'ponytail-mcp/package.json',
 ];
 // Gemini auto-discovers these by directory; the manifest is only useful if they exist.
 const REUSED_COMMANDS = ['commands/ponytail.toml', 'commands/ponytail-review.toml'];


### PR DESCRIPTION
… VERSIONED_MANIFESTS with check-versions.js

- package.json: commands/ was missing from files, breaking npm installs (Gemini CLI and Claude Code TOML commands not shipped)
- tests/gemini-extension.test.js: VERSIONED_MANIFESTS was missing .devin-plugin/plugin.json, package.json, and ponytail-mcp/package.json