### PR TITLE
feat: add Factory Droid adapter (#167)

### DIFF
--- a/.factory-plugin/plugin.json
+++ b/.factory-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "ponytail",
+  "version": "4.8.4",
+  "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
+  "author": {
+    "name": "Dietrich Gebert",
+    "url": "https://github.com/DietrichGebert"
+  },
+  "homepage": "https://github.com/DietrichGebert/ponytail",
+  "repository": "https://github.com/DietrichGebert/ponytail",
+  "license": "MIT",
+  "keywords": ["yagni", "minimalism", "code-review", "productivity"],
+  "skills": "skills/",
+  "hooks": "./hooks/droid-hooks.json"
+}

--- a/README.md
+++ b/README.md
@@ -241,6 +241,17 @@ clawhub install ponytail
 
 Installs ponytail as an OpenClaw skill from ClawHub; the review, audit, debt, gain, and help skills install the same way (`clawhub install ponytail-review`, and so on). OpenClaw applies it on coding tasks and also exposes it as a `/ponytail` command. Without ClawHub, copy [`.openclaw/skills/ponytail`](.openclaw/skills/) into `~/.openclaw/skills/`.
 
+### Factory Droid
+
+```bash
+droid plugin marketplace add https://github.com/DietrichGebert/ponytail
+droid plugin install ponytail@ponytail
+```
+
+Restart Droid after installing. The plugin activates ponytail mode on every session, tracks mode switches via `/ponytail lite|full|ultra|off`, and injects the ruleset into subagents. Requires `node` on PATH. The six skills (`ponytail`, `ponytail-review`, `ponytail-audit`, `ponytail-debt`, `ponytail-gain`, `ponytail-help`) are available as Droid slash commands. Droid runs on Linux and Mac only (POSIX).
+
+Reads `AGENTS.md` from the project root as instruction-only fallback; copy `skills/` into `.factory/skills/` or `~/.factory/skills/` to use the skills without hooks.
+
 That was it. He'd be proud. He won't say it.
 
 Active every session, with a handful of commands (see [Commands](#commands)). `/ponytail ultra` exists for when the codebase has wronged you personally. Startup and mode-change text shows the current mode.

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -13,6 +13,7 @@ to load in a given agent.
 | OpenCode | `.opencode/plugins/ponytail.mjs`, `.opencode/command/`, `hooks/`, `skills/` | Server plugin injects the ruleset each turn via `experimental.chat.system.transform` and persists `/ponytail` switches; reuses the shared instruction builder. |
 | pi | `pi-extension/`, `skills/`, `hooks/` | Package extension: injects the ruleset each turn through the shared instruction builder and registers the `/ponytail` commands. |
 | Hermes Agent | `plugin.yaml`, `__init__.py`, `skills/` | Native Hermes plugin: injects active mode through `pre_llm_call`, rewrites gateway `/ponytail-*` skill commands into agent prompts, registers `/ponytail` mode switching, and exposes bundled skills as `ponytail:<skill>`. |
+| Factory Droid | `.factory-plugin/plugin.json`, `hooks/droid-hooks.json`, `hooks/`, `skills/` | Plugin install with lifecycle hooks (SessionStart, SubagentStart, UserPromptSubmit) for mode activation and tracking. Uses `DROID_PLUGIN_ROOT` instead of `CLAUDE_PLUGIN_ROOT`. POSIX-only (Linux/Mac); no Windows `commandWindows` needed. |
 | Gemini CLI | `gemini-extension.json`, `AGENTS.md`, `commands/`, `skills/` | Extension manifest points `contextFileName` at `AGENTS.md` for always-on rules, and reuses the existing `commands/*.toml` and `skills/`, which Gemini CLI auto-discovers. The Claude/Codex hook map is not placed at Gemini's auto-discovered `hooks/hooks.json` path. |
 | Cursor | `.cursor/rules/ponytail.mdc` | Always-on project rule. |
 | Windsurf | `.windsurf/rules/ponytail.md` | Project rule. |

--- a/hooks/droid-hooks.json
+++ b/hooks/droid-hooks.json
@@ -1,0 +1,41 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "exec node \"${DROID_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
+            "timeout": 5,
+            "statusMessage": "Loading ponytail mode..."
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "exec node \"${DROID_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"",
+            "timeout": 5,
+            "statusMessage": "Loading ponytail mode..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "exec node \"${DROID_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
+            "timeout": 5,
+            "statusMessage": "Tracking ponytail mode..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -4,7 +4,8 @@ const { getClaudeDir } = require('./ponytail-config');
 
 const STATE_FILE = '.ponytail-active';
 const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
-const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
+const isCodex = !isCopilot && !process.env.DROID_PLUGIN_ROOT && Boolean(process.env.PLUGIN_DATA);
+const isDroid = Boolean(process.env.DROID_PLUGIN_ROOT);
 
 let stateDir = getClaudeDir();
 if (isCodex) stateDir = process.env.PLUGIN_DATA;
@@ -37,7 +38,7 @@ function writeHookOutput(event, mode, context = '') {
       event === 'SessionStart' && context ? { additionalContext: context } : {}));
     return;
   }
