### PR TITLE
feat: hide the pi status bar indicator while keeping ponytail active (#324)

### DIFF
--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -96,6 +96,23 @@ function getDefaultMode() {
   return DEFAULT_MODE;
 }
 
+// Hide the status-bar indicator while keeping ponytail active (#324).
+// PONYTAIL_HIDE_STATUS=1 (or any truthy value; 0/false/empty mean "don't hide")
+// takes precedence, else config.hideStatus === true.
+function getHideStatus() {
+  const env = process.env.PONYTAIL_HIDE_STATUS;
+  if (env !== undefined) {
+    const v = env.trim().toLowerCase();
+    return v !== '' && v !== '0' && v !== 'false' && v !== 'no';
+  }
+  try {
+    const config = JSON.parse(fs.readFileSync(getConfigPath(), 'utf8').replace(/^\uFEFF/, ''));
+    return config.hideStatus === true;
+  } catch (_) {
+    return false;
+  }
+}
+
 function writeDefaultMode(mode) {
   const normalized = normalizeConfigMode(mode);
   if (!normalized) return null;
@@ -120,6 +137,7 @@ module.exports = {
   getConfigDir,
   getConfigPath,
   getClaudeDir,
+  getHideStatus,
   isShellSafe,
   normalizeMode,
   normalizeConfigMode,

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -4,6 +4,7 @@ const require = createRequire(import.meta.url);
 const {
   DEFAULT_MODE,
   getDefaultMode,
+  getHideStatus,
   normalizeMode,
   normalizeConfigMode,
   normalizePersistedMode,
@@ -56,6 +57,7 @@ export { writeDefaultMode };
 export default function ponytailExtension(pi) {
   let currentMode = DEFAULT_MODE;
   let configuredDefaultMode = getDefaultMode();
+  let hideStatus = getHideStatus();
   let isActive = false;
   let lastCtx = null;
 
@@ -63,6 +65,8 @@ export default function ponytailExtension(pi) {
   function syncStatus(ctx) {
     if (ctx) lastCtx = ctx;
     const c = ctx || lastCtx;
+    // ponytail: hide the indicator but keep the ruleset active (#324).
+    if (hideStatus) return;
     if (!c?.ui?.setStatus || !c.ui.theme?.fg) return;
     const theme = c.ui.theme;
     if (currentMode === "off") {
@@ -167,6 +171,7 @@ export default function ponytailExtension(pi) {
   pi.on("session_start", async (_event, ctx) => {
     const entries = ctx?.sessionManager?.getBranch?.() || ctx?.sessionManager?.getEntries?.() || [];
     configuredDefaultMode = getDefaultMode();
+    hideStatus = getHideStatus();
     currentMode = resolveSessionMode(entries, configuredDefaultMode);
     syncStatus(ctx);
     ctx?.ui?.notify?.(`Ponytail loaded: ${currentMode}`, "info");

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -1,5 +1,5 @@
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
@@ -43,13 +43,17 @@ function createCommandContext(overrides = {}) {
 function withTempConfig(fn) {
   const tempConfigHome = mkdtempSync(join(tmpdir(), "ponytail-test-"));
   const previousXdg = process.env.XDG_CONFIG_HOME;
+  const previousHide = process.env.PONYTAIL_HIDE_STATUS;
   process.env.XDG_CONFIG_HOME = tempConfigHome;
+  delete process.env.PONYTAIL_HIDE_STATUS;
 
   return Promise.resolve()
     .then(fn)
     .finally(() => {
       if (previousXdg === undefined) delete process.env.XDG_CONFIG_HOME;
       else process.env.XDG_CONFIG_HOME = previousXdg;
+      if (previousHide === undefined) delete process.env.PONYTAIL_HIDE_STATUS;
+      else process.env.PONYTAIL_HIDE_STATUS = previousHide;
       rmSync(tempConfigHome, { recursive: true, force: true });
     });
 }
@@ -187,4 +191,53 @@ test("status bar stays silent when ui lacks a theme", async () => withTempConfig
   await events.get("agent_start")({}, ctx);
 
   assert.deepEqual(calls, []);
+}));
+
+test("PONYTAIL_HIDE_STATUS hides the indicator but keeps ponytail active (#324)", async () => withTempConfig(async () => {
+  process.env.PONYTAIL_HIDE_STATUS = "1";
+  const { events } = createPiHarness();
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "ultra" } }] },
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_c, t) => t } },
+  });
+
+  await events.get("session_start")({ reason: "resume" }, ctx);
+  await events.get("agent_start")({}, ctx);
+  const injected = await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx);
+
+  assert.deepEqual(statusWrites, [], "status bar must not be drawn when hidden");
+  assert.match(injected.systemPrompt, /PONYTAIL MODE ACTIVE/, "ruleset must still inject while status is hidden");
+}));
+
+test("config.hideStatus hides the indicator but keeps ponytail active (#324)", async () => withTempConfig(async () => {
+  mkdirSync(join(process.env.XDG_CONFIG_HOME, "ponytail"), { recursive: true });
+  writeFileSync(join(process.env.XDG_CONFIG_HOME, "ponytail", "config.json"), JSON.stringify({ hideStatus: true }));
+  const { events } = createPiHarness();
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_c, t) => t } },
+  });
+
+  await events.get("session_start")({ reason: "startup" }, ctx);
+  await events.get("agent_start")({}, ctx);
+  const injected = await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx);
+
+  assert.deepEqual(statusWrites, [], "config.hideStatus must suppress the status bar");
+  assert.match(injected.systemPrompt, /PONYTAIL MODE ACTIVE/, "ruleset must still inject while status is hidden");
+}));
+
+test("PONYTAIL_HIDE_STATUS=0 does not hide the indicator", async () => withTempConfig(async () => {
+  process.env.PONYTAIL_HIDE_STATUS = "0";
+  const { events } = createPiHarness();
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "ultra" } }] },
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_c, t) => t } },
+  });
+
+  await events.get("session_start")({ reason: "resume" }, ctx);
+  await events.get("agent_start")({}, ctx);
+
+  assert.ok(statusWrites.length > 0, "0 must be treated as 'do not hide'");
 }));


