### PR TITLE
fix: qualify auto-active claim in ponytail-help for Copilot CLI (#248)

### DIFF
--- a/.openclaw/skills/ponytail-help/SKILL.md
+++ b/.openclaw/skills/ponytail-help/SKILL.md
@@ -42,7 +42,7 @@ Say "stop ponytail" or "normal mode". Resume anytime with `/ponytail`.
 
 ## Configure Default Mode
 
-Default mode = `full`, auto-active every session. Change it:
+Default mode = `full`. Auto-active every session on hook-capable hosts (Claude Code, Codex, OpenCode). GitHub Copilot CLI is instruction-tier only — copy the rules into `~/.copilot/copilot-instructions.md` for always-on behavior, or run `/ponytail` per session. Change it:
 
 **Environment variable** (highest priority):
 ```bash

--- a/skills/ponytail-help/SKILL.md
+++ b/skills/ponytail-help/SKILL.md
@@ -43,7 +43,7 @@ Say "stop ponytail" or "normal mode". Resume anytime with `/ponytail`.
 
 ## Configure Default Mode
 
-Default mode = `full`, auto-active every session. Change it:
+Default mode = `full`. Auto-active every session on hook-capable hosts (Claude Code, Codex, OpenCode). GitHub Copilot CLI is instruction-tier only — copy the rules into `~/.copilot/copilot-instructions.md` for always-on behavior, or run `/ponytail` per session. Change it:
 
 **Environment variable** (highest priority):
 ```bash


### PR DESCRIPTION
The ponytail-help card said 'auto-active every session' without qualification, but GitHub Copilot CLI is instruction-tier only and does not receive auto-activation. Updated to clarify which hosts support auto-activation and how Copilot CLI users opt in.

Fixes #248