### PR TITLE
fix: prevent Windows session freeze from stdin EOF deadlock (#443)

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -6,8 +6,11 @@ const { getDefaultMode, isDeactivationCommand } = require('./ponytail-config');
 const { clearMode, setMode, writeHookOutput } = require('./ponytail-runtime');
 
 let input = '';
-process.stdin.on('data', chunk => { input += chunk; });
-process.stdin.on('end', () => {
+let done = false;
+
+function finish() {
+  if (done) return;
+  done = true;
   try {
     // Strip UTF-8 BOM some shells prepend when piping (breaks JSON.parse)
     const data = JSON.parse(input.replace(/^\uFEFF/, ''));
@@ -52,4 +55,17 @@ process.stdin.on('end', () => {
   } catch (e) {
     // Silent fail
   }
-});
+}
+
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', finish);
+
+// Never hang the session. On Windows, Claude Code runs this hook through a
+// PowerShell `if {}` wrapper that can swallow the piped prompt JSON, so stdin
+// 'end' never fires and the hook blocks forever — freezing the session (#443).
+// On error, or after a short fallback, process whatever arrived (recovering the
+// mode if data came without EOF) and exit. unref() keeps the timer from adding
+// latency to the normal path, where 'end' fires first. Mirrors the best-effort,
+// never-block contract the other lifecycle hooks already follow.
+process.stdin.on('error', () => { finish(); process.exit(0); });
+setTimeout(() => { finish(); process.exit(0); }, 1000).unref();

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -9,6 +9,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+const { spawn } = require('child_process');
 
 const root = path.join(__dirname, '..');
 const HOOKS_JSON = 'hooks/claude-codex-hooks.json';
@@ -71,6 +72,27 @@ test('every hook command points at a script that ships in hooks/', () => {
       assert.ok(fs.existsSync(script), `command references a missing hook script: ${match[1]}`);
     }
   }
+});
+
+// Issue #443: on Windows the UserPromptSubmit hook runs inside a PowerShell
+// `if {}` wrapper that can swallow the piped prompt JSON, so stdin 'end' never
+// fires. The hook must never wait on stdin forever — that freezes the whole
+// session. It has to self-exit even when stdin stays open and empty.
+test('ponytail-mode-tracker self-exits when stdin never closes (no freeze)', async () => {
+  const hook = path.join(root, 'hooks', 'ponytail-mode-tracker.js');
+  // stdin is a pipe we never write to or end, reproducing the deadlock.
+  const child = spawn(process.execPath, [hook], { stdio: ['pipe', 'ignore', 'ignore'] });
+
+  const code = await new Promise((resolve, reject) => {
+    const guard = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('hook hung on open stdin — it would freeze the session'));
+    }, 3000);
+    child.on('exit', (c) => { clearTimeout(guard); resolve(c); });
+    child.on('error', reject);
+  });
+
+  assert.equal(code, 0, 'hook must exit cleanly when stdin never closes');
 });
 
 test('Claude and Codex manifests point at the shared host-specific hook config', () => {


### PR DESCRIPTION
## Problem

Closes #443. On Windows, Claude Code freezes indefinitely after installing ponytail — submit any prompt and the session hangs with no spinner, no output, no error; only `Ctrl+C` recovers it.

## Root cause

`hooks/ponytail-mode-tracker.js` (the `UserPromptSubmit` hook) only ever completed inside `process.stdin.on('end', …)`:

```js
process.stdin.on('data', chunk => { input += chunk; });
process.stdin.on('end', () => { /* parse, set mode, exit */ });
```

On Windows the hook is launched via the PowerShell wrapper in `claude-codex-hooks.json`:

```
if (Get-Command node -ErrorAction SilentlyContinue) { node "$env:CLAUDE_PLUGIN_ROOT\hooks\ponytail-mode-tracker.js" }
```

A native command invoked inside a PowerShell `if {}` block does not reliably receive the parent's piped stdin, so the prompt JSON never reaches `node` and the `'end'` event never fires. The process stays alive waiting on stdin forever, and Claude Code blocks on the hook — freezing the session.

## Fix

Make the hook non-blocking, matching the best-effort / never-block contract the other lifecycle hooks already follow:

- Extract the handler into `finish()`, guarded by a `done` flag so it runs at most once.
- Add a `process.stdin.on('error', …)` handler.
- Add a **1s `unref()`'d safety timeout** that runs `finish()` (recovering the mode even if data arrived without EOF) and exits cleanly.

`unref()` means the timer never holds the event loop open on the normal path — `'end'` fires first there, so there is **zero added latency** for the common case. The fallback only matters when EOF never comes.

## Testing

- `node --test tests/*.test.js`: same results as `main` except **+1 passing test** — no new failures. (Pre-existing failures in `hermes-plugin`/`correctness` only occur where Python/pandas isn't installed locally and are unrelated.)
- Added a regression test in `tests/hooks-windows.test.js` that spawns the hook with a stdin pipe that is never written to or closed, and asserts the process self-exits (cleanly, code 0) instead of hanging. Without this fix the test hits its 3s guard and fails.

Manually verified: spawning the patched hook with an open, empty stdin pipe exits in ~1s (code 0) rather than hanging indefinitely.