### PR TITLE
Clarify that model routing is not process overhead

### DIFF
--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -62,6 +62,7 @@ every sibling caller still broken. Fix it once, where all callers route through.
 - Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
 - Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
 - Mark deliberate simplifications with a `ponytail:` comment (`// ponytail: this exists`), simple reads as intent, not ignorance. Shortcut with a known ceiling (global lock, O(n²) scan, naive heuristic)? The comment names the ceiling and the upgrade path: `# ponytail: global lock, per-account locks if throughput matters`.
+- Model routing is not process overhead. When a plan already contains complete code, dispatching to a cheaper model to write files is the lazier choice — fewer expensive tokens for zero-judgment work. Never skip subagent dispatch by calling it "over-process"; the ladder governs the solution, not which model executes it.
 
 ## Output
 


### PR DESCRIPTION
## Problem

When a plan already contains complete implementation code (e.g. 500 lines across two files), ponytail's "skip subagents — that's over-process" heuristic prevents dispatching to a cheaper model. The result: the expensive frontier model re-generates pre-written code verbatim, burning ~5x more tokens for zero additional value.

## Real-world conflict

The [superpowers](https://github.com/anthropics/claude-code-superpowers) plugin includes model-routing configuration that assigns plan tasks a tier (`mechanical`, `standard`, `frontier`) and dispatches subagents to the appropriate model. Tasks with complete code in the plan steps are `mechanical` → routed to Haiku.

Ponytail intercepts this flow: "The plan already has the code, dispatching subagents to copy-paste it would be over-process — just write it directly." This sounds lazy but isn't: Opus outputting 500 lines of pre-written code costs ~5x what Haiku would.

## Fix

New bullet in Rules clarifying that **model routing ≠ ceremony**. The ladder governs what the solution looks like, not which model tier writes the files. When the code is already designed and written in the plan, dispatching to a mechanical-tier model is the lazier (cheaper) path.

## Example

Plan contains two complete scripts (~500 lines total), tier: `mechanical`. Without this fix:
- Ponytail: "just write it yourself, subagents are over-process" → Opus outputs 500 lines → expensive

With this fix:
- Ponytail recognizes dispatch-to-Haiku as the lazy choice → Haiku outputs 500 lines → 5x cheaper, same result

🤖 Generated with Claude Code