### PR TITLE
fix: hermes test hardcoding python3 (fails on Windows) (#498)

### DIFF
--- a/tests/hermes-plugin.test.js
+++ b/tests/hermes-plugin.test.js
@@ -15,8 +15,21 @@ const skillCommands = commands.filter((name) => name !== 'ponytail');
 
 const root = path.join(__dirname, '..');
 
+// ponytail: probe once; on Windows `python3` is the Store-alias stub that fails
+// even when Python is installed, so fall back to `python` (mirrors benchmarks/correctness.js).
+let pythonCmd;
+function pythonExe() {
+  if (pythonCmd) return pythonCmd;
+  for (const cmd of ['python3', 'python']) {
+    if (spawnSync(cmd, ['-c', 'import sys'], { encoding: 'utf8' }).status === 0) {
+      return (pythonCmd = cmd);
+    }
+  }
+  return (pythonCmd = 'python3');
+}
+
 function python(script, env = {}) {
-  const result = spawnSync('python3', ['-c', script], {
+  const result = spawnSync(pythonExe(), ['-c', script], {
     cwd: root,
     env: { ...process.env, ...env },
     encoding: 'utf8',


### PR DESCRIPTION
tests/hermes-plugin.test.js spawned python3 with no fallback. On Windows python3 is the Store app-execution-alias stub that exits non-zero even when Python is installed. Reuse the probe/fallback pattern from benchmarks/correctness.js: try python3, fall back to python, cache the result.

Fixes #498