### PR TITLE
fix: restore VS Code Copilot hook compatibility on Windows

### DIFF
--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "exec node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\" }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "exec node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-subagent.js\" }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "exec node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\" }",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."

--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -3,12 +3,28 @@ const path = require('path');
 const { getClaudeDir } = require('./ponytail-config');
 
 const STATE_FILE = '.ponytail-active';
-const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
+
+// VS Code Copilot's agent-plugin host never sets COPILOT_PLUGIN_DATA — it only
+// injects CLAUDE_PLUGIN_ROOT, pointed at its own install dir under
+// <home>/.vscode/agent-plugins/... . Without this fallback, ponytail mistakes
+// it for native Claude Code (issue #528): wrong hook output shape, and a
+// statusLine setup nudge for a settings.json VS Code Copilot never reads.
+function looksLikeVSCodeCopilotPluginRoot(pluginRoot) {
+  if (!pluginRoot) return false;
+  const segments = pluginRoot.split(/[\\/]+/);
+  return segments.includes('agent-plugins') &&
+    segments.some((s) => s.toLowerCase() === '.vscode');
+}
+
+const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA) ||
+  looksLikeVSCodeCopilotPluginRoot(process.env.CLAUDE_PLUGIN_ROOT);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 
 let stateDir = getClaudeDir();
 if (isCodex) stateDir = process.env.PLUGIN_DATA;
-if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA;
+// Only redirect state into COPILOT_PLUGIN_DATA when it's actually set — the
+// VS Code Copilot fallback above detects Copilot without it being present.
+if (process.env.COPILOT_PLUGIN_DATA) stateDir = process.env.COPILOT_PLUGIN_DATA;
 
 const statePath = path.join(stateDir, STATE_FILE);
 

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -53,13 +53,24 @@ test('shared hook commands avoid POSIX-only guard syntax', () => {
   }
 });
 
-test('shared hook commands exec node instead of leaving a wrapper shell behind', () => {
+// Issue #461 added `exec node` here so POSIX shells replace the wrapper
+// process instead of forking a child, avoiding zombie pileup on Codex/zsh.
+// Issue #527: `exec` is a bash/zsh builtin with no PowerShell equivalent, and
+// VS Code Copilot always runs `command` through PowerShell on Windows — it
+// never reads commandWindows the way Claude Code and Codex do on Windows. Any
+// literal "exec" here makes every hook fail outright for Windows Copilot
+// users. That outweighs the narrower POSIX benefit, especially since
+// ponytail-mode-tracker.js separately self-exits on a stuck stdin (issue
+// #443/#477), which covered the unbounded-pileup half of #461. Plain
+// `node "..."` is the simplest command both shells run correctly.
+test('shared hook commands run node directly, without shell-only syntax', () => {
   const commands = commandHooks()
     .map((h) => h.command)
     .filter(Boolean);
   assert.ok(commands.length > 0, 'expected at least one shared command entry');
   for (const cmd of commands) {
-    assert.match(cmd, /^exec node\s+/, `command must replace the shell with node: ${cmd}`);
+    assert.match(cmd, /^node\s+/, `command must run node directly so PowerShell (VS Code Copilot on Windows) can execute it: ${cmd}`);
+    assert.doesNotMatch(cmd, /\bexec\b/, `command must avoid the POSIX-only "exec" builtin, which crashes under PowerShell: ${cmd}`);
     assert.doesNotMatch(cmd, /;\s*exit 0$/, `command must not leave a shell wrapper waiting on node: ${cmd}`);
   }
 });

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -173,6 +173,40 @@ assert.equal(
 output = JSON.parse(result.stdout);
 assert.deepEqual(output, {});
 
+// VS Code Copilot's agent-plugin host never sets COPILOT_PLUGIN_DATA — only
+// CLAUDE_PLUGIN_ROOT, pointed at its own install dir (issue #528). Without
+// detecting that, ponytail treats it as native Claude Code: writeHookOutput
+// writes raw text instead of JSON (so JSON.parse below would throw), and the
+// statusLine setup nudge fires for a settings.json Copilot never reads.
+const vscodeCopilotHome = path.join(temp, 'vscode-copilot-home');
+fs.mkdirSync(vscodeCopilotHome, { recursive: true });
+const vscodeCopilotPluginRoot = path.join(
+  vscodeCopilotHome, '.vscode', 'agent-plugins', 'github.com', 'DietrichGebert', 'ponytail',
+);
+result = run('ponytail-activate.js', {
+  HOME: vscodeCopilotHome,
+  USERPROFILE: vscodeCopilotHome,
+  CLAUDE_PLUGIN_ROOT: vscodeCopilotPluginRoot,
+  PONYTAIL_DEFAULT_MODE: 'full',
+});
+assert.equal(result.status, 0, result.stderr);
+assert.equal(
+  fs.readFileSync(path.join(vscodeCopilotHome, '.claude', '.ponytail-active'), 'utf8'),
+  'full',
+  'without COPILOT_PLUGIN_DATA, state must still land in the ~/.claude fallback',
+);
+output = JSON.parse(result.stdout);
+assert.ok(
+  !('systemMessage' in output),
+  'must use the Copilot output shape (additionalContext only), not the Codex systemMessage shape',
+);
+assert.match(output.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);
+assert.doesNotMatch(
+  output.additionalContext,
+  /STATUSLINE SETUP NEEDED/,
+  'VS Code Copilot never reads settings.json statusLine — must not nudge for it',
+);
+
 // SubagentStart hook: when ponytail mode is active it injects the ruleset into
 // each subagent (issue #252). Native Claude must get the hookSpecificOutput JSON
 // form, not raw stdout, or the context is dropped.


### PR DESCRIPTION
Two related bugs reported against 4.8.4 on Windows + VS Code Copilot:

- claude-codex-hooks.json's shared `command` field used `exec node "..."`. `exec` is a bash/zsh builtin with no PowerShell equivalent. Copilot always dispatches `command` through PowerShell on Windows (unlike Claude Code and Codex, which use the PowerShell-native `commandWindows` field there), so every hook threw CommandNotFoundException outright. `exec` was added in 7eda70d (#461) to stop POSIX shells from leaving a wrapper process behind on Codex/zsh; dropping it trades that narrower POSIX optimization for working hooks on Windows Copilot, and the unbounded-pileup half of #461 is already covered separately by ponytail-mode-tracker's stdin self-exit guard (#443/#477). Updated the hooks-windows.test.js regression test to match.

- ponytail-runtime.js detected Copilot via COPILOT_PLUGIN_DATA, which VS Code Copilot's agent-plugin host never sets (it only injects CLAUDE_PLUGIN_ROOT). So it was misidentified as native Claude Code: wrong hook output shape, plus a statusLine setup nudge pointing at a settings.json key Copilot never reads. Added a path-based fallback for the .vscode/agent-plugins install layout, with a regression test.

Closes #527, closes #528