### PR TITLE
fix: strip UTF-8 BOM before parsing config.json (#375)

### DIFF
--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -83,7 +83,8 @@ function getDefaultMode() {
   // 2. Config file
   try {
     const configPath = getConfigPath();
-    const config = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    // Strip UTF-8 BOM (common on Windows-saved files) so JSON.parse doesn't choke
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
     if (config.defaultMode && VALID_MODES.includes(config.defaultMode.toLowerCase())) {
       return config.defaultMode.toLowerCase();
     }


### PR DESCRIPTION
## Problem

Closes #375. `getDefaultMode()` in `hooks/ponytail-config.js` parsed the config file with `JSON.parse(fs.readFileSync(...))` and no BOM strip. A `config.json` saved with a UTF-8 BOM (common on Windows editors/PowerShell) fails to parse, so the user's `defaultMode` is silently ignored and ponytail falls back to `full`.

## Fix

Strip the BOM before parsing, using the same `/^\uFEFF/` pattern already used in `ponytail-activate.js`, `check-versions.js`, and `ponytail-mode-tracker.js`. One line.

## Verification

- `npm test`: 69 + 15 pass, exit 0. `check-rule-copies` / `check-versions`: exit 0.
- End-to-end: wrote a BOM-prefixed `config.json` (via `XDG_CONFIG_HOME`) with `{"defaultMode":"ultra"}`; `getDefaultMode()` returned `ultra` (before the fix it silently returned the default).

## Note

Supersedes the `#375` portion of #384 (same fix by @nanaubusiness, credited as co-author). Two differences: this uses the repo's `/^\uFEFF/` escape rather than a literal BOM character in the source (an invisible source char is fragile and can be stripped by editors/linters), and it drops #384's unrelated `scripts/uninstall.js` change, which duplicates the dedicated PR #383 (that belongs to #374, not #375). Suggest closing #384 in favor of this; #383 still tracks the uninstall.js/#374 change on its own.