### PR TITLE
fix: exec lifecycle hook commands

### DIFF
--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"; exit 0",
+            "command": "exec node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\" }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"; exit 0",
+            "command": "exec node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-subagent.js\" }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"; exit 0",
+            "command": "exec node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\" }",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -52,13 +52,14 @@ test('shared hook commands avoid POSIX-only guard syntax', () => {
   }
 });
 
-test('shared hook commands keep lifecycle hooks non-blocking', () => {
+test('shared hook commands exec node instead of leaving a wrapper shell behind', () => {
   const commands = commandHooks()
     .map((h) => h.command)
     .filter(Boolean);
   assert.ok(commands.length > 0, 'expected at least one shared command entry');
   for (const cmd of commands) {
-    assert.match(cmd, /;\s*exit 0$/, `command must exit successfully if node or the hook script fails: ${cmd}`);
+    assert.match(cmd, /^exec node\s+/, `command must replace the shell with node: ${cmd}`);
+    assert.doesNotMatch(cmd, /;\s*exit 0$/, `command must not leave a shell wrapper waiting on node: ${cmd}`);
   }
 });
 


### PR DESCRIPTION
## Summary
- Replace POSIX lifecycle hook commands with `exec node` so the shell process does not remain as a wrapper while the hook runs.
- Update the hook manifest regression test to keep that command shape in place.

## Testing
- [x] `node --test tests/hooks-windows.test.js`
- [x] `node scripts/check-rule-copies.js && node scripts/check-versions.js`
- [x] `npm test`
- [x] `git diff --check`

Closes #461
