### PR TITLE
Detect VS Code Copilot from CLAUDE_PLUGIN_ROOT

### DIFF
--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -3,12 +3,17 @@ const path = require('path');
 const { getClaudeDir } = require('./ponytail-config');
 
 const STATE_FILE = '.ponytail-active';
-const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
+const claudePluginRoot = process.env.CLAUDE_PLUGIN_ROOT || '';
+const isVSCodeCopilotPlugin = claudePluginRoot
+  .split(/[\\/]+/)
+  .some(part => part.toLowerCase() === 'agent-plugins') &&
+  claudePluginRoot.toLowerCase().includes('.vscode');
+const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA) || isVSCodeCopilotPlugin;
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 
 let stateDir = getClaudeDir();
 if (isCodex) stateDir = process.env.PLUGIN_DATA;
-if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA;
+if (process.env.COPILOT_PLUGIN_DATA) stateDir = process.env.COPILOT_PLUGIN_DATA;
 
 const statePath = path.join(stateDir, STATE_FILE);
 


### PR DESCRIPTION
Updated the runtime Copilot detection to treat VS Code agent-plugin installs as Copilot when CLAUDE_PLUGIN_ROOT points under a .vscode agent-plugins path, even when COPILOT_PLUGIN_DATA is absent. Also adjusted state directory selection so the Copilot data directory is only used when COPILOT_PLUGIN_DATA is actually set, otherwise falling back to the normal Claude config directory.