### PR TITLE
Fix wrong npm package name in update instructions

### DIFF
--- a/skills/ponytail-help/SKILL.md
+++ b/skills/ponytail-help/SKILL.md
@@ -62,7 +62,7 @@ Resolution: env var > config file > `full`.
 
 Enable auto-update once: open `/plugin`, go to Marketplaces, pick ponytail, Enable auto-update. Claude Code then pulls new versions at startup (run `/reload-plugins` when it prompts). Manual refresh: `/plugin marketplace update ponytail` then `/reload-plugins`.
 
-If `/plugin` is not recognized, your Claude Code is out of date. Update it (`npm install -g @anthropic-ai/claude-code@latest`, or `brew upgrade claude-code`) and restart. Other hosts use their own update flow.
+If `/plugin` is not recognized, your Claude Code is out of date. Update it (`npm install -g @anthropic-ai/code@latest`, or `brew upgrade claude-code`) and restart. Other hosts use their own update flow.
 
 ## More
 


### PR DESCRIPTION
Fixes the npm package name in the update instructions from the non-existent `@anthropic-ai/claude-code` to the correct `@anthropic-ai/code`.

See issue #404.