### PR TITLE
fix: add CJK language paragraph to ponytail instructions (#333)

### DIFF
--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -70,6 +70,13 @@ function getFallbackInstructions(mode) {
     'Ponytail governs what you build, not how you talk. "stop ponytail" or "normal mode": revert. Level persists until changed or session end.';
 }
 
+const CJK_PARAGRAPH =
+  '\n\n## CJK languages\n\n' +
+  'When the conversation is in Chinese, Japanese, or Korean: ' +
+  'skip English-specific brevity rules (article dropping, synonym shortening — CJK has no articles and is already compact). ' +
+  'The ladder, YAGNI, stdlib-first, shortest diff, and all structural rules still apply. ' +
+  'Keep code comments and identifiers in whichever language the codebase already uses.';
+
 function getPonytailInstructions(mode) {
   const configuredMode = normalizePersistedMode(mode) || DEFAULT_MODE;
 
@@ -81,9 +88,9 @@ function getPonytailInstructions(mode) {
 
   try {
     return 'PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' +
-      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode);
+      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode) + CJK_PARAGRAPH;
   } catch (e) {
-    return getFallbackInstructions(effectiveMode);
+    return getFallbackInstructions(effectiveMode) + CJK_PARAGRAPH;
   }
 }
 

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -209,4 +209,16 @@ assert.equal(output.systemMessage, 'PONYTAIL:FULL');
 assert.equal(output.hookSpecificOutput.hookEventName, 'SubagentStart');
 assert.match(output.hookSpecificOutput.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);
 
+// CJK language paragraph (issue #333): instructions must include CJK guidance.
+const { getPonytailInstructions } = require('../hooks/ponytail-instructions');
+const cjkInstructions = getPonytailInstructions('full');
+assert.ok(
+  cjkInstructions.includes('CJK languages'),
+  'instructions must include CJK language section',
+);
+assert.ok(
+  cjkInstructions.includes('article dropping'),
+  'CJK section must mention skipping article-dropping for CJK',
+);
+
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
Heyy — was using ponytail in a mixed Chinese/English codebase and realized the "drop articles" and "short synonyms" rules don't really make sense for CJK. Chinese doesn't have articles, and CJK characters are already compact so "use shorter synonyms" is a no-op at best, confusing at worst.

Rather than adding runtime language detection in the hooks (which don't see user messages anyway), this takes the instruction-level approach similar to caveman PR #576 — just tells the model directly to skip the English-specific brevity rules when responding in CJK. The structural stuff (ladder, YAGNI, stdlib-first) is language-agnostic and still applies.

## Summary
- Adds a CJK languages section to ponytail instructions
- Skips: article dropping, synonym shortening (English-specific)
- Keeps: all structural rules (ladder, YAGNI, stdlib-first, shortest diff)
- Code comments/identifiers follow whichever language the codebase already uses

## Test plan
- [x] `node tests/hooks.test.js` passes with new CJK assertions
- [x] Pi-extension tests (8/8) still pass
- [x] Verified CJK paragraph present in both SKILL.md-based and fallback instruction paths

Fixes #333