### PR TITLE
fix: CRLF in behavior.js codeOf + MCP server version from package.json (#533, #535)

### DIFF
--- a/benchmarks/behavior.js
+++ b/benchmarks/behavior.js
@@ -11,7 +11,7 @@
 // Metric: `behavior` (1 = behavior present, 0 = absent).
 
 function codeOf(text) {
-  return [...String(text || '').matchAll(/```[\w-]*\n([\s\S]*?)```/g)].map((m) => m[1]).join('\n');
+  return [...String(text || '').matchAll(/```[\w-]*\r?\n([\s\S]*?)```/g)].map((m) => m[1]).join('\n');
 }
 
 function proseOf(text) {

--- a/ponytail-mcp/index.js
+++ b/ponytail-mcp/index.js
@@ -3,13 +3,15 @@
 // prompt (user-invoked) and a tool (for hosts that pull context via tools).
 // It does NOT replace the always-on adapters; it's the clean option for hosts
 // whose only injection point is the prompt menu (see #70).
+import { readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 
 import { MODES, buildInstructions, resolveMode } from "./instructions.js";
 
-const server = new McpServer({ name: "ponytail", version: "0.1.0" });
+const { version } = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
+const server = new McpServer({ name: "ponytail", version });
 
 const modeArg = z
   .enum(MODES)

--- a/tests/behavior.test.js
+++ b/tests/behavior.test.js
@@ -71,6 +71,15 @@ test('onecheck: no check fails', () => {
   assert.equal(r.pass, false);
 });
 
+// --- CRLF: Windows line endings must not break code extraction (#533) ---
+
+test('hardware: CRLF code fences are correctly parsed', () => {
+  const r = check('hardware',
+    '```python\r\ndef read_c(beta=3950, r0=10000):\r\n    ...\r\n```\r\n' +
+    'Notes: beta/r0 drift part-to-part, measure your own r0 at a known temp.');
+  assert.equal(r.pass, true);
+});
+
 // --- unknown probe is skipped, not failed ---
 
 test('unknown probe is skipped', () => {


### PR DESCRIPTION
## Summary

Fixes two newly discovered bugs:

**#533 — behavior.js `codeOf()` misses CRLF code fences** (companion to #339)
- The regex used `\n` instead of `\r?\n`, so on Windows (CRLF files) fenced code blocks were not extracted — causing the behavior gate to grade on raw text and produce incorrect pass/fail results for the `hardware` and `onecheck` probes.

**#535 — ponytail-mcp McpServer version hardcoded to "0.1.0"**
- `ponytail-mcp/index.js` passed `version: "0.1.0"` to the McpServer constructor while `ponytail-mcp/package.json` declares `"4.8.4"`. MCP clients saw a stale version. Now reads it from package.json at startup using `new URL("./package.json", import.meta.url)`.

## Test plan

- [x] New test: `hardware: CRLF code fences are correctly parsed` — feeds CRLF-encoded code block to the behavior gate and verifies pass
- [x] All behavior tests pass (9/9)
- [x] All MCP tests pass (3/3)
- [x] Full suite: `npm test` — 70/71 pass, 1 pre-existing failure (csv benchmark, environment-dependent)