### PR TITLE
docs: add integration patterns guide and benchmark scope documentation

### DIFF
--- a/docs/benchmark-scope.md
+++ b/docs/benchmark-scope.md
@@ -1,0 +1,64 @@
+# Benchmark Scope and Methodology
+
+Ponytail's benchmarks measure code generation on specific task types. This
+document clarifies what the numbers mean, where they apply, and where they
+don't — extending the honest-limitations culture established in
+`benchmarks/results/`.
+
+## Task-type dependency
+
+Ponytail's wins are largest on **over-build traps** — tasks where the naive
+approach produces unnecessary code:
+
+| Task type | Typical LOC reduction | Why |
+|-----------|----------------------|-----|
+| Native replacement (date picker, modal, validation) | 50-95% | Platform feature replaces library + custom code |
+| Stdlib substitution (CSV parsing, grouping, cloning) | 70-90% | One stdlib call replaces multi-line implementation |
+| Irreducible CRUD (REST endpoints, form handling) | 0-15% | Both approaches converge on similar code |
+| Complex algorithms | ~0% | No shortcut exists; ponytail correctly doesn't invent one |
+
+The published -54% LOC (agentic) and 80-94% (single-shot) numbers are
+dominated by over-build-trap tasks. Extrapolating to all code generation
+overstates the effect.
+
+## Model-specific cost behavior
+
+| Model family | Cost impact | Source |
+|-------------|-------------|--------|
+| Claude (Haiku, Sonnet) | 42-75% cheaper | Published benchmarks |
+| OpenAI reasoning (gpt-5.4-mini) | ~26% MORE expensive | Robustness audit |
+| OpenAI reasoning (gpt-5.5) | ~39% MORE expensive | Robustness audit |
+| Small local (llama3.2) | No measurable effect | Local model benchmark |
+
+The cost savings are **Claude-specific**. On OpenAI reasoning models, ponytail's
+questioning and ladder-climbing generate more reasoning tokens than the naive
+approach saves in output tokens.
+
+## Independent evaluation findings
+
+An independent evaluation using blind multi-agent experiments (10 reviewers,
+4-lens council) found:
+
+- **Signal density:** ponytail-review produces ~3.2x more findings per unit of
+  output compared to unstructured review — directionally correct, slightly
+  below the 3.5x initially estimated
+- **Structural blind spot:** Tag-and-line format misses structural YAGNI
+  (wrapper layers, unnecessary abstractions) — addressable with hybrid output
+- **Ultra uniqueness:** In a multi-agent council, ponytail-ultra produced 0
+  unique findings beyond what an unstructured simplify lens caught
+- **Safety:** 100% maintained across 90+ runs and 14 targeted probes
+
+## Evaluation methodology recommendations
+
+When evaluating ponytail (or any agent tool) for integration:
+
+1. **Use independent test material.** Ponytail's own showcase examples
+   (email-validation, rate-limit, etc.) are selected to demonstrate strengths.
+   Use your project's actual code for evaluation.
+2. **Blind comparisons.** Run reviewers independently without seeing each
+   other's output. Single-agent simulation (one agent playing multiple roles)
+   overstates differences.
+3. **Check for false negatives.** A tool that reports "clean" is only useful if
+   the code actually is clean. Test against code with known issues.
+4. **Model-match your evaluation.** Results on Claude don't predict results on
+   GPT or local models.

