### PR TITLE
feat: add PONYTAIL_HIDE_STATUS to suppress status bar indicator (#324)

### DIFF
--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -96,6 +96,15 @@ function getDefaultMode() {
   return DEFAULT_MODE;
 }
 
+function getHideStatus() {
+  if (process.env.PONYTAIL_HIDE_STATUS) return true;
+  try {
+    const configPath = getConfigPath();
+    const config = JSON.parse(fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
+    return config.hideStatus === true;
+  } catch (_) { return false; }
+}
+
 function writeDefaultMode(mode) {
   const normalized = normalizeConfigMode(mode);
   if (!normalized) return null;
@@ -114,6 +123,7 @@ module.exports = {
   getConfigDir,
   getConfigPath,
   getClaudeDir,
+  getHideStatus,
   isShellSafe,
   normalizeMode,
   normalizeConfigMode,

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -4,6 +4,7 @@ const require = createRequire(import.meta.url);
 const {
   DEFAULT_MODE,
   getDefaultMode,
+  getHideStatus,
   normalizeMode,
   normalizeConfigMode,
   normalizePersistedMode,
@@ -64,6 +65,8 @@ export default function ponytailExtension(pi) {
     if (ctx) lastCtx = ctx;
     const c = ctx || lastCtx;
     if (!c?.ui?.setStatus || !c.ui.theme?.fg) return;
+    // ponytail: hide status via PONYTAIL_HIDE_STATUS env or hideStatus config (#324).
+    if (getHideStatus()) return;
     const theme = c.ui.theme;
     if (currentMode === "off") {
       c.ui.setStatus("ponytail", "");

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -152,6 +152,25 @@ test("status bar renders the mode and flips active on agent_start", async () => 
   assert.match(statusWrites.at(-1).text, /●.*ULTRA/);
 }));
 
+test("status bar hides when PONYTAIL_HIDE_STATUS is set (#324)", async () => withTempConfig(async () => {
+  process.env.PONYTAIL_HIDE_STATUS = "1";
+  try {
+    const { events } = createPiHarness();
+    const statusWrites = [];
+    const ctx = createCommandContext({
+      sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "ultra" } }] },
+      ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_color, text) => text } },
+    });
+
+    await events.get("session_start")({ reason: "resume" }, ctx);
+    await events.get("agent_start")({}, ctx);
+
+    assert.deepEqual(statusWrites, [], "status should not be written when hidden");
+  } finally {
+    delete process.env.PONYTAIL_HIDE_STATUS;
+  }
+}));
+
 test("status bar stays silent when ui lacks a theme", async () => withTempConfig(async () => {
   const { events } = createPiHarness();
   const calls = [];


### PR DESCRIPTION
Adds `getHideStatus()` to ponytail-config.js that checks `PONYTAIL_HIDE_STATUS` env var and `hideStatus` config flag. The pi-extension's `syncStatus()` returns early when set, keeping ponytail active without the status bar indicator.

Fixes #324