### PR TITLE
fix(pi): avoid undefined system prompt prefix

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -184,6 +184,8 @@ export default function ponytailExtension(pi) {
 
   pi.on("before_agent_start", async (event) => {
     if (!currentMode || currentMode === "off") return;
-    return { systemPrompt: `${event.systemPrompt}\n\n${getPonytailInstructions(currentMode)}` };
+    const basePrompt = typeof event?.systemPrompt === "string" ? event.systemPrompt : "";
+    const instructions = getPonytailInstructions(currentMode);
+    return { systemPrompt: basePrompt ? `${basePrompt}\n\n${instructions}` : instructions };
   });
 }

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -93,6 +93,17 @@ test("session_start restores latest persisted mode", async () => withTempConfig(
   assert.ok(result.systemPrompt.includes("lite"));
 }));
 
+test("missing systemPrompt does not prepend undefined", async () => withTempConfig(async () => {
+  const { events } = createPiHarness();
+  const ctx = createCommandContext();
+
+  await events.get("session_start")({ reason: "startup" }, ctx);
+  const result = await events.get("before_agent_start")({}, ctx);
+
+  assert.match(result.systemPrompt, /PONYTAIL MODE ACTIVE/);
+  assert.doesNotMatch(result.systemPrompt, /^undefined/);
+}));
+
 test("skill alias commands delegate to Pi skill commands", async () => {
   const { commands, sentUserMessages } = createPiHarness();
   const ctx = createCommandContext();


### PR DESCRIPTION
Treats a missing Pi `event.systemPrompt` as an empty base prompt before appending Ponytail instructions, so a truthy event object like `{}` no longer injects a literal `undefined` prefix into the model's system prompt.

Closes #440.

Verified with `npm test --prefix pi-extension` and full `npm test` after prepending the local Python 3.11 install to PATH so the Hermes tests can resolve `python3`.
