### PR TITLE
fix: use computed settingsPath in statusline nudge (#250)

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -66,7 +66,7 @@ if (!isCodex && !isCopilot) try {
       output += "\n\n" +
         "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode " +
         "(e.g. [PONYTAIL], [PONYTAIL:ULTRA]). It is not configured yet. " +
-        "To enable, add this to ~/.claude/settings.json: " +
+        "To enable, add this to " + settingsPath + ": " +
         statusLineSnippet + " " +
         "Proactively offer to set this up for the user on first interaction.";
     } else {
@@ -76,7 +76,7 @@ if (!isCodex && !isCopilot) try {
         "STATUSLINE SETUP NEEDED: The ponytail plugin includes a statusline badge showing active mode. " +
         "Its install path contains characters unsafe to embed in a shell command, so configure it manually: " +
         "add a statusLine command of type \"command\" that runs " + scriptName +
-        " from the plugin's hooks directory to ~/.claude/settings.json, quoting/escaping the path for your shell. " +
+        " from the plugin's hooks directory to " + settingsPath + ", quoting/escaping the path for your shell. " +
         "Proactively offer to set this up for the user on first interaction.";
     }
   }

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -133,6 +133,17 @@ assert.equal(
   false,
   'flag must not land in ~/.claude when CLAUDE_CONFIG_DIR is set',
 );
+// Statusline nudge must reference the custom config dir, not ~/.claude (#250).
+if (result.stdout.includes('STATUSLINE SETUP NEEDED')) {
+  assert.ok(
+    result.stdout.includes(customConfigDir),
+    'statusline nudge must reference CLAUDE_CONFIG_DIR, not hardcoded ~/.claude',
+  );
+  assert.ok(
+    !result.stdout.includes('~/.claude/settings.json'),
+    'statusline nudge must not hardcode ~/.claude/settings.json when CLAUDE_CONFIG_DIR is set',
+  );
+}
 
 const copilotData = path.join(temp, 'copilot-data');
 const codexData = path.join(temp, 'codex-data-shadow');


### PR DESCRIPTION
When CLAUDE_CONFIG_DIR is set, the statusline setup nudge was telling users to edit ~/.claude/settings.json — the wrong file. Now interpolates the already-computed settingsPath so the nudge points at the right file.

Fixes #250