### PR TITLE
fix: ship scripts/uninstall.js in the npm package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "skills/",
     ".opencode/",
     "pi-extension/",
+    "scripts/uninstall.js",
     "assets/",
     "LICENSE"
   ],

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -1,0 +1,23 @@
+#!/usr/bin/env node
+// The README tells users to run `node scripts/uninstall.js`, so the npm package
+// must actually ship it. Guard the files entry so it can't silently drop out.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+
+test('npm package ships the advertised cleanup script', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(root, 'package.json'), 'utf8'));
+  assert.ok(
+    pkg.files.includes('scripts/uninstall.js'),
+    'package.json "files" must include scripts/uninstall.js (README tells users to run it)',
+  );
+  // And the file it points at must exist.
+  assert.ok(
+    fs.existsSync(path.join(root, 'scripts', 'uninstall.js')),
+    'scripts/uninstall.js is listed in files but missing on disk',
+  );
+});


### PR DESCRIPTION
## Problem

README:270 tells users to run `node scripts/uninstall.js` to clean up state ponytail writes outside the plugin folder, but `package.json`'s `files` list ships no `scripts/`. Verified on main via `npm pack --dry-run`: `scripts/uninstall.js` is **not** in the tarball, so npm-installed users don't have the file the docs point them to.

## Fix

Add `scripts/uninstall.js` to `files` (one line). Its only dependency, `hooks/`, already ships, so the script resolves once installed. Guard with a small test that asserts the `files` entry and that the file exists on disk.

## Verification

- `npm test`: 71 + 15 pass, exit 0. `check-rule-copies` / `check-versions`: exit 0.
- `npm pack --dry-run` now includes `scripts/uninstall.js`.

## Note

Supersedes #471 (same fix by @Anmolnoor, credited as co-author). Two differences: this places the same one-line `files` addition, and it replaces #471's `npm pack` subprocess test with a plain files-array assertion. The pack-spawn test passed in CI but broke when run standalone on Windows (`spawnSync('npm.cmd', …)` without `shell:true` throws EINVAL on modern Node), which the PR's own 'how to test' command would hit. The assertion guards the same regression (the entry being dropped) with no subprocess and works on every platform. Suggest closing #471 in favor of this.