### PR TITLE
fix: three benchmark bugs

### DIFF
--- a/benchmarks/agentic/tasks.py
+++ b/benchmarks/agentic/tasks.py
@@ -25,7 +25,7 @@ from pathlib import Path
 
 # Real-repo fixture: tiangolo/full-stack-fastapi-template @ cd83fc1 (v0.10.0, MIT), cloned locally.
 # Reproduce: git clone https://github.com/tiangolo/full-stack-fastapi-template && git -C ... checkout cd83fc1
-_TMPL = r"D:\dev\fullstack-fastapi-template"
+_TMPL = os.environ.get("PONYTASK_TEMPLATE_DIR") or r"D:\dev\fullstack-fastapi-template"
 
 # --- helpers ---
 _imp_n = 0

--- a/benchmarks/benchmark-local.py
+++ b/benchmarks/benchmark-local.py
@@ -41,7 +41,8 @@ def count_loc(text):
     """Non-blank, non-comment lines of code: fenced blocks, or the whole
     response when the model emitted bare code with no fence."""
     blocks = re.findall(r"```[a-zA-Z0-9_+\-]*\n([\s\S]*?)```", text)
-    lines = ("\n".join(blocks) if blocks else text).splitlines()
+    code = ("\n".join(blocks) if blocks else text).replace(/\/\*[\s\S]*?\*\//g, '')
+    lines = code.splitlines()
     return sum(
         1 for l in lines
         if l.strip()

--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -250,6 +250,7 @@ else:
     const hasFastAPI = /fastapi|FastAPI|app\s*=|@app\./.test(src);
 
     const failures = [];
+    if (!hasTimeTracking) failures.push('no time tracking (time./datetime/asyncio)');
     if (!hasLimitLogic) failures.push('no rate limit logic');
     if (!hasFastAPI) failures.push('no FastAPI usage');
 


### PR DESCRIPTION
## Summary

Three bugs found and fixed in the benchmark code:

### 1. benchmarks/correctness.js - hasTimeTracking defined but never used

**Before:** hasTimeTracking was computed but never added to the failures array in the ratelimit checker.

**After:** hasTimeTracking is now checked alongside hasLimitLogic and hasFastAPI.

### 2. benchmarks/agentic/tasks.py - _TMPL hardcoded Windows path

**Before:** _TMPL was hardcoded to D:\dev\fullstack-fastapi-template, breaking fixture tasks on non-Windows machines.

**After:** _TMPL falls back to the hardcoded path but can be overridden with PONYTASK_TEMPLATE_DIR environment variable.

### 3. benchmarks/benchmark-local.py - count_loc doesnt strip inline block comments

**Before:** count_loc only removed lines starting with block comment markers, but not inline /* ... */ within a line.

**After:** Adds .replace(/\/\*[\s\S]*?\*\//g, '') to strip all block comments before counting lines.

Co-Authored-By: Claude <noreply@anthropic.com>