### PR TITLE
docs: add ForgeCat community profile mention (#317)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,16 @@ clawhub install ponytail
 
 Installs ponytail as an OpenClaw skill from ClawHub; the review, audit, debt, gain, and help skills install the same way (`clawhub install ponytail-review`, and so on). OpenClaw applies it on coding tasks and also exposes it as a `/ponytail` command. Without ClawHub, copy [`.openclaw/skills/ponytail`](.openclaw/skills/) into `~/.openclaw/skills/`.
 
+### ForgeCat
+
+A community-maintained profile is available:
+
+```bash
+forgecat install @forgecat/dietrichgebert_ponytail
+```
+
+Profile repo: [nota-america/forgecat-agent-profiles](https://github.com/nota-america/forgecat-agent-profiles/tree/main/profiles/dietrichgebert/ponytail). Supports Claude Code, Cursor, and Codex.
+
 That was it. He'd be proud. He won't say it.
 
 Active every session, with a handful of commands (see [Commands](#commands)). `/ponytail ultra` exists for when the codebase has wronged you personally. Startup and mode-change text shows the current mode.

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -24,6 +24,7 @@ to load in a given agent.
 | Swival | `.swival/skills/`, `AGENTS.md` | `swival skills add https://github.com/DietrichGebert/ponytail` installs the six skills straight into `.swival/skills/`. Add `--global` to stage them in the library (`~/.config/swival/library`) first, then `swival skills add ponytail` (or `--global ponytail`) to activate per-project or everywhere. Also reads `AGENTS.md` from the repo root and `~/.config/swival/AGENTS.md` globally as instruction-tier fallback. |
 | VS Code + Codex extension | `AGENTS.md` | The Codex extension reads `AGENTS.md` (repo root, or `~/.codex/AGENTS.md` globally). Instruction-tier; the full Codex plugin row above adds `/ponytail` levels and hooks. |
 | Kiro | `.kiro/steering/ponytail.md` | Steering rule; copy globally or into a project. |
+| ForgeCat | — | Community-maintained profile at [forgecat-agent-profiles](https://github.com/nota-america/forgecat-agent-profiles/tree/main/profiles/dietrichgebert/ponytail). Install: `forgecat install @forgecat/dietrichgebert_ponytail`. Supports Claude Code, Cursor, and Codex. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 
 ## Adapter Rule


### PR DESCRIPTION
## Summary

Adds [ForgeCat](https://forgecat.ai) to the supported hosts list in the README and agent portability doc. A community-maintained profile already exists at [nota-america/forgecat-agent-profiles](https://github.com/nota-america/forgecat-agent-profiles/tree/main/profiles/dietrichgebert/ponytail).

## Changes

- **README.md** — ForgeCat install section under install instructions
- **docs/agent-portability.md** — ForgeCat row in the adapter table

## Test plan

- [x] `npm test` — all 85 tests pass
- [x] `node scripts/check-rule-copies.js` — passes

Closes #317