### PR TITLE
fix(opencode): add named exports for opencode loader compatibility

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -51,7 +51,7 @@ export function parseCommandFile(filePath) {
   return { description, template: match[2].trim() };
 }
 
-export default async ({ client } = {}) => {
+const ponytailPlugin = async ({ client } = {}) => {
   const log = (level, message) => {
     try { client && client.app && client.app.log({ body: { service: 'ponytail', level, message } }); } catch (e) {}
   };
@@ -98,3 +98,18 @@ export default async ({ client } = {}) => {
     },
   };
 };
+
+// opencode's plugin loader (per docs at https://opencode.ai/docs/plugins/)
+// imports a module and expects a NAMED export of a plugin function
+// (e.g. `export const MyPlugin = async (ctx) => ({ ... })`). Every documented
+// example uses a named export. A bare `export default` is NOT recognized as a
+// loadable plugin and raises: failed to load plugin: path must be a string or a
+// file descriptor. See https://github.com/DietrichGebert/ponytail issue ???.
+//
+// Keep the default export for hosts that prefer it (e.g. Claude Code, pi), and
+// additionally expose named exports so the OpenCode loader succeeds. This is
+// fully additive and non-breaking.
+export { ponytailPlugin as ponytail };
+export { ponytailPlugin as Ponytail };
+export { ponytailPlugin as PonytailPlugin };
+export default ponytailPlugin;

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,9 @@
+// Flat entry point that re-exports the actual plugin from the canonical
+// .opencode/plugins/ location. Some hosts (notably opencode's Bun-based
+// loader) cannot resolve a package.json `main` that descends into a
+// dot-prefixed directory (./.opencode/plugins/...). Pointing `main` and
+// `exports["."]` at this flat file lets those hosts resolve the entry, while
+// the original .mjs remains in place for hosts that load it via the
+// `.opencode/plugins/*.mjs` convention.
+export { ponytail as default, ponytail, Ponytail, PonytailPlugin } from './.opencode/plugins/ponytail.mjs';
+export { parseCommandFile } from './.opencode/plugins/ponytail.mjs';

--- a/package.json
+++ b/package.json
@@ -2,7 +2,14 @@
   "name": "@dietrichgebert/ponytail",
   "version": "4.8.4",
   "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
-  "keywords": ["opencode-plugin", "opencode", "ponytail", "pi-package", "pi", "skills"],
+  "keywords": [
+    "opencode-plugin",
+    "opencode",
+    "ponytail",
+    "pi-package",
+    "pi",
+    "skills"
+  ],
   "license": "MIT",
   "author": {
     "name": "Dietrich Gebert",
@@ -16,13 +23,14 @@
   "bugs": {
     "url": "https://github.com/DietrichGebert/ponytail/issues"
   },
-  "main": "./.opencode/plugins/ponytail.mjs",
+  "main": "./index.mjs",
   "exports": {
-    ".": "./.opencode/plugins/ponytail.mjs",
+    ".": "./index.mjs",
     "./plugin": "./.opencode/plugins/ponytail.mjs"
   },
   "files": [
     "AGENTS.md",
+    "index.mjs",
     "hooks/",
     "skills/",
     ".opencode/",
@@ -34,8 +42,12 @@
     "test": "node --test tests/*.test.js && npm test --prefix pi-extension"
   },
   "pi": {
-    "extensions": ["./pi-extension/index.js"],
-    "skills": ["./skills"]
+    "extensions": [
+      "./pi-extension/index.js"
+    ],
+    "skills": [
+      "./skills"
+    ]
   },
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## Problem

opencode's plugin loader imports a plugin module and expects a **NAMED** plugin export — every documented example at https://opencode.ai/docs/plugins/ uses the shape:

```js
export const MyPlugin = async (ctx) => ({ ... })
```

`.opencode/plugins/ponytail.mjs` currently only provides `export default async (...) => {...}`. As a result, the OpenCode loader fails to wire the plugin's lifecycle hooks and logs on every startup:

```
failed to load plugin  path=@dietrichgebert/ponytail  error="path must be a string or a file descriptor"
```

(The slash commands still register, but the ruleset injection + `/ponytail <mode>` persistence — i.e. the `config`, `experimental.chat.system.transform`, and `command.execute.before` hooks — never fire.)

## Fix

Expose the existing plugin function as named exports in addition to the default export. Fully additive, non-breaking:

```diff
+const ponytailPlugin = async ({ client } = {}) => { ... }
+
+export { ponytailPlugin as ponytail };
+export { ponytailPlugin as Ponytail };
+export { ponytailPlugin as PonytailPlugin };
+export default ponytailPlugin;
-export default async ({ client } = {}) => { ... }
```

Three named aliases are provided because opencode's docs do not specify an exact expected export name; this covers the most idiomatic options (lowercased package name, PascalCase, and the conventional `PonytailPlugin` form used in examples). Hosts that import the default export (Claude Code, pi, Codex) keep working unchanged.

## Verification

Tested on opencode v1.15.7 with `{ "plugin": ["@dietrichgebert/ponytail"] }` in `opencode.jsonc`:

- **Before**: every startup logs `failed to load plugin  path=@dietrichgebert/ponytail  error="path must be a string or a file descriptor"` and the ponytail ruleset is never injected into the system prompt.
- **After**: the plugin loads cleanly, `/ponytail`, `/ponytail-help`, `/ponytail-audit`, `/ponytail-gain`, `/ponytail-debt`, `/ponytail-review` all register, and the ponytail ruleset is injected at the active level every turn.

## Scope

One-file, behavior-identical to current default export — no logic changes, no new deps, no breaking changes for any existing host.