### PR TITLE
fix(uninstall): don't crash on malformed settings.json (#434)

### DIFF
--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -36,5 +36,12 @@ try {
     console.log(`Removed ponytail statusLine entry from ${settingsPath}`);
   }
 } catch (e) {
-  if (e.code !== 'ENOENT') throw e;
+  if (e.code === 'ENOENT') {
+    // no settings.json — nothing to clean
+  } else if (e instanceof SyntaxError) {
+    // ponytail: malformed settings.json — can't safely edit it; leave intact, warn
+    console.warn(`settings.json is malformed — could not remove the ponytail statusLine entry. Remove it manually from: ${settingsPath} (${e.message})`);
+  } else {
+    throw e;
+  }
 }

--- a/tests/uninstall.test.js
+++ b/tests/uninstall.test.js
@@ -69,6 +69,28 @@ assert.equal(
   "a user's own statusLine must not be touched",
 );
 
+// A malformed settings.json must not crash the script (issue #434): the ponytail
+// statusLine entry can't be auto-removed (can't safely edit invalid JSON), so the
+// script warns and leaves the file byte-for-byte intact.
+const malformedSettings = '{ "statusLine": { "command": "ponytail-statusline.sh", broken';
+fs.writeFileSync(settingsPath, malformedSettings);
+
+result = runUninstall(env);
+assert.equal(
+  result.status,
+  0,
+  `expected exit 0 on malformed settings.json, got:\n${result.stdout}${result.stderr}`,
+);
+assert.ok(
+  /malformed/i.test(result.stdout + result.stderr),
+  'must warn that the statusLine entry could not be removed',
+);
+assert.equal(
+  fs.readFileSync(settingsPath, 'utf8'),
+  malformedSettings,
+  'malformed settings.json must be left unchanged',
+);
+
 // Running on an already-clean machine must not throw.
 result = runUninstall({ HOME: path.join(temp, 'home-empty'), USERPROFILE: path.join(temp, 'home-empty') });
 assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
## What

Fixes a crash in `scripts/uninstall.js` when `settings.json` contains malformed JSON (#434).

## Why

`JSON.parse` on a malformed `settings.json` throws a `SyntaxError`, which has no `.code`. The ENOENT-only catch re-threw it, crashing the script mid-cleanup — after `.ponytail-active` and `config.json` were already deleted (lines 21-22), leaving a non-zero exit and a dangling `statusLine` entry pointing at a soon-to-be-deleted script (which then errors on the next Claude Code launch).

## How

Classify the error in the catch instead of checking only for ENOENT:

- `ENOENT` → no settings.json, nothing to clean (swallow, unchanged)
- `SyntaxError` → malformed JSON; can't safely edit it, so warn the user and leave the file intact
- anything else → re-throw (unchanged; matches the re-throw-unexpected behavior of `removeIfExists` in the same file)

`SyntaxError` can only originate from `JSON.parse` here, so the classification is unambiguous.

## Test

Added the missing malformed-JSON case to `tests/uninstall.test.js`: asserts exit 0, a warning is printed, and the file is left byte-for-byte intact. Closes the gap in the existing suite, which only covered valid and absent `settings.json`.

## Note on the issue

The "settings.json may have been partially modified" concern doesn't actually occur: `JSON.parse` (line 27) throws **before** the synchronous `writeFileSync` (line 35), so the file is left untouched, never half-written. The real harm is the crash + the dangling `statusLine` reference — both addressed by this fix.

Closes #434