--- a/docs/integration-patterns.md
+++ b/docs/integration-patterns.md
@@ -1,0 +1,68 @@
+# Integration Patterns
+
+How to use ponytail alongside other tools, frameworks, and multi-agent
+workflows. This guide covers the "one voice among many" integration model —
+where ponytail is a specialist skill, not a project governor.
+
+## On-demand profile
+
+For projects with their own rules, test policies, or multi-agent review systems:
+
+- **Install skills, not the always-on rule.** Use `ponytail-review`,
+  `ponytail-audit`, `ponytail-debt`, `ponytail-gain`, and `ponytail-help` as
+  pull-based tools invoked when needed — not the core `ponytail` skill with
+  its `ACTIVE EVERY RESPONSE` persistence.
+- **Use `ponytail-playbook`** (if available) for implementation guidance that
+  defers test policy to the host project's framework.
+- **No SessionStart hooks** in this profile. The hook system (`hooks/`) is
+  designed for always-on activation — skip it for on-demand use.
+
+## Anti-patterns
+
+### Double injection
+
+Installing ponytail as both a Cursor skill AND a project rule (`.cursor/rules/ponytail.mdc`)
+injects the instructions twice per turn. This doubles token cost and can
+produce conflicting guidance when the two copies drift.
+
+**Fix:** Choose one delivery mechanism. For on-demand use, install individual
+skills. For always-on use, use the rule file — not both.
+
+### Ultra as routine council member
+
+In multi-agent review setups (multiple independent reviewers), adding
+`ponytail-ultra` as a permanent 4th reviewer adds ~33% cost with ~75% overlap
+with any existing simplify/complexity reviewer.
+
+**When ultra IS appropriate:** On-demand, when reviewer judgment suggests the
+*problem itself* may be wrong — "should this feature exist?" is ultra's
+natural question, not "is this implementation clean?"
+
+### Standalone review as QA gate
+
+`ponytail-review` is scoped to over-engineering only. Using it as the sole
+code review gate misses correctness bugs, security holes, and performance
+issues. Always pair with dedicated reviewers for those concerns.
+
+## Multi-agent review integration
+
+The recommended pattern is **enhancing an existing complexity/simplify lens**
+with ponytail-review's structured output format, not adding a separate lens:
+
+1. Keep your existing review lenses (correctness, architecture, simplify)
+2. Add ponytail-review's tag format (`delete:`, `stdlib:`, `native:`, `yagni:`,
+   `shrink:`) as structured output guidance for the simplify lens
+3. Keep free-form structural observations alongside the tags
+
+This preserves signal density gains without the cost of an additional reviewer.
+
+## Skill inventory for on-demand use
+
+| Skill | When to invoke | What you get |
+|-------|----------------|-------------|
+| `ponytail-review` | Reviewing diffs for over-engineering | Tagged findings + net-lines metric |
+| `ponytail-audit` | Periodic repo health check | Ranked findings across the codebase |
+| `ponytail-debt` | Tracking deliberate simplifications | Ledger of `ponytail:`/`defer:` comments |
+| `ponytail-gain` | Curiosity about benchmark claims | Published scoreboard with caveats |
+| `ponytail-help` | Quick reference | Levels, skills, config, update |
+| `ponytail-playbook` | Implementation mode (TDD-compatible) | Ladder + deferred test policy |


### PR DESCRIPTION
## Summary

Two new documentation files based on findings from an independent evaluation:

- **docs/integration-patterns.md** — How to use ponytail as "one voice among many" in multi-agent workflows
- **docs/benchmark-scope.md** — Task-type dependency, model-specific cost behavior, and evaluation methodology

## Motivation

Ponytail's README covers installation for 16+ hosts but not integration patterns for projects with existing review systems or test frameworks. The benchmark results are honest about limitations (issue #126 response, agentic limitations), but scope and model-specific behavior deserve dedicated documentation.

## Key content

**Integration patterns:**
- On-demand profile (skills without SessionStart hooks)
- Anti-patterns: double injection, ultra as routine council member, standalone review as QA gate
- Multi-agent review integration: enhance existing lens, don't add a 4th

**Benchmark scope:**
- Over-build-trap wins vs irreducible CRUD convergence
- Claude-specific cost savings; OpenAI reasoning model cost increase (26-39%)
- Independent evaluation methodology and findings

## Test plan

- [x] `npm test` passes (1 pre-existing failure in csv correctness test, unrelated to docs)
- [x] No changes to code or skills — docs only

Made with [Cursor](https://cursor.com)