### PR TITLE
fix: handle CRLF line endings in loc.js fence regex (#339)

### DIFF
--- a/benchmarks/behavior.js
+++ b/benchmarks/behavior.js
@@ -10,10 +10,6 @@
 //
 // Metric: `behavior` (1 = behavior present, 0 = absent).
 
-function codeOf(text) {
-  return [...String(text || '').matchAll(/```[\w-]*\n([\s\S]*?)```/g)].map((m) => m[1]).join('\n');
-}
-
 function proseOf(text) {
   return String(text || '').replace(/```[\s\S]*?```/g, ' ').replace(/\s+/g, ' ').trim();
 }

--- a/benchmarks/loc.js
+++ b/benchmarks/loc.js
@@ -3,7 +3,7 @@
 // Recorded as the `code_loc` metric per arm (always passes; it is a measurement, not a gate).
 module.exports = (output) => {
   const text = String(output || '');
-  const blocks = [...text.matchAll(/```[a-zA-Z0-9_+-]*\n([\s\S]*?)```/g)].map((m) => m[1]);
+  const blocks = [...text.matchAll(/```[a-zA-Z0-9_+-]*\r?\n([\s\S]*?)```/g)].map((m) => m[1]);
   // Drop /* ... */ block comments before counting; the line filter below only
   // caught `*`-aligned JSDoc, so plain block comments were miscounted as code.
   const code = (blocks.length ? blocks.join('\n') : text).replace(/\/\*[\s\S]*?\*\//g, '');

--- a/benchmarks/loc.test.js
+++ b/benchmarks/loc.test.js
@@ -13,6 +13,7 @@ const cases = [
   ['inline block comment keeps its code line', score('```js\nconst x = 1; /* note */\nconst y = 2;\n```'), 2],
   ['line comments still stripped', score('```js\n// header\nconst x = 1;\n```'), 1],
   ['plain code unchanged', score('```js\nconst a = 1;\nconst b = 2;\n```'), 2],
+  ['CRLF fences parsed correctly (#339)', score('```js\r\nconst a = 1;\r\nconst b = 2;\r\n```'), 2],
 ];
 for (const [name, got, want] of cases) {
   assert.strictEqual(got, want, `FAILED: ${name} (got ${got}, want ${want})`);


### PR DESCRIPTION
Heyy, noticed `loc.js` was the odd one out — `correctness.js` and `robustness-audit.js` both handle CRLF with `\r?\n` but `loc.js` still used bare `\n`, so fenced blocks from Windows-origin responses just silently didn't match. Quick regex fix to bring it in line with the rest.

Also spotted that `codeOf()` in `behavior.js` is defined but never actually called by any of the check functions — removed the dead code while I was in there.

## Summary
- Fixes `loc.js` fence-matching regex to handle `\r\n` (CRLF) line endings using `\r?\n`
- Removes dead `codeOf()` function from `behavior.js` (defined but never called by any check function)
- Adds CRLF test case to `loc.test.js`

## Test plan
- [x] `node benchmarks/loc.test.js` — 6/6 pass including new CRLF test
- [x] `node tests/behavior.test.js` — 8/8 pass after dead code removal

Fixes #339