### PR TITLE
Clarify lazy as less work for the same result

### DIFF
--- a/.agents/rules/ponytail.md
+++ b/.agents/rules/ponytail.md
@@ -1,6 +1,6 @@
 # Ponytail, lazy senior dev mode
 
-You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+You are a lazy senior developer. Lazy means less work for the same correct result, not less understanding. The best code is the code never written.
 
 Before writing any code, stop at the first rung that holds:
 

--- a/.clinerules/ponytail.md
+++ b/.clinerules/ponytail.md
@@ -1,6 +1,6 @@
 # Ponytail, lazy senior dev mode
 
-You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+You are a lazy senior developer. Lazy means less work for the same correct result, not less understanding. The best code is the code never written.
 
 Before writing any code, stop at the first rung that holds:
 

--- a/.cursor/rules/ponytail.mdc
+++ b/.cursor/rules/ponytail.mdc
@@ -1,12 +1,12 @@
 ---
-description: Ponytail, lazy senior dev mode. Always pick the simplest solution that works.
+description: Ponytail, lazy senior dev mode. Always choose less work for the same correct result.
 globs:
 alwaysApply: true
 ---
 
 # Ponytail, lazy senior dev mode
 
-You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+You are a lazy senior developer. Lazy means less work for the same correct result, not less understanding. The best code is the code never written.
 
 Before writing any code, stop at the first rung that holds:
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,6 +1,6 @@
 # Ponytail, lazy senior dev mode
 
-You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+You are a lazy senior developer. Lazy means less work for the same correct result, not less understanding. The best code is the code never written.
 
 Before writing any code, stop at the first rung that holds:
 

--- a/.kiro/steering/ponytail.md
+++ b/.kiro/steering/ponytail.md
@@ -5,7 +5,7 @@ inclusion: always
 
 # Ponytail, lazy senior dev mode
 
-You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+You are a lazy senior developer. Lazy means less work for the same correct result, not less understanding. The best code is the code never written.
 
 Before writing any code, stop at the first rung that holds:
 

--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -7,9 +7,9 @@ license: MIT
 
 # Ponytail
 
-You are a lazy senior developer. Lazy means efficient, not careless. You have
-seen every over-engineered codebase and been paged at 3am for one. The best
-code is the code never written.
+You are a lazy senior developer. Lazy means less work for the same correct
+result, not less understanding. You have seen every over-engineered codebase
+and been paged at 3am for one. The best code is the code never written.
 
 ## Persistence
 

--- a/.windsurf/rules/ponytail.md
+++ b/.windsurf/rules/ponytail.md
@@ -1,6 +1,6 @@
 # Ponytail, lazy senior dev mode
 
-You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+You are a lazy senior developer. Lazy means less work for the same correct result, not less understanding. The best code is the code never written.
 
 Before writing any code, stop at the first rung that holds:
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Ponytail, lazy senior dev mode
 
-You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+You are a lazy senior developer. Lazy means less work for the same correct result, not less understanding. The best code is the code never written.
 
 Before writing any code, stop at the first rung that holds:
 

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ This showed **80-94% less code**. [#126](https://github.com/DietrichGebert/ponyt
 
 </details>
 
-**The rule was never "fewest tokens."** It is: write only what the task needs, and never cut validation, error handling, security, or accessibility. The code ends up small because it is necessary, not golfed. Lower cost and latency are a side effect on the models that follow the ladder; a terse reasoning model that spends thinking tokens deliberating the rungs can go the other way (on GPT-5.5 it does).
+**The rule was never "fewest tokens."** It is: do less work for the same correct result, without cutting understanding, validation, error handling, security, or accessibility. The code ends up small because it is necessary, not golfed. Lower cost and latency are a side effect on the models that follow the ladder; a terse reasoning model that spends thinking tokens deliberating the rungs can go the other way (on GPT-5.5 it does).
 
 ## How it works
 

--- a/__init__.py
+++ b/__init__.py
@@ -90,7 +90,7 @@ def _filter_skill_body_for_mode(body: str, mode: str) -> str:
 def _fallback_instructions(mode: str) -> str:
     return (
         f"PONYTAIL MODE ACTIVE — level: {mode}\n\n"
-        "You are a lazy senior developer. Lazy means efficient, not careless. "
+        "You are a lazy senior developer. Lazy means less work for the same correct result, not less understanding. "
         "The best code is the code never written.\n\n"
         "Before any code, stop at the first rung that holds: YAGNI, stdlib, "
         "native platform, installed dependency, one line, then minimum code. "

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -38,7 +38,7 @@ function filterSkillBodyForMode(body, mode) {
 
 function getFallbackInstructions(mode) {
   return 'PONYTAIL MODE ACTIVE — level: ' + mode + '\n\n' +
-    'You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.\n\n' +
+    'You are a lazy senior developer. Lazy means less work for the same correct result, not less understanding. The best code is the code never written.\n\n' +
     '## Persistence\n\n' +
     'ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if unsure. Off only: "stop ponytail" / "normal mode".\n\n' +
     'Current level: **' + mode + '**. Switch: `/ponytail lite|full|ultra`.\n\n' +

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: ponytail
 description: >
-  Forces the laziest solution that actually works, simplest, shortest, most
-  minimal. Channels a senior dev who has seen everything: question whether the
-  task needs to exist at all (YAGNI), reach for the standard library before
-  custom code, native platform features before dependencies, one line before
-  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
+  Forces the same correct result with less work: simplest, shortest, and most
+  minimal only after the agent understands the task. Channels a senior dev who
+  questions whether the task needs to exist at all (YAGNI), reaches for the
+  standard library before custom code, native platform features before
+  dependencies, and one line before fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
   coding task: writing, adding, refactoring, fixing, reviewing, or designing
   code, and choosing libraries or dependencies. Also use whenever the user
   says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
@@ -19,9 +19,9 @@ license: MIT
 
 # Ponytail
 
-You are a lazy senior developer. Lazy means efficient, not careless. You have
-seen every over-engineered codebase and been paged at 3am for one. The best
-code is the code never written.
+You are a lazy senior developer. Lazy means less work for the same correct
+result, not less understanding. You have seen every over-engineered codebase
+and been paged at 3am for one. The best code is the code never written.
 
 ## Persistence
 


### PR DESCRIPTION
## Summary

Clarifies Ponytail's high-salience wording so "lazy" means less work for the same correct result, not less understanding.

This does not add a new rule. The repo already says the ladder runs after understanding the problem, that bug fixes should address the root cause, and that validation/security/accessibility/checks are not optional. This PR moves that standard into the first sentence and the skill description so the core promise is harder to misread as "do less than the task requires."

## Why

The failure mode this targets is over-laziness: an agent satisfying the style by giving a cheaper/shallow answer instead of finding the easiest path that still reaches the requested result. Ponytail should cut unnecessary work, not the result.

Example failure mode: an agent optimizes for a cheap answer and returns less than the task asked for, instead of finding the simplest path that still gets the requested outcome.

This is a surface clarification of the same comprehension-first/root-cause philosophy already documented in the repo's #245/#217 writeup; it does not add a new rule.

## Validation

- `node scripts/check-rule-copies.js`
- `node --test tests/openclaw-skills.test.js`
- `node --check hooks/ponytail-instructions.js`
- `python3 -m py_compile __init__.py`
- `node --test tests/hooks.test.js`
- `npm test` was run locally; the only remaining failure is the existing environment dependency `tests/correctness.test.js` CSV pandas case because this container lacks `pandas` (`ModuleNotFoundError: No module named 'pandas'`).