### PR TITLE
 fix(pi): recognize and display review mode

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -47,7 +47,7 @@ export function parsePonytailCommand(text, defaultMode = DEFAULT_MODE) {
     return mode ? { type: "set-default", mode } : { type: "invalid", reason: "invalid-default-mode" };
   }
 
-  const mode = normalizeMode(primary);
+  const mode = normalizePersistedMode(primary);
   return mode ? { type: "set-mode", mode } : { type: "invalid", reason: "invalid-mode", mode: primary };
 }
 

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -69,7 +69,7 @@ export default function ponytailExtension(pi) {
       c.ui.setStatus("ponytail", "");
       return;
     }
-    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥" };
+    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥", review: "🔎" };
     const icon = levelIcons[currentMode] || "";
     const label = currentMode.toUpperCase();
     const indicator = isActive ? theme.fg("accent", "●") : theme.fg("dim", "○");

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -152,6 +152,20 @@ test("status bar renders the mode and flips active on agent_start", async () => 
   assert.match(statusWrites.at(-1).text, /●.*ULTRA/);
 }));
 
+test("status bar renders persisted review mode", async () => withTempConfig(async () => {
+  const { events } = createPiHarness();
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "review" } }] },
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_color, text) => text } },
+  });
+
+  await events.get("session_start")({ reason: "resume" }, ctx);
+
+  assert.equal(statusWrites.at(-1).key, "ponytail");
+  assert.match(statusWrites.at(-1).text, /○.*🔎 REVIEW/);
+}));
+
 test("status bar stays silent when ui lacks a theme", async () => withTempConfig(async () => {
   const { events } = createPiHarness();
   const calls = [];

--- a/pi-extension/test/helpers.test.js
+++ b/pi-extension/test/helpers.test.js
@@ -18,6 +18,7 @@ test("parsePonytailCommand falls back to full when invoked bare and default is o
 
 test("parsePonytailCommand parses modes, status, and default subcommand", () => {
   assert.deepEqual(parsePonytailCommand("ultra", "full"), { type: "set-mode", mode: "ultra" });
+  assert.deepEqual(parsePonytailCommand("review", "full"), { type: "set-mode", mode: "review" });
   assert.deepEqual(parsePonytailCommand("status", "full"), { type: "status" });
   assert.deepEqual(parsePonytailCommand("default lite", "full"), { type: "set-default", mode: "lite" });
 });


### PR DESCRIPTION
## Summary

`review` is already a valid, persisted mode across the project (`VALID_MODES` in `hooks/ponytail-config.js`, referenced by the MCP instructions, the mode-tracker hook, and the Hermes plugin), but the Pi extension hadn't caught up on two fronts:

- The command parser used `normalizeMode` instead of `normalizePersistedMode`, so typing `review` as a command wasn't accepted (it silently fell through as invalid).
- The status bar's `levelIcons` map had no entry for `review`, so a persisted review-mode session rendered with no icon.

## Changes

- `pi-extension/index.js`: accept `review` as a settable mode via the command parser (`normalizePersistedMode`); add a `review: "🔎"` icon so the status bar renders it distinctly from `lite`/`full`/`ultra`.
- Tests covering both: command parsing accepts `review`, and the status bar renders `🔎 REVIEW` for a persisted review-mode session.

## Test plan

- [x] `npm test` — all 77 tests pass (16 root + 61 pi-extension, incl. the 2 new cases)