### PR TITLE
fix(package): ship uninstall cleanup script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "skills/",
     ".opencode/",
     "pi-extension/",
+    "scripts/uninstall.js",
     "assets/",
     "LICENSE"
   ],

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -1,0 +1,32 @@
+#!/usr/bin/env node
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const root = path.join(__dirname, '..');
+
+test('npm package ships the advertised cleanup script', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-pack-'));
+  try {
+    const npmCommand = process.env.npm_execpath ? process.execPath : (process.platform === 'win32' ? 'npm.cmd' : 'npm');
+    const npmArgs = process.env.npm_execpath
+      ? [process.env.npm_execpath, 'pack', '--dry-run', '--json']
+      : ['pack', '--dry-run', '--json'];
+    const result = spawnSync(npmCommand, npmArgs, {
+      cwd: root,
+      env: { ...process.env, npm_config_cache: path.join(temp, 'npm-cache') },
+      encoding: 'utf8',
+    });
+
+    assert.equal(result.status, 0, result.stderr);
+    const [pack] = JSON.parse(result.stdout);
+    const files = new Set(pack.files.map((file) => file.path));
+    assert.ok(files.has('scripts/uninstall.js'), 'missing scripts/uninstall.js from npm package');
+  } finally {
+    fs.rmSync(temp, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## What

Ships `scripts/uninstall.js` in the npm package.

## Why

This complements the fix from @isaukywhite in #469 for #434. That PR makes `scripts/uninstall.js` safer when `settings.json` is malformed, but the npm package currently does not ship `scripts/uninstall.js`, even though the README tells users to run it.

## How

Add `scripts/uninstall.js` to `package.json`'s `files` list and add a package regression test using `npm pack --dry-run --json`.

## Test

`node --test tests/package.test.js tests/uninstall.test.js`

Related: #469 by @isaukywhite
Refs #434
