### PR TITLE
fix: persist mode changes to config so /ponytail off survives restart (#329)

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -2,7 +2,7 @@
 // ponytail — UserPromptSubmit hook to track which ponytail mode is active
 // Inspects user input for /ponytail commands and writes mode to flag file
 
-const { getDefaultMode, isDeactivationCommand } = require('./ponytail-config');
+const { getDefaultMode, isDeactivationCommand, writeDefaultMode } = require('./ponytail-config');
 const { clearMode, setMode, writeHookOutput } = require('./ponytail-runtime');
 
 let input = '';
@@ -36,6 +36,7 @@ function finish() {
 
       if (mode && mode !== 'off') {
         setMode(mode);
+        if (mode !== 'review') try { writeDefaultMode(mode); } catch (_) {}
         writeHookOutput(
           'UserPromptSubmit',
           mode,
@@ -43,6 +44,7 @@ function finish() {
         );
       } else if (mode === 'off') {
         clearMode();
+        try { writeDefaultMode('off'); } catch (_) {}
         writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
       }
     }
@@ -50,6 +52,7 @@ function finish() {
     // Detect deactivation
     if (isDeactivationCommand(prompt)) {
       clearMode();
+      writeDefaultMode('off');
       writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
     }
   } catch (e) {

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -209,4 +209,56 @@ assert.equal(output.systemMessage, 'PONYTAIL:FULL');
 assert.equal(output.hookSpecificOutput.hookEventName, 'SubagentStart');
 assert.match(output.hookSpecificOutput.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);
 
+// /ponytail off must persist across sessions — issue #329.
+// After `/ponytail off`, the next SessionStart should honour the persisted default
+// instead of re-activating with the hardcoded "full" fallback.
+const persistHome = path.join(temp, 'persist-home');
+fs.mkdirSync(persistHome, { recursive: true });
+const persistEnv = { HOME: persistHome, USERPROFILE: persistHome };
+
+// Activate first (creates flag file, mode = full by default)
+result = run('ponytail-activate.js', persistEnv);
+assert.equal(result.status, 0, result.stderr);
+const persistFlag = path.join(persistHome, '.claude', '.ponytail-active');
+assert.equal(fs.readFileSync(persistFlag, 'utf8'), 'full');
+
+// Now /ponytail off — should persist "off" to config.json
+result = run(
+  'ponytail-mode-tracker.js',
+  persistEnv,
+  JSON.stringify({ prompt: '/ponytail off' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.existsSync(persistFlag), false, 'flag should be cleared');
+const persistConfig = path.join(persistHome, '.config', 'ponytail', 'config.json');
+assert.equal(fs.existsSync(persistConfig), true, 'config.json should be created');
+assert.equal(
+  JSON.parse(fs.readFileSync(persistConfig, 'utf8')).defaultMode,
+  'off',
+  '/ponytail off must persist defaultMode to config.json',
+);
+
+// Next SessionStart should respect persisted "off" — no flag file, exit 0
+result = run('ponytail-activate.js', persistEnv);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(
+  fs.existsSync(persistFlag),
+  false,
+  'SessionStart after /ponytail off must not re-activate',
+);
+
+// Re-enable via /ponytail lite — should persist "lite" to config.json
+result = run(
+  'ponytail-mode-tracker.js',
+  persistEnv,
+  JSON.stringify({ prompt: '/ponytail lite' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.readFileSync(persistFlag, 'utf8'), 'lite');
+assert.equal(
+  JSON.parse(fs.readFileSync(persistConfig, 'utf8')).defaultMode,
+  'lite',
+  '/ponytail lite must persist defaultMode',
+);
+
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
Was playing around with different modes and noticed that /ponytail off doesn't stick across sessions — next time Claude starts, it's right back to full. Turns out the mode tracker cleared the session flag but never persisted the choice to config.json, so SessionStart re-activated every time.

## Summary
- Import and call `writeDefaultMode()` in `ponytail-mode-tracker.js` when mode changes
- All runtime mode switches (lite, full, ultra, off) are now persisted to `~/.config/ponytail/config.json`
- Review mode is intentionally excluded from persistence (it's a transient workflow)
- Deactivation via "stop ponytail" / "normal mode" also persists "off"

## Test plan
- [x] Added end-to-end persistence test: `/ponytail off` → verify config.json → SessionStart respects it
- [x] Added re-enable test: `/ponytail lite` → verify config.json updated
- [x] All existing hook tests still pass (`node tests/hooks.test.js`)

Fixes #329