### PR TITLE
docs(help): list all 6 skills and fix OpenCode command count (#437, #438)

### DIFF
--- a/.openclaw/skills/ponytail-help/SKILL.md
+++ b/.openclaw/skills/ponytail-help/SKILL.md
@@ -26,12 +26,14 @@ Level sticks until changed or session end.
 |-------|---------|--------------|
 | **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
 | **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
+| **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit: ranked list of what to delete. |
+| **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` shortcut comments into a tracked ledger. |
 | **ponytail-gain** | `/ponytail-gain` | Measured-impact scoreboard: less code, less cost, more speed. |
 | **ponytail-help** | `/ponytail-help` | This card. |
 
 Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
-and OpenCode use the slash-command forms above (OpenCode ships `/ponytail` and
-`/ponytail-review`).
+and OpenCode use the slash-command forms above (OpenCode ships all six as
+slash commands).
 
 ## Deactivate
 

--- a/skills/ponytail-help/SKILL.md
+++ b/skills/ponytail-help/SKILL.md
@@ -27,12 +27,14 @@ Level sticks until changed or session end.
 |-------|---------|--------------|
 | **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
 | **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
+| **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit: ranked list of what to delete. |
+| **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` shortcut comments into a tracked ledger. |
 | **ponytail-gain** | `/ponytail-gain` | Measured-impact scoreboard: less code, less cost, more speed. |
 | **ponytail-help** | `/ponytail-help` | This card. |
 
 Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
-and OpenCode use the slash-command forms above (OpenCode ships `/ponytail` and
-`/ponytail-review`).
+and OpenCode use the slash-command forms above (OpenCode ships all six as
+slash commands).
 
 ## Deactivate
 


### PR DESCRIPTION
## Problem

- **#437**: the ponytail-help skills table listed only 4 skills, omitting `ponytail-audit` and `ponytail-debt` (both ship as commands). A user reading /ponytail-help would not know they exist.
- **#438**: the same file claimed OpenCode ships only `/ponytail` and `/ponytail-review`, when `.opencode/command/` ships all six.

## Fix

Add the two missing table rows (with accurate descriptions: audit is whole-repo, debt harvests `ponytail:` comments) and correct the OpenCode note to "ships all six as slash commands". Regenerated the `.openclaw` copy via `scripts/build-openclaw-skills.js` so it stays in sync (the suite enforces this).

## Verification

- `npm test`: 69 + 15 pass, exit 0 (the openclaw-sync tests that would flag a stale copy pass). `check-rule-copies` / `check-versions`: exit 0.

## Notes

- Supersedes #441 (which bundled an unrelated, syntactically broken `uninstall.js` change and gave `ponytail-audit` a wrong description) and #470 (already closed). Suggest closing #441.
- This is a `skills/` file, so it's under your benchmark gate. It's a display-only help card though (no ruleset or trigger/description change), so behavior is unaffected.
- Separate, not fixed here: the `.opencode/command/ponytail-help.md` card omits `/ponytail-gain` in its command list (the `.toml` one has it). Same class, different file — happy to do it in a follow-up.