### PR TITLE
docs: clarify that GitHub Copilot Chat (VS Code/JetBrains) is supported (#497)

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ Active every session, with a handful of commands (see [Commands](#commands)). `/
 
 Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`.
 
-Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro, Zed, CodeWhale, Swival: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
+Cursor, Windsurf, Cline, GitHub Copilot Chat (VS Code, JetBrains, Visual Studio — the editor extension, distinct from the standalone Copilot CLI covered under [Install](#install)), Aider, Kiro, Zed, CodeWhale, Swival: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
 
 Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kiro/steering/` in your project.
 


### PR DESCRIPTION
## Summary
- "GitHub Copilot (editor)" was buried in a comma-separated list of adapters with no indication of which product it meant, so someone asking "does this support VS Code Copilot?" had no way to tell from the README that the answer is already yes.
- Spelled it out as "GitHub Copilot Chat (VS Code, JetBrains, Visual Studio — the editor extension...)" and explicitly disambiguated it from the separately documented standalone Copilot CLI, so the existing support is discoverable.

## Test plan
- [x] `node --test tests/*.test.js` — all 70 tests pass (docs-only change)

Closes #497