### PR TITLE
docs(help): correct OpenCode command list in ponytail-help (closes #438)

### DIFF
--- a/.openclaw/skills/ponytail-help/SKILL.md
+++ b/.openclaw/skills/ponytail-help/SKILL.md
@@ -30,8 +30,7 @@ Level sticks until changed or session end.
 | **ponytail-help** | `/ponytail-help` | This card. |
 
 Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
-and OpenCode use the slash-command forms above (OpenCode ships `/ponytail` and
-`/ponytail-review`).
+and OpenCode use the slash-command forms above (OpenCode ships all 6 commands).
 
 ## Deactivate
 

--- a/skills/ponytail-help/SKILL.md
+++ b/skills/ponytail-help/SKILL.md
@@ -31,8 +31,7 @@ Level sticks until changed or session end.
 | **ponytail-help** | `/ponytail-help` | This card. |
 
 Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
-and OpenCode use the slash-command forms above (OpenCode ships `/ponytail` and
-`/ponytail-review`).
+and OpenCode use the slash-command forms above (OpenCode ships all 6 commands).
 
 ## Deactivate
 


### PR DESCRIPTION
🎯 **What:** Corrects the `ponytail-help` skill documentation to accurately state that OpenCode ships all 6 ponytail commands, rather than just 2.
💡 **Why:** The previous text was factually incorrect and misled users into thinking they could only use `/ponytail` and `/ponytail-review` on OpenCode, when in reality all 6 commands (`ponytail`, `ponytail-review`, `ponytail-audit`, `ponytail-debt`, `ponytail-gain`, `ponytail-help`) are available as `.opencode/command/*.md` files.
✅ **Verification:** Verified the change by running `scripts/build-openclaw-skills.js` to propagate the update to the generated OpenClaw files, after which all 68 relevant `npm test` checks pass successfully.
✨ **Result:** Users reading `/ponytail-help` on OpenCode will see the correct command availability.