### PR TITLE
docs: update Claude Code Desktop install steps to match the current UI (#342)

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ The Claude Code and Codex plugins run two tiny Node.js lifecycle hooks, so `node
 ```
 (You have to send two separate prompts for the install to work) 
 
-The desktop app has no `/plugin` command. Install it from the UI instead: Customize, the + by personal plugins, Create plugin and add marketplace, Add from repository, then enter the repo URL (thanks @NiklasDHahn, #98).
+Same steps in the Claude Code Desktop app's Code tab: type the two `/plugin` commands above into the prompt box, or click the **+** button next to it, choose **Plugins** → **Add plugin** to browse your configured marketplaces, and manage marketplaces from **Customize** in the sidebar.
 
 ### Codex
 


### PR DESCRIPTION
## Summary
- The README's desktop-app install note pointed at a "Customize > + > Create plugin and add marketplace > Add from repository" flow (added for #98) that reporters on both Windows and Mac say no longer matches the app.
- The unified Claude Code Desktop app's **Code** tab runs real Claude Code sessions, so the same `/plugin marketplace add` / `/plugin install` commands from the CLI section above work directly when typed into its prompt box. The **+** button also opens a **Plugins** browser (**Add plugin**), and marketplaces are managed from **Customize** in the sidebar — per Anthropic's current desktop app docs (`code.claude.com/docs/en/desktop`).
- Scope: only `README.md` (the file the issue references). The translated READMEs (`README.es.md`, `README.ko.md`) have the same stale wording but are out of scope for this fix; happy to follow up if wanted.

## Test plan
- [x] `node --test tests/*.test.js` — all 70 tests pass (this is a docs-only change, no test coverage exists for README prose)

Closes #342