### PR TITLE
fix: don't destroy combined statuslines on uninstall (#374)

### DIFF
--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -26,14 +26,26 @@ try {
   const raw = fs.readFileSync(settingsPath, 'utf8').replace(/^\uFEFF/, '');
   const settings = JSON.parse(raw);
   const cmd = settings.statusLine && settings.statusLine.command;
-  // ponytail: substring-match the script name, then drop the whole statusLine
-  // key. A combined statusline (e.g. caveman+ponytail) whose command contains
-  // "ponytail-statusline" gets removed wholesale. Parse out only ponytail's part
-  // if combined statuslines become common.
+  // Only remove the statusLine if ponytail owns the whole command. If the user
+  // combined it with another statusline (e.g. caveman && ponytail), deleting the
+  // key or the command field would destroy the other plugin's part, so leave it
+  // and tell them to strip ponytail's segment by hand.
+  // ponytail: splits on && / ; to detect other segments — good enough; a user
+  // piping statuslines together is on their own.
   if (typeof cmd === 'string' && cmd.includes('ponytail-statusline')) {
-    delete settings.statusLine;
-    fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
-    console.log(`Removed ponytail statusLine entry from ${settingsPath}`);
+    const others = cmd
+      .split(/&&|;/)
+      .map((s) => s.trim())
+      .filter((s) => s && !s.includes('ponytail-statusline'));
+    if (others.length === 0) {
+      delete settings.statusLine;
+      fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
+      console.log(`Removed ponytail statusLine entry from ${settingsPath}`);
+    } else {
+      console.log(
+        `Left your combined statusLine in ${settingsPath} untouched; remove the ponytail-statusline part by hand.`,
+      );
+    }
   }
 } catch (e) {
   if (e.code !== 'ENOENT') throw e;

--- a/tests/uninstall.test.js
+++ b/tests/uninstall.test.js
@@ -69,6 +69,21 @@ assert.equal(
   "a user's own statusLine must not be touched",
 );
 
+// #374: a combined statusline (another plugin && ponytail) must keep the other
+// plugin's part — uninstall must not nuke the whole command or leave a husk.
+fs.writeFileSync(settingsPath, JSON.stringify({
+  statusLine: { type: 'command', command: 'bash ~/caveman-statusline.sh && bash /p/ponytail-statusline.sh' },
+}));
+
+result = runUninstall(env);
+assert.equal(result.status, 0, result.stderr);
+const settingsAfter3 = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+assert.equal(
+  settingsAfter3.statusLine.command,
+  'bash ~/caveman-statusline.sh && bash /p/ponytail-statusline.sh',
+  'a combined statusLine must be left untouched, not partially destroyed',
+);
+
 // Running on an already-clean machine must not throw.
 result = runUninstall({ HOME: path.join(temp, 'home-empty'), USERPROFILE: path.join(temp, 'home-empty') });
 assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
## Problem

Closes #374. `scripts/uninstall.js` deleted the entire `statusLine` key whenever the command contained `ponytail-statusline`. If a user combined statuslines (e.g. `bash caveman-statusline.sh && bash ponytail-statusline.sh`), uninstalling ponytail destroyed the other plugin's statusline too.

PR #383's approach (`delete settings.statusLine.command`) does not fix this: on a combined command it still removes the whole command string (caveman included) and leaves a malformed `{type:'command'}` husk. Demonstrated:

| approach | result on `caveman && ponytail` |
|---|---|
| old (`delete statusLine`) | whole key gone, caveman destroyed |
| #383 (`delete .command`) | husk left, caveman still destroyed |
| this PR | left untouched, caveman preserved |

## Fix

Only remove the statusLine when ponytail owns the whole command. If it's combined with other segments (split on `&&` / `;`), leave it and print a one-line notice to strip ponytail's part by hand. Never nukes another plugin's statusline, never leaves a husk. The common ponytail-only case behaves exactly as before.

## Verification

- `npm test`: 69 + 15 pass, exit 0. `check-rule-copies` / `check-versions`: exit 0.
- Added a regression test: a combined `caveman && ponytail` statusLine is left untouched after uninstall.

## Note

Supersedes #383 (same issue, by @nanaubusiness, credited as co-author), whose one-line change did not actually preserve the other plugin's statusline. Suggest closing #383 in favor of this.