### PR TITLE
fix: detect compression-plugin conflicts and add deconfliction (#332)

### DIFF
--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -95,6 +95,24 @@ function getDefaultMode() {
   return DEFAULT_MODE;
 }
 
+const KNOWN_COMPRESSION_PLUGINS = ['caveman'];
+
+function detectCompressionPlugins() {
+  try {
+    const settingsPath = path.join(getClaudeDir(), 'settings.json');
+    const raw = fs.readFileSync(settingsPath, 'utf8').replace(/^﻿/, '');
+    const settings = JSON.parse(raw);
+    const found = [];
+    const blob = JSON.stringify(settings).toLowerCase();
+    for (const name of KNOWN_COMPRESSION_PLUGINS) {
+      if (blob.includes(name)) found.push(name);
+    }
+    return found;
+  } catch (e) {
+    return [];
+  }
+}
+
 function writeDefaultMode(mode) {
   const normalized = normalizeConfigMode(mode);
   if (!normalized) return null;
@@ -109,6 +127,7 @@ module.exports = {
   DEFAULT_MODE,
   VALID_MODES,
   RUNTIME_MODES,
+  detectCompressionPlugins,
   getDefaultMode,
   getConfigDir,
   getConfigPath,

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { DEFAULT_MODE, normalizeMode, normalizePersistedMode } = require('./ponytail-config');
+const { DEFAULT_MODE, normalizeMode, normalizePersistedMode, detectCompressionPlugins } = require('./ponytail-config');
 
 const INDEPENDENT_MODES = new Set(['review']);
 const SKILL_PATH = path.join(__dirname, '..', 'skills', 'ponytail', 'SKILL.md');
@@ -70,6 +70,16 @@ function getFallbackInstructions(mode) {
     'Ponytail governs what you build, not how you talk. "stop ponytail" or "normal mode": revert. Level persists until changed or session end.';
 }
 
+function getCompressionDeconfliction() {
+  const peers = detectCompressionPlugins();
+  if (peers.length === 0) return '';
+  return '\n\n## Compression plugin coexistence\n\n' +
+    'Detected: ' + peers.join(', ') + '. ' +
+    'Ponytail governs WHAT to build (the ladder, YAGNI, stdlib-first, minimal diffs). ' +
+    'Defer to the other plugin for output STYLE (brevity, tone, formatting). ' +
+    'If rules conflict, the structural rule (ponytail) wins for code decisions; the style rule (peer plugin) wins for prose and formatting.';
+}
+
 function getPonytailInstructions(mode) {
   const configuredMode = normalizePersistedMode(mode) || DEFAULT_MODE;
 
@@ -78,12 +88,13 @@ function getPonytailInstructions(mode) {
   }
 
   const effectiveMode = normalizeMode(configuredMode) || DEFAULT_MODE;
+  const deconfliction = getCompressionDeconfliction();
 
   try {
     return 'PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' +
-      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode);
+      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode) + deconfliction;
   } catch (e) {
-    return getFallbackInstructions(effectiveMode);
+    return getFallbackInstructions(effectiveMode) + deconfliction;
   }
 }
 

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -209,4 +209,48 @@ assert.equal(output.systemMessage, 'PONYTAIL:FULL');
 assert.equal(output.hookSpecificOutput.hookEventName, 'SubagentStart');
 assert.match(output.hookSpecificOutput.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);
 
+// Compression-plugin deconfliction (issue #332): when caveman is in settings.json
+// the instructions must include a deconfliction paragraph.
+const { detectCompressionPlugins } = require('../hooks/ponytail-config');
+const { getPonytailInstructions } = require('../hooks/ponytail-instructions');
+
+const deconflictHome = path.join(temp, 'deconflict-home');
+const deconflictClaudeDir = path.join(deconflictHome, '.claude');
+fs.mkdirSync(deconflictClaudeDir, { recursive: true });
+
+const cavemanSettings = {
+  hooks: {
+    SessionStart: [{ hooks: [{ type: 'command', command: 'node /path/to/caveman/activate.js' }] }],
+  },
+};
+fs.writeFileSync(path.join(deconflictClaudeDir, 'settings.json'), JSON.stringify(cavemanSettings));
+
+const prevConfigDir = process.env.CLAUDE_CONFIG_DIR;
+process.env.CLAUDE_CONFIG_DIR = deconflictClaudeDir;
+
+const peers = detectCompressionPlugins();
+assert.ok(peers.includes('caveman'), 'detectCompressionPlugins must find caveman in settings.json');
+const instructions = getPonytailInstructions('full');
+assert.ok(
+  instructions.includes('Compression plugin coexistence'),
+  'instructions must include deconfliction paragraph when caveman detected',
+);
+assert.ok(
+  instructions.includes('caveman'),
+  'deconfliction paragraph must name the detected plugin',
+);
+
+// Without caveman: no deconfliction paragraph.
+fs.writeFileSync(path.join(deconflictClaudeDir, 'settings.json'), JSON.stringify({}));
+const noPeers = detectCompressionPlugins();
+assert.deepEqual(noPeers, [], 'no compression plugins detected without caveman');
+const cleanInstructions = getPonytailInstructions('full');
+assert.ok(
+  !cleanInstructions.includes('Compression plugin coexistence'),
+  'instructions must not include deconfliction paragraph without caveman',
+);
+
+if (prevConfigDir === undefined) delete process.env.CLAUDE_CONFIG_DIR;
+else process.env.CLAUDE_CONFIG_DIR = prevConfigDir;
+
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
Hey! Saw that caveman already added ponytail detection on their side (PR #577), so figured ponytail should reciprocate. Right now if you have both installed, the model gets two full instruction sets with overlapping (and sometimes contradictory) style rules every session — not great.

This adds a `detectCompressionPlugins()` check that scans `settings.json` for known peers. When caveman is present, ponytail appends a short deconfliction paragraph establishing clear lanes: ponytail owns code structure decisions (the ladder, YAGNI, stdlib-first), peer plugin owns output style. No more tug-of-war.

## Changes
- `hooks/ponytail-config.js` — new `detectCompressionPlugins()` function + export
- `hooks/ponytail-instructions.js` — `getCompressionDeconfliction()` appends boundary paragraph when peers detected
- `tests/hooks.test.js` — tests detection with/without caveman in mock settings.json

## Test plan
- [x] `node tests/hooks.test.js` passes with new caveman detection tests
- [x] Verifies deconfliction paragraph appears when caveman detected
- [x] Verifies no deconfliction paragraph without caveman
- [x] Pi-extension tests (8/8) still pass

Fixes #332