### PR TITLE
Trigger ponytail skill on any coding task, not just keywords

### DIFF
--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ponytail
-description: "Lazy senior dev mode. Forces the simplest, shortest solution that works: YAGNI, stdlib first, no unrequested abstractions."
+description: "Lazy senior dev mode for any coding task (write, refactor, fix, review): YAGNI, stdlib first, no unrequested abstractions. Not for non-coding requests."
 homepage: https://github.com/DietrichGebert/ponytail
 license: MIT
 ---

--- a/scripts/build-openclaw-skills.js
+++ b/scripts/build-openclaw-skills.js
@@ -17,7 +17,7 @@ const ROOT = path.join(__dirname, '..');
 const HOMEPAGE = 'https://github.com/DietrichGebert/ponytail';
 
 const DESCRIPTIONS = {
-  'ponytail': 'Lazy senior dev mode. Forces the simplest, shortest solution that works: YAGNI, stdlib first, no unrequested abstractions.',
+  'ponytail': 'Lazy senior dev mode for any coding task (write, refactor, fix, review): YAGNI, stdlib first, no unrequested abstractions. Not for non-coding requests.',
   'ponytail-review': 'Review a diff for over-engineering. Finds what to delete: reinvented stdlib, needless deps, speculative abstractions. One line per finding.',
   'ponytail-audit': 'Audit the whole repo for over-engineering. A ranked list of what to delete, simplify, or replace with stdlib or native features.',
   'ponytail-debt': 'Harvest every ponytail: shortcut comment into one debt ledger, so deferrals get tracked instead of forgotten. One-shot report.',

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -5,11 +5,14 @@ description: >
   minimal. Channels a senior dev who has seen everything: question whether the
   task needs to exist at all (YAGNI), reach for the standard library before
   custom code, native platform features before dependencies, one line before
-  fifty. Supports intensity levels: lite, full (default), ultra. Use whenever
-  the user says "ponytail", "be lazy", "lazy mode", "simplest solution",
-  "minimal solution", "yagni", "do less", or "shortest path", and whenever
-  they complain about over-engineering, bloat, boilerplate, or unnecessary
-  dependencies.
+  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
+  coding task: writing, adding, refactoring, fixing, reviewing, or designing
+  code, and choosing libraries or dependencies. Also use whenever the user
+  says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
+  solution", "yagni", "do less", or "shortest path", or complains about
+  over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
+  use for non-coding requests (general knowledge, prose, translation,
+  summaries, recipes).
 argument-hint: "[lite|full|ultra]"
 license: MIT
 ---


### PR DESCRIPTION
## Problem

The ponytail skill's frontmatter `description` was written keyword-first ("use whenever the user says lazy / complains about boilerplate"). A model-invoked host (the conditional, API-level way to ship the skill) reads only the name + description to decide whether to load it. With the old wording it only fired on prompts that hit those keywords and **skipped plain coding tasks** like "add a date picker", "write a dedupe function", "build a cache", "fix this bug", the exact over-build cases ponytail is best at.

## Test

Skill-router proxy: a model given only the skill name + description, 12 labeled prompts (6 coding, 6 non-coding), 3 runs each.

| | recall (coding loaded) | precision (non-coding skipped) | run-to-run |
|---|--:|--:|--:|
| before | 2/6 (33%) | 6/6 | 3/3 identical |
| after | **6/6 (100%)** | 6/6 | 3/3 identical |

Triggering was always deterministic; the old description just under-fired. Adding one clause naming coding tasks explicitly, plus a negative clause, takes recall to 100% without costing precision.

## Change

Trigger descriptions live in two source-of-truth spots, both updated:
- `skills/ponytail/SKILL.md` (canonical, covers Claude Code, Codex, Devin, pi, Swival, OpenCode)
- `DESCRIPTIONS` map in `scripts/build-openclaw-skills.js` (`.openclaw/` regenerated)

The store blurbs in `.codex-plugin/plugin.json`, `gemini-extension.json`, `package.json`, `.claude-plugin/*`, and `.cursor/*.mdc` are listing metadata or always-on rule frontmatter, not task-routing triggers, so they are intentionally left alone.

All 61 tests in `tests/` pass.