### PR TITLE
feat: add support for Amp CLI (#341)

### DIFF
--- a/.amp/plugins/ponytail.ts
+++ b/.amp/plugins/ponytail.ts
@@ -1,0 +1,303 @@
+// @ts-ignore — @ampcode/plugin is types-only; Bun erases this import at runtime.
+import type { PluginAPI } from '@ampcode/plugin'
+import { fileURLToPath } from 'url'
+import { dirname, resolve, delimiter, join } from 'path'
+import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs'
+import { homedir } from 'os'
+
+// When the plugin lives at .amp/plugins/ inside the repo, walking up from the
+// plugin file finds skills/ponytail/SKILL.md. When copied to
+// ~/.config/amp/plugins/ (system-wide install) there is no such directory —
+// every lookup below falls back to inline defaults so the plugin still works.
+const __dirname = dirname(fileURLToPath(import.meta.url))
+
+/**
+ * Walk up from `startDir` looking for `skills/ponytail/SKILL.md`. This is more
+ * robust than assuming a fixed "../.." depth, since it keeps working if the
+ * plugin file is nested differently (e.g. `.amp/plugins/ponytail/index.ts`).
+ */
+function findRepoRoot(startDir: string): string | null {
+  let dir = startDir
+  for (let i = 0; i < 6; i++) {
+    if (existsSync(join(dir, 'skills', 'ponytail', 'SKILL.md'))) return dir
+    const parent = dirname(dir)
+    if (parent === dir) break
+    dir = parent
+  }
+  return null
+}
+
+const REPO_ROOT = findRepoRoot(__dirname) ?? resolve(__dirname, '../..')
+
+// ── Config (inlined — no external require, works wherever the file is placed) ─
+const DEFAULT_MODE = 'full'
+const RUNTIME_MODES = ['off', 'lite', 'full', 'ultra']
+const VALID_MODES = [...RUNTIME_MODES, 'review']
+const CONFIG_KEY = 'ponytail.mode'
+
+export function normalizeMode(m: unknown): string | null {
+  if (typeof m !== 'string') return null
+  const n = m.trim().toLowerCase()
+  return RUNTIME_MODES.includes(n) ? n : null
+}
+
+export function getConfigPath(): string {
+  const base = process.env.XDG_CONFIG_HOME
+    ?? (process.platform === 'win32'
+        ? (process.env.APPDATA ?? join(homedir(), 'AppData', 'Roaming'))
+        : join(homedir(), '.config'))
+  return join(base, 'ponytail', 'config.json')
+}
+
+/** Synchronous, amp-independent read: env var > local file > built-in default.
+ *  Used for the very first read before amp.configuration is available, and
+ *  kept exported/pure so it stays unit-testable. */
+export function getMode(): string {
+  const env = process.env.PONYTAIL_DEFAULT_MODE
+  if (env && VALID_MODES.includes(env.toLowerCase())) return env.toLowerCase()
+  try {
+    const cfg = JSON.parse(readFileSync(getConfigPath(), 'utf8')) as Record<string, unknown>
+    const m = String(cfg.defaultMode ?? '').toLowerCase()
+    if (VALID_MODES.includes(m)) return m
+  } catch { /* no config file yet */ }
+  return DEFAULT_MODE
+}
+
+export function saveMode(mode: string): void {
+  const p = getConfigPath()
+  mkdirSync(dirname(p), { recursive: true })
+  writeFileSync(p, JSON.stringify({ defaultMode: mode }, null, 2), 'utf8')
+}
+
+// ── Instructions ─────────────────────────────────────────────────────────────
+// Inline fallback used whenever skills/ponytail/SKILL.md isn't reachable
+// (system-wide install, or repo checked out without the skills/ directory).
+const FALLBACK_RULES = `You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if unsure. Off only: "stop ponytail" / "normal mode".
+
+## The ladder
+
+Before any code, stop at the first rung that holds (the ladder runs after you understand the problem, not instead of it — read the code it touches and trace the real flow first):
+1. Does this need to be built at all? (YAGNI)
+2. Does it already exist in this codebase? Reuse what is already here, do not re-write it.
+3. Does the standard library do this? Use it.
+4. Does a native platform feature cover it? Use it.
+5. Does an already-installed dependency solve it? Use it.
+6. Can this be one line? Make it one line.
+7. Only then: write the minimum code that works.
+
+Bug fix = root cause, not symptom: grep every caller of the function you touch and fix the shared function once (a smaller diff than one guard per caller); patching only the path the ticket names leaves a sibling caller broken.
+
+## Rules
+
+No abstractions that were not requested. No avoidable dependencies. No boilerplate nobody asked for. Deletion over addition. Boring over clever. Fewest files possible. Ship the lazy version and question the complex request in the same response — never stall. Between two same-size stdlib options, pick the one correct on edge cases. Mark intentional simplifications with a \`ponytail:\` comment — a shortcut with a known ceiling names the ceiling and the upgrade path in the comment.
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it. If the explanation is longer than the code, delete the explanation. Explanation the user explicitly asked for is not debt, give it in full.
+
+## When NOT to be lazy
+
+Never simplify away: understanding the problem (read it fully and trace the real flow before picking a rung — a small diff you do not understand is just laziness dressed up as efficiency), input validation at trust boundaries, error handling that prevents data loss, security measures, accessibility basics, the calibration real hardware needs (the platform is never the spec ideal), anything the user explicitly asked to keep. Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind (assert-based demo/self-check or one small test file; no frameworks). Trivial one-liners need no test.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk. "stop ponytail" or "normal mode": revert. Level persists until changed or session end.`
+
+export function filterBodyForMode(body: string, mode: string): string {
+  return body.replace(/^---[\s\S]*?---\s*/, '').split(/\r?\n/).filter(line => {
+    const tbl = line.match(/^\|\s*\*\*(.+?)\*\*\s*\|/)
+    if (tbl && normalizeMode(tbl[1])) return tbl[1].trim().toLowerCase() === mode
+    const ex = line.match(/^-\s*([^:]+):\s*/)
+    if (ex && normalizeMode(ex[1])) return ex[1].trim().toLowerCase() === mode
+    return true
+  }).join('\n')
+}
+
+export function getInstructions(mode: string): string {
+  const m = normalizeMode(mode) ?? DEFAULT_MODE
+  const header = `PONYTAIL MODE ACTIVE — level: ${m}\n\n`
+  try {
+    const body = readFileSync(resolve(REPO_ROOT, 'skills/ponytail/SKILL.md'), 'utf8')
+    return header + filterBodyForMode(body, m)
+  } catch {
+    return header + FALLBACK_RULES
+  }
+}
+
+// ── Skills ───────────────────────────────────────────────────────────────────
+const SKILL_NAMES = ['ponytail-review', 'ponytail-audit', 'ponytail-debt', 'ponytail-gain', 'ponytail-help']
+
+// Inline fallbacks for system-wide installs where SKILL.md files aren't on disk.
+const SKILL_FALLBACKS: Record<string, string> = {
+  'ponytail-review': 'Review the current git diff for over-engineering. List only what can be deleted or replaced with stdlib/native equivalents. One line per finding: location, what to cut, what replaces it.',
+  'ponytail-audit': 'Audit the entire repository for over-engineering. Scan all files and produce a ranked list of what to delete, simplify, or replace with stdlib/native equivalents.',
+  'ponytail-debt': 'Find every `ponytail:` comment in the codebase and produce a debt ledger: file, line, comment, suggested next step.',
+  'ponytail-gain': "Show ponytail's measured impact scoreboard: less code, less cost, more speed. Display the benchmark results concisely.",
+  'ponytail-help': 'Show a quick-reference card for all ponytail modes, skills, and commands.',
+}
+
+export function readSkillPrompt(name: string): string {
+  try {
+    return readFileSync(resolve(REPO_ROOT, 'skills', name, 'SKILL.md'), 'utf8')
+      .replace(/^---[\s\S]*?---\s*/, '')
+      .trim()
+  } catch {
+    return SKILL_FALLBACKS[name] ?? `Run ${name}.`
+  }
+}
+
+export function statusText(mode: string): string {
+  const icon: Record<string, string> = { lite: '🌿', full: '⚡', ultra: '🔥' }
+  return mode === 'off' ? '' : `🐴 ponytail: ${icon[mode] ?? ''} ${mode.toUpperCase()}`
+}
+
+// ── Plugin ───────────────────────────────────────────────────────────────────
+/** Fire a notification without blocking the caller. Awaiting ctx.ui.notify()
+ *  before returning a hook result delays that result for no benefit — and on
+ *  a cold-started plugin that delay can be the difference between the first
+ *  prompt of a session landing before or after Amp has already moved on. */
+function notify(ctx: { ui: { notify: (text: string) => Promise<void> } }, text: string): void {
+  ctx.ui.notify(text).catch(() => { /* best-effort */ })
+}
+
+export default async function (amp: PluginAPI) {
+  let mode: string = getMode()
+
+  async function persistMode(next: string) {
+    mode = next
+    saveMode(next) // best-effort local file, kept for offline/system-wide installs
+    try {
+      await amp.configuration.update({ [CONFIG_KEY]: next }, 'workspace')
+    } catch { /* non-fatal — file copy above still has it */ }
+  }
+
+  const statusItem = amp.experimental?.createStatusItem({ text: statusText(mode) })
+
+  // ── Hooks & commands are registered FIRST, synchronously, before any
+  // `await` below runs. Amp can dispatch the first session.start/agent.start
+  // event as soon as the plugin module loads; if hook registration is stuck
+  // behind awaited setup work (config reads, skills-path registration), that
+  // first event can arrive before a handler is attached, or the handler can
+  // resolve too slowly to have its returned message applied in time. That's
+  // what caused "works from message 2 onward" — the plugin was still
+  // finishing async init when the first prompt's agent.start fired.
+
+  amp.on('session.start', async (_event, ctx) => {
+    try {
+      const cfg = await amp.configuration.get()
+      mode = normalizeMode((cfg as Record<string, unknown>)[CONFIG_KEY]) ?? getMode()
+    } catch {
+      mode = getMode()
+    }
+    statusItem?.update({ text: statusText(mode) })
+    if (mode !== 'off') notify(ctx, `Ponytail active: ${mode}`)
+  })
+
+  amp.on('agent.start', async (event, ctx) => {
+    const text = event.message.trim()
+
+    // /ponytail [lite|full|ultra|off] — mode switch
+    const modeMatch = text.match(/^\/ponytail(?:\s+(\S+))?$/i)
+    if (modeMatch) {
+      const arg = (modeMatch[1] ?? '').toLowerCase()
+      const next = arg ? normalizeMode(arg) : mode
+      if (next) {
+        await persistMode(next)
+        statusItem?.update({ text: statusText(mode) })
+        notify(ctx, `Ponytail mode: ${mode}`)
+      }
+      return
+    }
+
+    // /ponytail-review, /ponytail-audit, etc. — inject skill as hidden context
+    const skillMatch = text.match(/^\/(ponytail-(?:review|audit|debt|gain|help))(?:\s|$)/i)
+    if (skillMatch) {
+      notify(ctx, `🐴 ponytail: running ${skillMatch[1]}`)
+      return { message: { content: readSkillPrompt(skillMatch[1].toLowerCase()), display: false } }
+    }
+
+    // Always-on instruction injection, applied to every normal prompt.
+    if (mode === 'off') return
+
+    // The Plugin API only supports appending content after the user's typed
+    // text (there is no "prepend" hook), so the closest supported way to
+    // surface "ponytail is active on this prompt" every time the user hits
+    // enter is a UI notification fired on every matching turn. Fired without
+    // awaiting so it can never delay the returned instructions payload.
+    notify(ctx, statusText(mode) || 'ponytail active')
+
+    return { message: { content: getInstructions(mode), display: false } }
+  })
+
+  // ── Command palette ───────────────────────────────────────────────────────
+
+  amp.registerCommand('ponytail-mode', {
+    title: 'set mode',
+    category: 'ponytail',
+    description: 'Switch Ponytail intensity: lite, full, ultra, or off',
+  }, async (ctx) => {
+    const choice = await ctx.ui.select({
+      title: 'Ponytail mode',
+      message: `Current: ${mode}`,
+      options: ['lite', 'full', 'ultra', 'off'],
+      initialValue: mode,
+    })
+    if (!choice) return
+    await persistMode(choice)
+    statusItem?.update({ text: statusText(mode) })
+    notify(ctx, `Ponytail mode: ${mode}`)
+  })
+
+  for (const skill of SKILL_NAMES) {
+    const title = skill.replace('ponytail-', '')
+    amp.registerCommand(skill, {
+      title,
+      category: 'ponytail',
+    }, async (ctx) => {
+      const content = readSkillPrompt(skill)
+      const thread = ctx.thread ?? await amp.getBuiltinAgent('smart').createThread({ show: true })
+      await thread.append([{ type: 'user-message', content }])
+    })
+  }
+
+  amp.logger.log(`[ponytail] plugin initialized (repo root: ${REPO_ROOT})`)
+
+  // ── Background init (non-blocking) ──────────────────────────────────────
+  // Runs after hooks/commands are already wired up, so it can never delay or
+  // race the first event. Pulls the persisted mode override from
+  // amp.configuration (workspace-synced, survives ephemeral executors) and
+  // registers skills/ so `amp skills list` discovers them. If this hasn't
+  // resolved yet when the very first prompt arrives, that prompt just uses
+  // the synchronous file/env/default mode from getMode() above — a safe,
+  // reasonable value — rather than blocking or being skipped.
+  void (async () => {
+    try {
+      const cfg = await amp.configuration.get()
+      const cfgMode = normalizeMode((cfg as Record<string, unknown>)[CONFIG_KEY])
+      if (cfgMode) {
+        mode = cfgMode
+        statusItem?.update({ text: statusText(mode) })
+      }
+    } catch { /* configuration API unavailable — fall back to file/env/default */ }
+
+    try {
+      const skillsDir = resolve(REPO_ROOT, 'skills')
+      if (existsSync(skillsDir)) {
+        const config = await amp.configuration.get()
+        const existing = String((config as Record<string, unknown>)['amp.skills.path'] ?? '')
+          .split(delimiter)
+          .filter(Boolean)
+        if (!existing.includes(skillsDir)) {
+          await amp.configuration.update(
+            { 'amp.skills.path': [...existing, skillsDir].join(delimiter) },
+            'workspace',
+          )
+        }
+      }
+    } catch { /* skills path registration is best-effort */ }
+  })()
+}

--- a/README.md
+++ b/README.md
@@ -180,6 +180,28 @@ Injects the ruleset every turn at the active level; adds the `/ponytail` command
 
 The `./` path resolves against your project's `opencode.json`; to share one checkout across projects, point it at the absolute path of the `.mjs` instead (it finds its `hooks/` and `skills/` relative to its own file).
 
+### Ampcode
+
+```bash
+# System-wide — active in every project (recommended)
+mkdir -p ~/.config/amp/plugins
+curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/.amp/plugins/ponytail.ts \
+  -o ~/.config/amp/plugins/ponytail.ts
+```
+
+Then open Amp and run `plugins: reload` from the command palette (`Ctrl+O`).
+
+```bash
+# Project-level — scoped to one project
+mkdir -p .amp/plugins
+curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/.amp/plugins/ponytail.ts \
+  -o .amp/plugins/ponytail.ts
+```
+
+Commands work two ways: type `/ponytail ultra` in the chat, or open the command palette (`Ctrl+O`) and search `ponytail` to pick from the six commands. The mode is persisted in `~/.config/ponytail/config.json` and shared with Claude, OpenCode, and other platforms.
+
+The system-wide install works fully without the checkout — it uses built-in fallback instructions that are functionally equivalent.
+
 ### Gemini CLI
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/*.test.js && npm test --prefix pi-extension"
+    "test": "node --experimental-strip-types --test tests/*.test.js && npm test --prefix pi-extension"
   },
   "pi": {
     "extensions": ["./pi-extension/index.js"],

--- a/scripts/check-rule-copies.js
+++ b/scripts/check-rule-copies.js
@@ -66,9 +66,28 @@ for (const phrase of INVARIANTS) {
   }
 }
 
+// Check that the inline FALLBACK_RULES in the Amp plugin contains the same
+// load-bearing invariants. The fallback is only reached on system-wide installs
+// where SKILL.md isn't on disk; stale wording there is low-risk, but a dropped
+// safety rule would silently weaken the system-wide install.
+const ampPlugin = read('.amp/plugins/ponytail.ts');
+const fallbackMatch = ampPlugin.match(/const FALLBACK_RULES = `([\s\S]*?)`/);
+if (!fallbackMatch) {
+  console.error('.amp/plugins/ponytail.ts: FALLBACK_RULES constant not found');
+  failed = true;
+} else {
+  const fallback = fallbackMatch[1];
+  for (const phrase of INVARIANTS) {
+    if (!fallback.includes(phrase)) {
+      console.error(`.amp/plugins/ponytail.ts FALLBACK_RULES drifted — missing: "${phrase}"`);
+      failed = true;
+    }
+  }
+}
+
 if (failed) {
   console.error('Update the copied rule text, AGENTS.md, or SKILL.md so the shared rules match.');
   process.exit(1);
 }
 
-console.log(`Rule copies match AGENTS.md; ${INVARIANTS.length} rule invariants present in SKILL.md and AGENTS.md.`);
+console.log(`Rule copies match AGENTS.md; ${INVARIANTS.length} rule invariants present in SKILL.md, AGENTS.md, and Amp FALLBACK_RULES.`);

--- a/tests/amp-plugin.test.js
+++ b/tests/amp-plugin.test.js
@@ -1,0 +1,295 @@
+#!/usr/bin/env node
+// Tests for .amp/plugins/ponytail.ts — the AmpCode platform adapter.
+// Run via: node --experimental-strip-types --test tests/*.test.js
+// All test names start with "amp-plugin:" per project convention.
+
+const test = require('node:test')
+const assert = require('node:assert/strict')
+const fs = require('fs')
+const os = require('os')
+const path = require('path')
+const { pathToFileURL } = require('url')
+
+// Set XDG_CONFIG_HOME before module load so getConfigPath() resolves to a
+// deterministic temp location and never touches the real user config.
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-amp-'))
+process.env.XDG_CONFIG_HOME = tmp
+delete process.env.PONYTAIL_DEFAULT_MODE
+
+let mod
+test.before(async () => {
+  const url = pathToFileURL(path.join(__dirname, '..', '.amp', 'plugins', 'ponytail.ts'))
+  mod = await import(url)
+})
+test.after(() => fs.rmSync(tmp, { recursive: true, force: true }))
+
+// ── Mock helpers ──────────────────────────────────────────────────────────────
+
+function makeAmp(configValue = {}) {
+  const events = {}
+  const commands = {}
+  const statusUpdates = []
+  const configUpdates = []
+  const cfg = { ...configValue }
+  return {
+    events, commands, statusUpdates, configUpdates,
+    on(event, handler) { events[event] = handler },
+    registerCommand(name, _meta, handler) { commands[name] = handler },
+    experimental: {
+      createStatusItem() {
+        return { update(o) { statusUpdates.push(o.text) } }
+      },
+    },
+    configuration: {
+      async get() { return { ...cfg } },
+      async update(values) { configUpdates.push({ ...values }); Object.assign(cfg, values) },
+    },
+    getBuiltinAgent() {
+      return { createThread: async () => ({ append: async () => {} }) }
+    },
+    logger: { log() {} },
+  }
+}
+
+function makeCtx() {
+  const notifications = []
+  return {
+    notifications,
+    ui: { notify: async (text) => { notifications.push(text) } },
+    thread: null,
+  }
+}
+
+// Flush pending microtasks so the background void IIFE inside the plugin
+// (which awaits amp.configuration.get() twice) fully resolves before assertions.
+// setImmediate fires after all queued microtasks, so one hop is sufficient.
+const drain = () => new Promise(r => setImmediate(r))
+
+// ── normalizeMode ─────────────────────────────────────────────────────────────
+
+test('amp-plugin: normalizeMode accepts valid runtime modes case-insensitively', () => {
+  const { normalizeMode } = mod
+  assert.equal(normalizeMode('lite'), 'lite')
+  assert.equal(normalizeMode('FULL'), 'full')
+  assert.equal(normalizeMode('  Ultra  '), 'ultra')
+  assert.equal(normalizeMode('off'), 'off')
+})
+
+test('amp-plugin: normalizeMode rejects invalid and non-string inputs', () => {
+  const { normalizeMode } = mod
+  assert.equal(normalizeMode('review'), null)   // not a runtime mode
+  assert.equal(normalizeMode(''), null)
+  assert.equal(normalizeMode(123), null)
+  assert.equal(normalizeMode(null), null)
+  assert.equal(normalizeMode(undefined), null)
+})
+
+// ── getConfigPath ─────────────────────────────────────────────────────────────
+
+test('amp-plugin: getConfigPath uses XDG_CONFIG_HOME when set', () => {
+  const p = mod.getConfigPath()
+  assert.ok(p.startsWith(tmp), `expected path under ${tmp}, got ${p}`)
+  assert.ok(p.endsWith('config.json'))
+})
+
+// ── getMode ───────────────────────────────────────────────────────────────────
+
+test('amp-plugin: getMode returns env var when PONYTAIL_DEFAULT_MODE is valid', () => {
+  process.env.PONYTAIL_DEFAULT_MODE = 'ultra'
+  try {
+    assert.equal(mod.getMode(), 'ultra')
+  } finally {
+    delete process.env.PONYTAIL_DEFAULT_MODE
+  }
+})
+
+test('amp-plugin: getMode falls back to config file, then to full', () => {
+  delete process.env.PONYTAIL_DEFAULT_MODE
+  try { fs.rmSync(mod.getConfigPath()) } catch {}
+  assert.equal(mod.getMode(), 'full')
+  mod.saveMode('lite')
+  assert.equal(mod.getMode(), 'lite')
+  fs.rmSync(mod.getConfigPath())
+  assert.equal(mod.getMode(), 'full')
+})
+
+test('amp-plugin: getMode ignores invalid env var and falls through to default', () => {
+  process.env.PONYTAIL_DEFAULT_MODE = 'bogus'
+  try {
+    assert.equal(mod.getMode(), 'full')
+  } finally {
+    delete process.env.PONYTAIL_DEFAULT_MODE
+  }
+})
+
+// ── saveMode ──────────────────────────────────────────────────────────────────
+
+test('amp-plugin: saveMode writes defaultMode to config JSON', () => {
+  mod.saveMode('ultra')
+  const written = JSON.parse(fs.readFileSync(mod.getConfigPath(), 'utf8'))
+  assert.equal(written.defaultMode, 'ultra')
+  fs.rmSync(mod.getConfigPath())
+})
+
+test('amp-plugin: saveMode creates parent directories automatically', () => {
+  const saved = process.env.XDG_CONFIG_HOME
+  process.env.XDG_CONFIG_HOME = path.join(tmp, 'nested', 'deep')
+  try {
+    mod.saveMode('lite')
+    assert.ok(fs.existsSync(mod.getConfigPath()))
+  } finally {
+    process.env.XDG_CONFIG_HOME = saved
+  }
+})
+
+// ── filterBodyForMode ─────────────────────────────────────────────────────────
+
+test('amp-plugin: filterBodyForMode strips frontmatter', () => {
+  const result = mod.filterBodyForMode('---\ntitle: test\n---\nActual content', 'full')
+  assert.ok(!result.includes('---'))
+  assert.ok(!result.includes('title:'))
+  assert.ok(result.includes('Actual content'))
+})
+
+test('amp-plugin: filterBodyForMode keeps lines matching mode, drops others', () => {
+  const body = `preamble\n| **lite** | only lite |\n| **full** | only full |\n| **ultra** | only ultra |\npostamble`
+  const result = mod.filterBodyForMode(body, 'full')
+  assert.ok(result.includes('only full'))
+  assert.ok(!result.includes('only lite'))
+  assert.ok(!result.includes('only ultra'))
+  assert.ok(result.includes('preamble') && result.includes('postamble'))
+})
+
+test('amp-plugin: filterBodyForMode keeps non-mode lines unchanged', () => {
+  const body = 'rule 1\nrule 2\nrule 3'
+  assert.equal(mod.filterBodyForMode(body, 'lite'), body)
+})
+
+// ── getInstructions ───────────────────────────────────────────────────────────
+
+test('amp-plugin: getInstructions header contains active mode name', () => {
+  const result = mod.getInstructions('full')
+  assert.match(result, /PONYTAIL MODE ACTIVE — level: full/)
+  assert.ok(result.length > 50)
+})
+
+test('amp-plugin: getInstructions normalizes unknown mode to full', () => {
+  assert.match(mod.getInstructions('invalid'), /PONYTAIL MODE ACTIVE — level: full/)
+})
+
+// ── readSkillPrompt ───────────────────────────────────────────────────────────
+
+test('amp-plugin: readSkillPrompt returns content for known skill names', () => {
+  const review = mod.readSkillPrompt('ponytail-review')
+  assert.ok(review.length > 0)
+  assert.ok(review.toLowerCase().includes('over-engineer') || review.includes('Review'))
+})
+
+test('amp-plugin: readSkillPrompt returns generic fallback for unknown skill name', () => {
+  assert.equal(mod.readSkillPrompt('ponytail-unknown'), 'Run ponytail-unknown.')
+})
+
+// ── statusText ────────────────────────────────────────────────────────────────
+
+test('amp-plugin: statusText is empty string for off mode', () => {
+  assert.equal(mod.statusText('off'), '')
+})
+
+test('amp-plugin: statusText includes emoji and uppercased mode for active modes', () => {
+  assert.match(mod.statusText('lite'), /🌿/)
+  assert.match(mod.statusText('lite'), /LITE/)
+  assert.match(mod.statusText('full'), /⚡/)
+  assert.match(mod.statusText('full'), /FULL/)
+  assert.match(mod.statusText('ultra'), /🔥/)
+  assert.match(mod.statusText('ultra'), /ULTRA/)
+})
+
+// ── Plugin integration (session.start) ───────────────────────────────────────
+
+test('amp-plugin: session.start syncs mode from amp.configuration', async () => {
+  const amp = makeAmp({ 'ponytail.mode': 'ultra' })
+  await mod.default(amp)
+  await drain()
+  await amp.events['session.start']({}, makeCtx())
+  const last = amp.statusUpdates.at(-1) ?? ''
+  assert.match(last, /ULTRA/, `expected status to contain ULTRA, got: ${last}`)
+})
+
+test('amp-plugin: session.start notifies when mode is active', async () => {
+  const amp = makeAmp({})
+  await mod.default(amp)
+  await drain()
+  const ctx = makeCtx()
+  await amp.events['session.start']({}, ctx)
+  assert.ok(ctx.notifications.some(n => n.includes('Ponytail active')))
+})
+
+test('amp-plugin: session.start skips notification when mode is off', async () => {
+  const amp = makeAmp({ 'ponytail.mode': 'off' })
+  await mod.default(amp)
+  await drain()
+  const ctx = makeCtx()
+  await amp.events['session.start']({}, ctx)
+  assert.equal(ctx.notifications.length, 0)
+})
+
+// ── Plugin integration (agent.start) ─────────────────────────────────────────
+
+test('amp-plugin: agent.start /ponytail ultra persists mode and returns early', async () => {
+  const amp = makeAmp({})
+  await mod.default(amp)
+  await drain()
+  const result = await amp.events['agent.start']({ message: '/ponytail ultra' }, makeCtx())
+  assert.equal(result, undefined)
+  assert.ok(
+    amp.configUpdates.some(u => u['ponytail.mode'] === 'ultra'),
+    'expected ponytail.mode to be persisted as ultra',
+  )
+})
+
+test('amp-plugin: agent.start /ponytail with invalid arg is ignored', async () => {
+  const amp = makeAmp({})
+  await mod.default(amp)
+  await drain()
+  const before = amp.configUpdates.length
+  const result = await amp.events['agent.start']({ message: '/ponytail nonsense' }, makeCtx())
+  // Returns early (undefined) but does not persist a mode update for 'nonsense'
+  assert.equal(result, undefined)
+  const newModeUpdates = amp.configUpdates.slice(before).filter(u => 'ponytail.mode' in u)
+  assert.equal(newModeUpdates.length, 0)
+})
+
+test('amp-plugin: agent.start /ponytail-review returns hidden skill message', async () => {
+  const amp = makeAmp({})
+  await mod.default(amp)
+  await drain()
+  const result = await amp.events['agent.start']({ message: '/ponytail-review' }, makeCtx())
+  assert.equal(result?.message?.display, false)
+  assert.ok(typeof result?.message?.content === 'string' && result.message.content.length > 0)
+})
+
+test('amp-plugin: agent.start /ponytail-audit returns hidden skill message', async () => {
+  const amp = makeAmp({})
+  await mod.default(amp)
+  await drain()
+  const result = await amp.events['agent.start']({ message: '/ponytail-audit' }, makeCtx())
+  assert.equal(result?.message?.display, false)
+  assert.ok(typeof result?.message?.content === 'string' && result.message.content.length > 0)
+})
+
+test('amp-plugin: agent.start normal prompt injects instructions when active', async () => {
+  const amp = makeAmp({})
+  await mod.default(amp)
+  await drain()
+  const result = await amp.events['agent.start']({ message: 'fix this bug' }, makeCtx())
+  assert.equal(result?.message?.display, false)
+  assert.match(result?.message?.content ?? '', /PONYTAIL MODE ACTIVE/)
+})
+
+test('amp-plugin: agent.start normal prompt returns nothing when mode is off', async () => {
+  const amp = makeAmp({ 'ponytail.mode': 'off' })
+  await mod.default(amp)
+  await drain()
+  const result = await amp.events['agent.start']({ message: 'fix this bug' }, makeCtx())
+  assert.equal(result, undefined)
+})


### PR DESCRIPTION
There is demand to add support for Amp Code, a widely used coding agent adopted by both individual developers and enterprises. This PR adds that support to ponytail. Closes #341 

Reference: [Amp plugin documentation](https://ampcode.com/manual#plugin-locations)

### What is added
- `.amp/plugins/ponytail.ts` the Amp-supported plugin. Per Amp's plugin documentation (linked above), Amp only loads project plugins from `.amp/plugins/*.ts`, so the plugin is added as a `.ts` file to be auto-discovered by the Amp CLI.

### What is updated
- `scripts/check-rule-copies.js`  updated to also check for prompt drift in the new Amp plugin, keeping it in sync with the source rules.
- `README.md`  added instructions for installing the ponytail plugin both system-wide and per-project for Amp Code.
- `package.json` updated the test script. Since the new Amp plugin (`ponytail.ts`) is written in TypeScript, Node needs the `--experimental-strip-types` flag to run/type-strip `.ts` files directly during the test run, without requiring a separate compile step or an additional build dependency like `ts-node`.

### Tests
```
 @dietrichgebert/ponytail@4.8.4 test
> node --experimental-strip-types --test tests/*.test.js && npm test --prefix pi-extension

(node:58903) [MODULE_TYPELESS_PACKAGE_JSON] Warning: Module type of file:///mnt/d/projects/ponytail/.amp/plugins/ponytail.ts is not specified and it doesn't parse as CommonJS.
Reparsing as ES module because module syntax was detected. This incurs a performance overhead.
To eliminate this warning, add "type": "module" to /mnt/d/projects/ponytail/package.json.
(Use `node --trace-warnings ...` to show where the warning was created)
✔ amp-plugin: normalizeMode accepts valid runtime modes case-insensitively (14.129954ms)
✔ amp-plugin: normalizeMode rejects invalid and non-string inputs (0.586903ms)
✔ amp-plugin: getConfigPath uses XDG_CONFIG_HOME when set (0.624402ms)
✔ amp-plugin: getMode returns env var when PONYTAIL_DEFAULT_MODE is valid (0.680702ms)
✔ amp-plugin: getMode falls back to config file, then to full (5.32272ms)
✔ amp-plugin: getMode ignores invalid env var and falls through to default (0.719003ms)
✔ amp-plugin: saveMode writes defaultMode to config JSON (2.168909ms)
✔ amp-plugin: saveMode creates parent directories automatically (2.324109ms)
✔ amp-plugin: filterBodyForMode strips frontmatter (0.874703ms)
✔ amp-plugin: filterBodyForMode keeps lines matching mode, drops others (1.028904ms)
✔ amp-plugin: filterBodyForMode keeps non-mode lines unchanged (0.391302ms)
✔ amp-plugin: getInstructions header contains active mode name (16.405462ms)
✔ amp-plugin: getInstructions normalizes unknown mode to full (5.18062ms)
✔ amp-plugin: readSkillPrompt returns content for known skill names (4.427417ms)
✔ amp-plugin: readSkillPrompt returns generic fallback for unknown skill name (2.136808ms)
✔ amp-plugin: statusText is empty string for off mode (0.402302ms)
✔ amp-plugin: statusText includes emoji and uppercased mode for active modes (0.648803ms)
✔ amp-plugin: session.start syncs mode from amp.configuration (33.585805ms)
✔ amp-plugin: session.start notifies when mode is active (3.355001ms)
✔ amp-plugin: session.start skips notification when mode is off (4.960501ms)
✔ amp-plugin: agent.start /ponytail ultra persists mode and returns early (1.9816ms)
✔ amp-plugin: agent.start /ponytail with invalid arg is ignored (3.115401ms)
✔ amp-plugin: agent.start /ponytail-review returns hidden skill message (11.612302ms)
✔ amp-plugin: agent.start /ponytail-audit returns hidden skill message (12.215102ms)
✔ amp-plugin: agent.start normal prompt injects instructions when active (5.870301ms)
✔ amp-plugin: agent.start normal prompt returns nothing when mode is off (1.920301ms)
```

### Verification
- ponytail options in amp command palette
<img width="1077" height="557" alt="image" src="https://github.com/user-attachments/assets/2a74aac2-7d38-4b93-ba95-ee06e0c3f5f9" />

- Auto selection for ponytail mode
<img width="1067" height="502" alt="image" src="https://github.com/user-attachments/assets/7953614c-0de8-46b9-94d8-c76879d622e2" />

- First prompt output is without activating ponytail, while second and third are with ponytail activated. ponytail activation is visible in  right bottom part.
<img width="1882" height="852" alt="image" src="https://github.com/user-attachments/assets/42b0aef7-5b98-48f1-b0ae-fb2affb6d288" />