### PR TITLE
fix: hermes test hardcoding python3 (fails on Windows)

### DIFF
--- a/tests/hermes-plugin.test.js
+++ b/tests/hermes-plugin.test.js
@@ -15,8 +15,21 @@ const skillCommands = commands.filter((name) => name !== 'ponytail');
 
 const root = path.join(__dirname, '..');
 
+// ponytail: probe once; on Windows `python3` is the Store-alias stub that fails
+// even when Python is installed, so fall back to `python` (mirrors benchmarks/correctness.js).
+let pythonCmd;
+function pythonExe() {
+  if (pythonCmd) return pythonCmd;
+  for (const cmd of ['python3', 'python']) {
+    if (spawnSync(cmd, ['-c', 'import sys'], { encoding: 'utf8' }).status === 0) {
+      return (pythonCmd = cmd);
+    }
+  }
+  return (pythonCmd = 'python3');
+}
+
 function python(script, env = {}) {
-  const result = spawnSync('python3', ['-c', script], {
+  const result = spawnSync(pythonExe(), ['-c', script], {
     cwd: root,
     env: { ...process.env, ...env },
     encoding: 'utf8',


### PR DESCRIPTION
## Problem

`tests/hermes-plugin.test.js` spawned `python3` with no fallback. On Windows, `python3` resolves to the Microsoft Store app-execution-alias stub, which exits non-zero even when Python is installed. Every python-backed case in the hermes suite therefore failed on Windows despite a working interpreter.

Reproduced locally: `python` -> `C:\Python314\python`, but `python3` -> the WindowsApps stub, and `node --test tests/hermes-plugin.test.js` errored on every python-backed case.

## Fix

Reuse the probe/fallback pattern already used in `benchmarks/correctness.js`: try `python3`, fall back to `python`, cache the result once.

## Verification

`node --test tests/hermes-plugin.test.js` -> 8 pass, 0 fail (was: every python-backed case erroring on Windows).

Fixes #498