### PR TITLE
feat(review): add structural observations section to review output

### DIFF
--- a/.openclaw/skills/ponytail-review/SKILL.md
+++ b/.openclaw/skills/ponytail-review/SKILL.md
@@ -8,7 +8,7 @@ license: MIT
 Review diffs for unnecessary complexity. One line per finding: location, what
 to cut, what replaces it. The diff's best outcome is getting shorter.
 
-## Format
+## Section 1 — Tagged findings
 
 `L<line>: <tag> <what>. <replacement>.`, or `<file>:L<line>: ...` for
 multi-file diffs.
@@ -42,11 +42,27 @@ End with the only metric that matters: `net: -<N> lines possible.`
 
 If there is nothing to cut, say `Lean already. Ship.` and stop.
 
+## Section 2 — Structural observations
+
+After the tagged findings and net-lines metric, note any structural concerns
+that don't reduce to a single tagged line. These are patterns the line-level
+format cannot express:
+
+- "This wrapper class exists only to forward calls — the abstraction layer shouldn't exist"
+- "The test suite tests the upstream library's behavior, not this code's behavior"
+- "This is a tutorial scaffold masquerading as production architecture"
+
+Structural observations often represent the highest-value findings. Do not
+suppress them because they don't fit the tag format.
+
+If there are no structural observations beyond the tagged findings, omit this
+section — do not add a placeholder.
+
 ## Boundaries
 
-Scope: over-engineering and complexity only. Correctness bugs, security holes,
-and performance are explicitly out of scope. Route them to a normal review
-pass, not this one. A single smoke test or `assert`-based
+**Scope: over-engineering and complexity only.** Correctness bugs, security
+holes, and performance issues are explicitly out of scope — route them to a
+dedicated review pass, not this one. A single smoke test or `assert`-based
 self-check is the ponytail minimum, not bloat, never flag it for deletion.
 Does not apply the fixes, only lists them.
 "stop ponytail-review" or "normal mode": revert to verbose review style.

--- a/skills/ponytail-review/SKILL.md
+++ b/skills/ponytail-review/SKILL.md
@@ -13,7 +13,7 @@ description: >
 Review diffs for unnecessary complexity. One line per finding: location, what
 to cut, what replaces it. The diff's best outcome is getting shorter.
 
-## Format
+## Section 1 — Tagged findings
 
 `L<line>: <tag> <what>. <replacement>.`, or `<file>:L<line>: ...` for
 multi-file diffs.
@@ -47,11 +47,27 @@ End with the only metric that matters: `net: -<N> lines possible.`
 
 If there is nothing to cut, say `Lean already. Ship.` and stop.
 
+## Section 2 — Structural observations
+
+After the tagged findings and net-lines metric, note any structural concerns
+that don't reduce to a single tagged line. These are patterns the line-level
+format cannot express:
+
+- "This wrapper class exists only to forward calls — the abstraction layer shouldn't exist"
+- "The test suite tests the upstream library's behavior, not this code's behavior"
+- "This is a tutorial scaffold masquerading as production architecture"
+
+Structural observations often represent the highest-value findings. Do not
+suppress them because they don't fit the tag format.
+
+If there are no structural observations beyond the tagged findings, omit this
+section — do not add a placeholder.
+
 ## Boundaries
 
-Scope: over-engineering and complexity only. Correctness bugs, security holes,
-and performance are explicitly out of scope. Route them to a normal review
-pass, not this one. A single smoke test or `assert`-based
+**Scope: over-engineering and complexity only.** Correctness bugs, security
+holes, and performance issues are explicitly out of scope — route them to a
+dedicated review pass, not this one. A single smoke test or `assert`-based
 self-check is the ponytail minimum, not bloat, never flag it for deletion.
 Does not apply the fixes, only lists them.
 "stop ponytail-review" or "normal mode": revert to verbose review style.


### PR DESCRIPTION
## Summary

- Adds **Section 2 — Structural observations** to `ponytail-review` output format
- Preserves existing tagged format (Section 1) exactly as-is
- Strengthens scope boundary to be explicit and non-optional

## Motivation

Blind A/B experiment (10 independent reviewers) found that the tag-and-line format produces false negatives on structural YAGNI. `ponytail-review` said "Lean already. Ship." on code with 4 genuine wrapper-layer issues because observations like "this wrapper shouldn't exist" don't fit the `L<line>: <tag>` format.

The unstructured simplify lens caught 1 structural finding that ponytail-review missed entirely, despite ponytail-review having 3.2x higher signal density on line-level findings.

## Changes

- `skills/ponytail-review/SKILL.md`: Added Section 2 for free-form structural observations after the tagged findings and net-lines metric. Strengthened Boundaries to make scope non-optional.

## Evidence

- Round 2 blind council: ponytail-review found 0 unique findings vs unstructured simplify; simplify caught 1 structural issue ponytail-review missed
- Hybrid format preserves 3.2x signal density while closing the structural blind spot
- Full methodology: see experimental design in the evaluating project

## Test plan

- [ ] Existing tests pass (`npm test`)
- [ ] `check-rule-copies.js` passes
- [ ] Manual: invoke `/ponytail-review` on code with a wrapper layer — verify structural observation appears

Made with [Cursor](https://cursor.com)