### PR TITLE
release: 4.8.4

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.devin-plugin/plugin.json
+++ b/.devin-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "author": {
     "name": "Dietrich Gebert",

--- a/.github/plugin/plugin.json
+++ b/.github/plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ponytail",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "author": {
     "name": "Dietrich Gebert",
     "url": "https://github.com/DietrichGebert"

--- a/gemini-extension.json
+++ b/gemini-extension.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
   "contextFileName": "AGENTS.md"
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dietrichgebert/ponytail",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
   "keywords": ["opencode-plugin", "opencode", "ponytail", "pi-package", "pi", "skills"],
   "license": "MIT",

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,5 +1,5 @@
 name: ponytail
-version: 4.8.3
+version: 4.8.4
 description: Lazy senior dev mode for Hermes Agent, always-on context, bundled skills, and slash commands.
 author: Salaamdev
 provides_hooks:

--- a/ponytail-mcp/package.json
+++ b/ponytail-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ponytail-mcp",
-  "version": "4.8.3",
+  "version": "4.8.4",
   "description": "MCP server that serves Ponytail's lazy-senior-dev instructions as a prompt and a tool.",
   "private": true,
   "type": "module",


### PR DESCRIPTION
Patch release.

- Trigger ponytail skill on any coding task, not just keywords (#447): the skill description now fires reliably on plain coding tasks in model-invoked / description-driven hosts. Recall on coding tasks went 2/6 to 6/6, precision unchanged.

Bumps the 6 version manifests 4.8.3 to 4.8.4. Tag `v4.8.4` after merge to publish.