### PR TITLE
feat: add /ponytail default <mode> to persist the default (#329)

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -2,7 +2,7 @@
 // ponytail — UserPromptSubmit hook to track which ponytail mode is active
 // Inspects user input for /ponytail commands and writes mode to flag file
 
-const { getDefaultMode, isDeactivationCommand } = require('./ponytail-config');
+const { getDefaultMode, isDeactivationCommand, writeDefaultMode } = require('./ponytail-config');
 const { clearMode, setMode, writeHookOutput } = require('./ponytail-runtime');
 
 let input = '';
@@ -27,6 +27,18 @@ function finish() {
       if (cmd === '/ponytail-review' || cmd === '/ponytail:ponytail-review') {
         mode = 'review';
       } else if (cmd === '/ponytail' || cmd === '/ponytail:ponytail') {
+        // `/ponytail default <mode>` persists the default to config (survives
+        // restarts). Plain switches stay session-scoped ("sticks until session
+        // end"), so this is the only path that writes config. review is not a
+        // valid default (#377), so only off/lite/full/ultra are accepted.
+        if (arg === 'default') {
+          const dmode = parts[2];
+          if (dmode === 'off' || dmode === 'lite' || dmode === 'full' || dmode === 'ultra') {
+            writeDefaultMode(dmode);
+            writeHookOutput('UserPromptSubmit', dmode, 'PONYTAIL DEFAULT SET — new sessions start in ' + dmode + '.');
+          }
+          return; // don't fall through to the session-mode switch
+        }
         if (arg === 'lite') mode = 'lite';
         else if (arg === 'full') mode = 'full';
         else if (arg === 'ultra') mode = 'ultra';

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -234,4 +234,27 @@ try {
   else process.env.XDG_CONFIG_HOME = prevXdg;
 }
 
+// #329: `/ponytail default <mode>` persists the default to config (survives
+// restart), while a plain switch stays session-scoped and never touches config.
+const defHome = path.join(temp, 'default-cmd-home');
+const defEnv = { HOME: defHome, USERPROFILE: defHome, XDG_CONFIG_HOME: path.join(defHome, '.config') };
+const defConfig = path.join(defHome, '.config', 'ponytail', 'config.json');
+const defFlag = path.join(defHome, '.claude', '.ponytail-active');
+
+result = run('ponytail-mode-tracker.js', defEnv, JSON.stringify({ prompt: '/ponytail default lite' }));
+assert.equal(result.status, 0, result.stderr);
+assert.equal(JSON.parse(fs.readFileSync(defConfig, 'utf8')).defaultMode, 'lite', '/ponytail default must persist the default');
+assert.equal(fs.existsSync(defFlag), false, '/ponytail default must not change the session mode');
+
+// A plain switch is transient: sets the session flag, leaves the default alone.
+result = run('ponytail-mode-tracker.js', defEnv, JSON.stringify({ prompt: '/ponytail ultra' }));
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.readFileSync(defFlag, 'utf8'), 'ultra', 'plain switch must set the session mode');
+assert.equal(JSON.parse(fs.readFileSync(defConfig, 'utf8')).defaultMode, 'lite', 'plain switch must not persist the default');
+
+// review is not a valid default (#377) — the command is ignored, config unchanged.
+result = run('ponytail-mode-tracker.js', defEnv, JSON.stringify({ prompt: '/ponytail default review' }));
+assert.equal(result.status, 0, result.stderr);
+assert.equal(JSON.parse(fs.readFileSync(defConfig, 'utf8')).defaultMode, 'lite', 'review must not be accepted as a default');
+
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
## Problem

#329: after `/ponytail off`, a new session comes back on. That is because plain `/ponytail` switches are **session-scoped by design** (SKILL.md: *"Level sticks until changed or session end"*), and Claude Code had no in-session way to change the **persistent** default — only `PONYTAIL_DEFAULT_MODE` or editing `config.json`.

## Why not the other PRs

#515 and #488 make *every* `/ponytail` switch write to config. That contradicts the documented session-scoped behavior, turns a one-off `/ponytail ultra` into a permanent default, and diverges from pi (which keeps switches transient and offers a separate `default` command). Rejected in favor of parity.

## Fix

Add `/ponytail default <mode>` to the mode-tracker hook, matching pi's existing command:
- Writes `defaultMode` to config (survives restart).
- Does **not** touch the current session flag, so plain switches stay transient.
- Rejects `review` as a default (#377); only `off/lite/full/ultra`.

So `/ponytail off` = off this session; `/ponytail default off` = off for new sessions too — which is what the reporter wanted.

## Verification

- `npm test`: 71 + 16 pass, exit 0.
- Test covers: default persists to config, session flag untouched; a plain `/ponytail ultra` sets the flag but leaves the default; `/ponytail default review` is ignored.
- e2e: `/ponytail default off` writes `{"defaultMode":"off"}` while the session flag stays `full`.

## Follow-up (not in this PR)

The help cards (`skills/ponytail-help`, `.opencode`, `.toml`) currently list only env/config for changing the default; they should mention `/ponytail default <mode>`. Kept out of here so the gated skill-file change is separate from the hook change.

Note: `hooks/` behavior change — flagged for your benchmark gate, though it only adds a new command path and doesn't alter the ruleset.