### PR DESCRIPTION
## Problem

#324: pi draws the status indicator (`○ 🐴 ponytail: ⚡ FULL`) whenever a mode is active, and the only way to blank it is `/ponytail off` — which also stops the ruleset. Users want a clean status bar **and** the always-on ruleset.

## Fix

Add `getHideStatus()` to the shared config resolver: `PONYTAIL_HIDE_STATUS` env (any truthy value; `0`/`false`/empty mean don't hide) or `config.hideStatus === true`, BOM-safe. The pi extension caches it at init, re-reads on `session_start`, and `syncStatus()` returns early when set — so the indicator is suppressed while the ruleset still injects every turn.

## Reconciles #511 and #328

Neither was cleanly mergeable, so this combines the best of both and closes them:
- from **#328**: cache at init + session_start, and the stronger test that asserts the ruleset still injects while the status is hidden;
- from **#511**: BOM-stripped config read;
- **stricter env check** than #511 (`PONYTAIL_HIDE_STATUS=0` correctly does *not* hide — #511 treated any non-empty string as hide);
- **drops #328's `writeDefaultMode` change**, which already landed in #514 (#490).

Both authors credited as co-authors.

## Verification

- `npm test`: root 71 + pi-extension 19 pass, exit 0.
- Tests: env-hide and config-hide each assert the status bar is silent **and** `before_agent_start` still injects the ruleset; a third asserts `PONYTAIL_HIDE_STATUS=0` does not hide.

Note: `hooks/ponytail-config.js` only gains a getter (no ruleset/behavior change); pi-extension isn't gated.