### PR TITLE
fix: don't crash uninstall on malformed settings.json (#434)

### DIFF
--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -48,5 +48,12 @@ try {
     }
   }
 } catch (e) {
-  if (e.code !== 'ENOENT') throw e;
+  if (e.code === 'ENOENT') {
+    // no settings.json — nothing to clean
+  } else if (e instanceof SyntaxError) {
+    // ponytail: malformed settings.json — can't safely edit it; leave intact, warn
+    console.warn(`settings.json is malformed — could not remove the ponytail statusLine entry. Remove it manually from: ${settingsPath} (${e.message})`);
+  } else {
+    throw e;
+  }
 }

--- a/tests/uninstall.test.js
+++ b/tests/uninstall.test.js
@@ -84,6 +84,28 @@ assert.equal(
   'a combined statusLine must be left untouched, not partially destroyed',
 );
 
+// #434: a malformed settings.json must not crash the script mid-cleanup. It
+// can't be safely edited, so uninstall warns and leaves the file byte-for-byte
+// intact instead of throwing a SyntaxError after other state was already removed.
+const malformedSettings = '{ "statusLine": { "command": "ponytail-statusline.sh", broken';
+fs.writeFileSync(settingsPath, malformedSettings);
+
+result = runUninstall(env);
+assert.equal(
+  result.status,
+  0,
+  `expected exit 0 on malformed settings.json, got:\n${result.stdout}${result.stderr}`,
+);
+assert.ok(
+  /malformed/i.test(result.stdout + result.stderr),
+  'must warn that the statusLine entry could not be removed',
+);
+assert.equal(
+  fs.readFileSync(settingsPath, 'utf8'),
+  malformedSettings,
+  'malformed settings.json must be left unchanged',
+);
+
 // Running on an already-clean machine must not throw.
 result = runUninstall({ HOME: path.join(temp, 'home-empty'), USERPROFILE: path.join(temp, 'home-empty') });
 assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
## Problem

Closes #434. In `scripts/uninstall.js`, a malformed `settings.json` makes `JSON.parse` throw a `SyntaxError`, which has no `.code`, so `if (e.code !== 'ENOENT') throw e` rethrew it and crashed the script — **after** the mode flag and config file were already removed, leaving cleanup half-done.

Reproduced on current main: with a malformed settings.json the script exits non-zero with an uncaught SyntaxError, after `.ponytail-active` was already deleted.

## Fix

Handle `SyntaxError` explicitly in the catch: warn that the statusLine entry couldn't be removed and leave the file untouched (invalid JSON can't be safely edited), then exit 0. ENOENT stays a no-op; any other error still rethrows.

## Verification

- `npm test`: 70 + 15 pass, exit 0. `check-rule-copies` / `check-versions`: exit 0.
- Added a regression test: malformed settings.json → exit 0, warns, file left byte-for-byte intact.
- e2e: with a stale flag present and malformed settings.json, the flag is removed, the script warns and exits 0, and settings.json is unchanged.

## Note

Supersedes #469 (same fix by @isaukywhite, credited as co-author), which branched before #479 (combined-statusline guard) and #480 landed and so conflicts on both changed files. This reconciles the identical fix onto current main. Suggest closing #469 in favor of this. (#471 is a separate packaging concern, not touched here.)