### PR TITLE
fix: guard before_agent_start against missing event

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -183,7 +183,7 @@ export default function ponytailExtension(pi) {
   });
 
   pi.on("before_agent_start", async (event) => {
-    if (!currentMode || currentMode === "off") return;
+    if (!currentMode || currentMode === "off" || !event) return;
     return { systemPrompt: `${event.systemPrompt}\n\n${getPonytailInstructions(currentMode)}` };
   });
 }

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -77,6 +77,16 @@ test("/ponytail updates session mode and injects instructions", async () => with
   assert.ok(result.systemPrompt.includes("ultra"));
 }));
 
+test("before_agent_start ignores missing event", async () => withTempConfig(async () => {
+  const { events } = createPiHarness();
+  const ctx = createCommandContext();
+
+  await events.get("session_start")({ reason: "startup" }, ctx);
+
+  assert.equal(await events.get("before_agent_start")(undefined, ctx), undefined);
+  assert.equal(await events.get("before_agent_start")(null, ctx), undefined);
+}));
+
 test("session_start restores latest persisted mode", async () => withTempConfig(async () => {
   const { events } = createPiHarness();
   const ctx = createCommandContext({


### PR DESCRIPTION
Fixes #439

This adds a null/undefined guard in the pi-extension `before_agent_start` handler so the extension does not crash if the Pi runtime invokes the hook without an event object.

The change intentionally only handles a missing event object. Handling a missing `event.systemPrompt` is left for #440.

Tested with:

```bash
cd pi-extension
npm test
```

Result:

```text
16 pass
0 fail
```
