### PR TITLE
fix: add missing skills to help table, strengthen review scope boundary

### DIFF
--- a/.openclaw/skills/ponytail-review/SKILL.md
+++ b/.openclaw/skills/ponytail-review/SKILL.md
@@ -44,9 +44,9 @@ If there is nothing to cut, say `Lean already. Ship.` and stop.
 
 ## Boundaries
 
-Scope: over-engineering and complexity only. Correctness bugs, security holes,
-and performance are explicitly out of scope. Route them to a normal review
-pass, not this one. A single smoke test or `assert`-based
+**Scope: over-engineering and complexity only.** Correctness bugs, security
+holes, and performance issues are explicitly out of scope — route them to a
+dedicated review pass, not this one. A single smoke test or `assert`-based
 self-check is the ponytail minimum, not bloat, never flag it for deletion.
 Does not apply the fixes, only lists them.
 "stop ponytail-review" or "normal mode": revert to verbose review style.

--- a/skills/ponytail-review/SKILL.md
+++ b/skills/ponytail-review/SKILL.md
@@ -49,9 +49,9 @@ If there is nothing to cut, say `Lean already. Ship.` and stop.
 
 ## Boundaries
 
-Scope: over-engineering and complexity only. Correctness bugs, security holes,
-and performance are explicitly out of scope. Route them to a normal review
-pass, not this one. A single smoke test or `assert`-based
+**Scope: over-engineering and complexity only.** Correctness bugs, security
+holes, and performance issues are explicitly out of scope — route them to a
+dedicated review pass, not this one. A single smoke test or `assert`-based
 self-check is the ponytail minimum, not bloat, never flag it for deletion.
 Does not apply the fixes, only lists them.
 "stop ponytail-review" or "normal mode": revert to verbose review style.


### PR DESCRIPTION
## Summary

- Adds `ponytail-audit` and `ponytail-debt` to the `ponytail-help` skills reference table (was listing only 4 of 6 skills)
- Strengthens the scope boundary statement in `ponytail-review` (bold, slightly stronger wording)

## Motivation

Users invoking `/ponytail-help` don't learn about the audit and debt capabilities. The review scope boundary was implicit enough that it could be misread as optional guidance rather than a hard constraint.

## Changes

- `skills/ponytail-help/SKILL.md`: Added 2 missing rows to skills table
- `skills/ponytail-review/SKILL.md`: Bolded scope boundary statement
- `.openclaw/skills/ponytail-help/SKILL.md`: Regenerated adapter copy
- `.openclaw/skills/ponytail-review/SKILL.md`: Regenerated adapter copy

## Test plan

- [x] `check-rule-copies.js` passes
- [x] `npm test` passes (68/69 — 1 pre-existing failure in csv correctness test, unrelated)
- [ ] Manual: invoke `/ponytail-help` — verify all 6 skills listed

Made with [Cursor](https://cursor.com)