### PR TITLE
feat(skills): add ponytail-no-hallucination companion skill

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -17,6 +17,7 @@ SKILL_COMMANDS = {
     "ponytail-debt": "List every deliberate `ponytail:` shortcut and its upgrade path.",
     "ponytail-gain": "Show the measured-impact scoreboard (less code, less cost, more speed).",
     "ponytail-help": "Show the Ponytail command reference.",
+    "ponytail-no-hallucination": "Activate the reality-check layer: blocks invented APIs, deprecated methods, and undeclared variables.",
 }
 
 ROOT = Path(__file__).resolve().parent

--- a/skills/ponytail-no-hallucination/SKILL.md
+++ b/skills/ponytail-no-hallucination/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: ponytail-no-hallucination
+description: >
+  Reality-check layer that prevents the agent from inventing APIs, methods,
+  imports, or variables that do not exist. Activates alongside the core
+  ponytail skill to ensure that "minimal code" means correct minimal code,
+  not hallucinated minimal code. A fake one-liner that calls a non-existent
+  function is not lazy — it is a bug with extra confidence. Use whenever
+  the user says "no hallucinations", "verify APIs", "reality check",
+  "don't invent functions", "check this exists", "anti-hallucination",
+  or asks you to confirm that all methods and imports in a response are real.
+  Do NOT activate for non-coding tasks.
+argument-hint: "[on|off]"
+license: MIT
+---
+
+# Ponytail — No Hallucination Layer
+
+Inventing a function that doesn't exist is the opposite of lazy.
+You wrote a line that looks minimal. You shipped a bug that takes an hour to debug.
+The true lazy path is: use only what is provably there.
+
+## The Only Rule
+
+Before you write any function call, import, or method access, you must be
+able to answer: **"Does this exist in the version the user is running?"**
+
+If the answer is "probably" or "I think so" — stop. You don't know.
+
+## What this blocks
+
+**Made-up methods.** `fs.readFileLines()` does not exist. `path.combine()` is
+.NET, not Node.js. `csv.read_csv()` is pandas, not Python's `csv` module.
+`render_template()` is Flask, not Django. Writing these is not minimal code —
+it is confident garbage.
+
+**Framework confusion.** Every framework has a twin that sounds like it:
+- `render_template` (Flask) vs `render()` (Django)
+- `req.isAuthenticated()` (Passport.js) vs rolling your own check (Express)
+- `useForm()` (react-hook-form) vs nothing built into React
+
+Do not cross the streams. Know which codebase you are in.
+
+**Deprecated APIs.** Using a deprecated API is not lazy — it is writing code
+that will break on the next upgrade:
+- `new Buffer()` → `Buffer.from()` (Node.js)
+- `ReactDOM.render()` → `createRoot().render()` (React 18+)
+- `express.bodyParser()` → `express.json()` (Express 4.16+)
+- `django.conf.urls.url()` → `path()` (Django 4+)
+
+**Undeclared variables.** Every name you reference must be declared or imported
+in the same response. A variable that exists in the user's head and not in the
+code is a hallucination with good intentions.
+
+## How to handle uncertainty
+
+You are not sure if a method exists in the user's version? Say so:
+
+```js
+// ponytail: verify fs.openAsBlob exists in your Node.js version (>= 20.0)
+```
+
+This is the lazy path. One comment costs nothing. A silent wrong call costs
+an hour of the user's time.
+
+If the uncertainty is high enough that you cannot write correct code, say:
+> "I'd need to check whether X exists in version Y before using it.
+> What version are you on?"
+
+That is not weakness. That is the senior dev who has been burned before.
+
+## Pairing
+
+This skill governs **what APIs you reference**.
+Ponytail governs **how much code you write**.
+Pair both: minimal code that is also provably real.
+
+`stop ponytail-no-hallucination` or `normal mode`: reverts.


### PR DESCRIPTION
## Summary

Adds a new `ponytail-no-hallucination` companion skill that acts as a reality-check layer alongside the core ponytail skill.

Closes #432

## Motivation

The ponytail ladder (YAGNI → stdlib → one line) encourages minimal output, but a model under minimalism pressure will sometimes invent a plausible-looking API rather than use the real one. Inventing `fs.readFileLines()` or `path.combine()` is not lazy — it ships a confident bug that takes an hour to debug.

## What this adds

A new skill at `skills/ponytail-no-hallucination/SKILL.md` that blocks:
- **Made-up methods** — functions that do not exist in the specified library
- **Framework confusion** — e.g. Flask's `render_template` in a Django codebase
- **Deprecated APIs** — `new Buffer()`, `ReactDOM.render()`, etc.
- **Undeclared variables** — names referenced but never imported or defined

Written in Ponytail's own voice: *"The true lazy path is to use only what is provably there."* Designed to pair with the core skill, not replace it.

## Changes

- `skills/ponytail-no-hallucination/SKILL.md` — new skill file
- `__init__.py` — registers `/ponytail-no-hallucination` in `SKILL_COMMANDS`
