### PR TITLE
fix: harden codex hooks and preserve active goals

### DIFF
--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -17,9 +17,18 @@ ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
 unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
 Switch: `/ponytail lite|full|ultra`.
 
-Active goals override brevity: when the user asks you to continue, resume,
-finish, keep going, or not stop, keep working through validation, deployment,
-or handoff. Do not ask back or mark done early.
+Active goals override brevity. When the user asks you to continue, resume,
+finish, keep going, or not stop, keep working until the stated objective is
+actually complete or genuinely blocked. A patch, plan, partial fix, or local
+unit check is not completion if validation, deployment, docs, handoff, or
+agent coordination are still part of the objective. Do not ask back or mark
+done early.
+
+Latest work wins. Before any commit, deploy, artifact promotion, or restart,
+check the current diff/status, stage only intentional files, and re-read files
+that may have changed since you last inspected them. Never overwrite newer
+edits from another agent, another session, or the user with an older worktree,
+stale artifact, broad checkout, or broad staging command.
 
 ## The ladder
 

--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -17,6 +17,10 @@ ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
 unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
 Switch: `/ponytail lite|full|ultra`.
 
+Active goals override brevity: when the user asks you to continue, resume,
+finish, keep going, or not stop, keep working through validation, deployment,
+or handoff. Do not ask back or mark done early.
+
 ## The ladder
 
 Stop at the first rung that holds:

--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"; exit 0",
+            "command": "/bin/sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-node-hook.sh\" ponytail-activate.js; exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\" }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"; exit 0",
+            "command": "/bin/sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-node-hook.sh\" ponytail-subagent.js; exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-subagent.js\" }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"; exit 0",
+            "command": "/bin/sh \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-node-hook.sh\" ponytail-mode-tracker.js; exit 0",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\" }",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -42,6 +42,7 @@ function getFallbackInstructions(mode) {
     '## Persistence\n\n' +
     'ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if unsure. Off only: "stop ponytail" / "normal mode".\n\n' +
     'Current level: **' + mode + '**. Switch: `/ponytail lite|full|ultra`.\n\n' +
+    'Active goals override brevity: when the user asks you to continue, resume, finish, keep going, or not stop, keep working through validation, deployment, or handoff. Do not ask back or mark done early.\n\n' +
     '## The ladder\n\n' +
     'Before any code, stop at the first rung that holds (the ladder runs after you understand the problem, not instead of it — read the code it touches and trace the real flow first):\n' +
     '1. Does this need to be built at all? (YAGNI)\n' +

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -42,7 +42,8 @@ function getFallbackInstructions(mode) {
     '## Persistence\n\n' +
     'ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if unsure. Off only: "stop ponytail" / "normal mode".\n\n' +
     'Current level: **' + mode + '**. Switch: `/ponytail lite|full|ultra`.\n\n' +
-    'Active goals override brevity: when the user asks you to continue, resume, finish, keep going, or not stop, keep working through validation, deployment, or handoff. Do not ask back or mark done early.\n\n' +
+    'Active goals override brevity. When the user asks you to continue, resume, finish, keep going, or not stop, keep working until the stated objective is actually complete or genuinely blocked. A patch, plan, partial fix, or local unit check is not completion if validation, deployment, docs, handoff, or agent coordination are still part of the objective. Do not ask back or mark done early.\n\n' +
+    'Latest work wins. Before any commit, deploy, artifact promotion, or restart, check the current diff/status, stage only intentional files, and re-read files that may have changed since you last inspected them. Never overwrite newer edits from another agent, another session, or the user with an older worktree, stale artifact, broad checkout, or broad staging command.\n\n' +
     '## The ladder\n\n' +
     'Before any code, stop at the first rung that holds (the ladder runs after you understand the problem, not instead of it — read the code it touches and trace the real flow first):\n' +
     '1. Does this need to be built at all? (YAGNI)\n' +

--- a/hooks/ponytail-node-hook.sh
+++ b/hooks/ponytail-node-hook.sh
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+script="${1:-}"
+case "$script" in
+  ponytail-*.js) ;;
+  *) exit 0 ;;
+esac
+
+root="${CLAUDE_PLUGIN_ROOT:-}"
+if [ -z "$root" ]; then
+  root="${0%/hooks/*}"
+fi
+
+node_bin="${NODE_BIN:-}"
+if [ -z "$node_bin" ]; then
+  node_bin="$(command -v node 2>/dev/null || true)"
+fi
+
+if [ -z "$node_bin" ] && [ -x /usr/bin/node ]; then
+  node_bin="/usr/bin/node"
+fi
+
+if [ -z "$node_bin" ] && [ -x /opt/homebrew/bin/node ]; then
+  node_bin="/opt/homebrew/bin/node"
+fi
+
+[ -n "$node_bin" ] && [ -x "$node_bin" ] || exit 0
+exec "$node_bin" "$root/hooks/$script"

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -29,6 +29,10 @@ ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
 unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
 Switch: `/ponytail lite|full|ultra`.
 
+Active goals override brevity: when the user asks you to continue, resume,
+finish, keep going, or not stop, keep working through validation, deployment,
+or handoff. Do not ask back or mark done early.
+
 ## The ladder
 
 Stop at the first rung that holds:

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -29,9 +29,18 @@ ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
 unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
 Switch: `/ponytail lite|full|ultra`.
 
-Active goals override brevity: when the user asks you to continue, resume,
-finish, keep going, or not stop, keep working through validation, deployment,
-or handoff. Do not ask back or mark done early.
+Active goals override brevity. When the user asks you to continue, resume,
+finish, keep going, or not stop, keep working until the stated objective is
+actually complete or genuinely blocked. A patch, plan, partial fix, or local
+unit check is not completion if validation, deployment, docs, handoff, or
+agent coordination are still part of the objective. Do not ask back or mark
+done early.
+
+Latest work wins. Before any commit, deploy, artifact promotion, or restart,
+check the current diff/status, stage only intentional files, and re-read files
+that may have changed since you last inspected them. Never overwrite newer
+edits from another agent, another session, or the user with an older worktree,
+stale artifact, broad checkout, or broad staging command.
 
 ## The ladder
 

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -61,6 +61,14 @@ assert.match(
   output.hookSpecificOutput.additionalContext,
   /PONYTAIL MODE ACTIVE — level: ultra/,
 );
+assert.match(
+  output.hookSpecificOutput.additionalContext,
+  /patch, plan, partial fix, or local\s+unit check is not completion/,
+);
+assert.match(
+  output.hookSpecificOutput.additionalContext,
+  /Latest work wins/,
+);
 
 result = run(
   'ponytail-mode-tracker.js',


### PR DESCRIPTION
## Summary
- document that active goal requests override Ponytail brevity
- add the same active-goal rule to fallback hook instructions
- route Codex lifecycle hooks through a shipped shell wrapper so they do not depend on a host PATH containing node
- regenerate the OpenClaw ponytail skill copy

## Validation
- npm test
- executed every Ponytail hook command from the marketplace checkout with PATH empty
- executed every Ponytail hook command from the installed cache copy with PATH empty