### PR TITLE
fix: prevent Windows session freeze from stdin EOF deadlock (#443)

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -6,9 +6,11 @@ const { getDefaultMode, isDeactivationCommand } = require('./ponytail-config');
 const { clearMode, setMode, writeHookOutput } = require('./ponytail-runtime');
 
 let input = '';
-process.stdin.on('error', () => process.exit(0)); // broken pipe / parent crash: exit clean, never block session
-process.stdin.on('data', chunk => { input += chunk; });
-process.stdin.on('end', () => {
+let done = false;
+
+function finish() {
+  if (done) return;
+  done = true;
   try {
     // Strip UTF-8 BOM some shells prepend when piping (breaks JSON.parse)
     const data = JSON.parse(input.replace(/^\uFEFF/, ''));
@@ -53,4 +55,17 @@ process.stdin.on('end', () => {
   } catch (e) {
     // Silent fail
   }
-});
+}
+
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', finish);
+
+// Never hang the session. On Windows, Claude Code runs this hook through a
+// PowerShell `if {}` wrapper that can swallow the piped prompt JSON, so stdin
+// 'end' never fires and the hook blocks forever — freezing the session (#443).
+// On error, or after a short fallback, process whatever arrived (recovering the
+// mode if data came without EOF) and exit. unref() keeps the timer from adding
+// latency to the normal path, where 'end' fires first. Mirrors the best-effort,
+// never-block contract the other lifecycle hooks already follow.
+process.stdin.on('error', () => { finish(); process.exit(0); });
+setTimeout(() => { finish(); process.exit(0); }, 1000).unref();

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -9,6 +9,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+const { spawn } = require('child_process');
 
 const root = path.join(__dirname, '..');
 const HOOKS_JSON = 'hooks/claude-codex-hooks.json';
@@ -72,6 +73,27 @@ test('every hook command points at a script that ships in hooks/', () => {
       assert.ok(fs.existsSync(script), `command references a missing hook script: ${match[1]}`);
     }
   }
+});
+
+// Issue #443: on Windows the UserPromptSubmit hook runs inside a PowerShell
+// `if {}` wrapper that can swallow the piped prompt JSON, so stdin 'end' never
+// fires. The hook must never wait on stdin forever — that freezes the whole
+// session. It has to self-exit even when stdin stays open and empty.
+test('ponytail-mode-tracker self-exits when stdin never closes (no freeze)', async () => {
+  const hook = path.join(root, 'hooks', 'ponytail-mode-tracker.js');
+  // stdin is a pipe we never write to or end, reproducing the deadlock.
+  const child = spawn(process.execPath, [hook], { stdio: ['pipe', 'ignore', 'ignore'] });
+
+  const code = await new Promise((resolve, reject) => {
+    const guard = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new Error('hook hung on open stdin — it would freeze the session'));
+    }, 3000);
+    child.on('exit', (c) => { clearTimeout(guard); resolve(c); });
+    child.on('error', reject);
+  });
+
+  assert.equal(code, 0, 'hook must exit cleanly when stdin never closes');
 });
 
 test('Claude and Codex manifests point at the shared host-specific hook config', () => {


### PR DESCRIPTION
## Problem

Closes #443. On Windows, Claude Code freezes indefinitely after installing ponytail: submit any prompt and the session hangs with no spinner, no output, only Ctrl+C recovers it.

## Root cause

`hooks/ponytail-mode-tracker.js` (UserPromptSubmit hook) only completed inside `process.stdin.on('end', ...)`. On Windows the hook runs via the PowerShell `if {}` wrapper in `claude-codex-hooks.json`; a native command inside that block does not reliably receive the parent's piped stdin, so the prompt JSON never reaches node and `'end'` never fires. The process waits on stdin forever and Claude Code blocks on the hook, freezing the session.

## Fix

Make the hook non-blocking, matching the never-block contract the other lifecycle hooks follow:

- Extract the handler into `finish()`, guarded by a `done` flag so it runs at most once.
- A `process.stdin.on('error', ...)` handler runs `finish()` then exits.
- A 1s `unref()`'d fallback timeout runs `finish()` (recovering the mode even if data arrived without EOF) and exits. `unref()` means zero added latency on the normal path, where `'end'` fires first.
- Regression test in `tests/hooks-windows.test.js` spawns the hook with a never-closing stdin pipe and asserts clean self-exit; without the fix it hits the 3s guard and fails.

## Verification

- `npm test`: 70 + 15 pass, exit 0. `check-rule-copies` / `check-versions`: exit 0.
- Freeze repro (open, never-closing stdin) exits 0 in ~1s instead of hanging.
- Normal `/ponytail` commands still work.

## Note

This supersedes #453 (same fix by @Hasnan42, credited as co-author): #453 branched before #227 and #474 landed and conflicts on both changed files. This reconciles the identical fix onto current main. Suggest closing #453 in favor of this.

Does not address the secondary settings.json BOM symptom mentioned in #443 (`Failed to set model ... not valid JSON`); that is tracked separately in #375.