-  if (isCodex) {
+  if (isCodex || isDroid) {
     const output = { systemMessage: `PONYTAIL:${mode.toUpperCase()}` };
     if (context) {
       output.hookSpecificOutput = {
@@ -62,6 +63,7 @@ module.exports = {
   clearMode,
   isCodex,
   isCopilot,
+  isDroid,
   readMode,
   setMode,
   writeHookOutput,

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -22,6 +22,7 @@ const VERSION_FILES = [
   '.claude-plugin/plugin.json',  // Claude Code plugin — what users install
   '.codex-plugin/plugin.json',   // Codex plugin
   '.devin-plugin/plugin.json',   // Devin CLI plugin
+  '.factory-plugin/plugin.json', // Factory Droid plugin
   '.github/plugin/plugin.json',  // Copilot plugin
   'gemini-extension.json',       // Gemini CLI extension
   'package.json',                // pi-package / repo root

--- a/tests/gemini-extension.test.js
+++ b/tests/gemini-extension.test.js
@@ -20,6 +20,7 @@ const VERSIONED_MANIFESTS = [
   'gemini-extension.json',
   '.claude-plugin/plugin.json',
   '.codex-plugin/plugin.json',
+  '.factory-plugin/plugin.json',
   '.github/plugin/plugin.json',
 ];
 // Gemini auto-discovers these by directory; the manifest is only useful if they exist.

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -16,6 +16,11 @@ const HOOKS_JSON = 'hooks/claude-codex-hooks.json';
 const HOST_PLUGIN_MANIFESTS = [
   '.claude-plugin/plugin.json',
   '.codex-plugin/plugin.json',
+  '.factory-plugin/plugin.json',
+];
+const SHARED_HOOK_MANIFESTS = [
+  '.claude-plugin/plugin.json',
+  '.codex-plugin/plugin.json',
 ];
 // cmd.exe variable syntax (%FOO%); PowerShell leaves it literal, breaking the path.
 const CMD_VAR_SYNTAX = /%[A-Za-z_][A-Za-z0-9_]*%/;
@@ -96,8 +101,13 @@ test('ponytail-mode-tracker self-exits when stdin never closes (no freeze)', asy
   assert.equal(code, 0, 'hook must exit cleanly when stdin never closes');
 });
 
+test('Factory Droid manifest points at its own host-specific hook config', () => {
+  const manifest = JSON.parse(fs.readFileSync(path.join(root, '.factory-plugin/plugin.json'), 'utf8'));
+  assert.equal(manifest.hooks, './hooks/droid-hooks.json', 'Droid must use its own hooks config, not the shared claude-codex-hooks.json');
+});
+
 test('Claude and Codex manifests point at the shared host-specific hook config', () => {
-  for (const rel of HOST_PLUGIN_MANIFESTS) {
+  for (const rel of SHARED_HOOK_MANIFESTS) {
     const manifest = JSON.parse(fs.readFileSync(path.join(root, rel), 'utf8'));
     assert.equal(manifest.hooks, `./${HOOKS_JSON}`, `${rel} must not rely on root hooks auto-discovery`);
   }


### PR DESCRIPTION
## Summary

Adds Factory Droid as a supported host with plugin manifest, lifecycle hooks, and runtime detection.

## Changes

- **`.factory-plugin/plugin.json`** — plugin manifest pointing at `skills/` and `hooks/droid-hooks.json`
- **`hooks/droid-hooks.json`** — SessionStart, SubagentStart, UserPromptSubmit hooks using `DROID_PLUGIN_ROOT` (POSIX-only, no commandWindows needed)
- **`hooks/ponytail-runtime.js`** — detect `DROID_PLUGIN_ROOT` env var, use Codex-style JSON output format for Droid hook responses
- **`scripts/check-versions.js`** — add `.factory-plugin/plugin.json` to version consistency check
- **`tests/gemini-extension.test.js`** — add factory manifest to version alignment check
- **`tests/hooks-windows.test.js`** — add factory to host manifests check, add dedicated test for Droid-specific hooks path
- **`docs/agent-portability.md`** — Factory Droid row in adapter table
- **`README.md`** — Factory Droid install section

## Test plan

- [x] `npm test` — all 85 tests pass
- [x] `node scripts/check-versions.js` — 8 version files pinned
- [x] `node scripts/check-rule-copies.js` — passes

Closes #167