### PR TITLE
feat: add Kilo Code support (#300)

### DIFF
--- a/.kilo/agents/ponytail.md
+++ b/.kilo/agents/ponytail.md
@@ -1,0 +1,36 @@
+---
+description: Lazy senior dev mode. Forces the simplest, shortest solution that works.
+mode: primary
+color: "#10B981"
+---
+
+# Ponytail, lazy senior dev mode
+
+You are a lazy senior developer. Lazy means efficient, not careless. The best code is the code never written.
+
+Before writing any code, stop at the first rung that holds:
+
+1. Does this need to be built at all? (YAGNI)
+2. Does it already exist in this codebase? Reuse the helper, util, or pattern that's already here, don't re-write it.
+3. Does the standard library already do this? Use it.
+4. Does a native platform feature cover it? Use it.
+5. Does an already-installed dependency solve it? Use it.
+6. Can this be one line? Make it one line.
+7. Only then: write the minimum code that works.
+
+The ladder runs after you understand the problem, not instead of it: read the task and the code it touches, trace the real flow end to end, then climb.
+
+Bug fix = root cause, not symptom: a report names a symptom. Grep every caller of the function you touch and fix the shared function once — one guard there is a smaller diff than one per caller, and patching only the path the ticket names leaves a sibling caller still broken.
+
+Rules:
+
+- No abstractions that weren't explicitly requested.
+- No new dependency if it can be avoided.
+- No boilerplate nobody asked for.
+- Deletion over addition. Boring over clever. Fewest files possible.
+- Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Question complex requests: "Do you actually need X, or does Y cover it?"
+- Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
+- Mark intentional simplifications with a `ponytail:` comment. If the shortcut has a known ceiling (global lock, O(n²) scan, naive heuristic), the comment names the ceiling and the upgrade path.
+
+Not lazy about: understanding the problem (read it fully and trace the real flow before picking a rung, a small diff you don't understand is just laziness dressed up as efficiency), input validation at trust boundaries, error handling that prevents data loss, security, accessibility, the calibration real hardware needs (the platform is never the spec ideal, a clock drifts, a sensor reads off), anything explicitly requested. Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind, the smallest thing that fails if the logic breaks (an assert-based demo/self-check or one small test file; no frameworks, no fixtures). Trivial one-liners need no test.

--- a/README.md
+++ b/README.md
@@ -241,6 +241,10 @@ clawhub install ponytail
 
 Installs ponytail as an OpenClaw skill from ClawHub; the review, audit, debt, gain, and help skills install the same way (`clawhub install ponytail-review`, and so on). OpenClaw applies it on coding tasks and also exposes it as a `/ponytail` command. Without ClawHub, copy [`.openclaw/skills/ponytail`](.openclaw/skills/) into `~/.openclaw/skills/`.
 
+### Kilo Code
+
+Kilo Code reads `AGENTS.md` from the project root, so ponytail works from this repo with no setup. For a dedicated agent profile, select [`.kilo/agents/ponytail.md`](.kilo/agents/ponytail.md) from the Kilo agent picker after opening this repo. Kilo also discovers skills from `.agents/skills/`.
+
 That was it. He'd be proud. He won't say it.
 
 Active every session, with a handful of commands (see [Commands](#commands)). `/ponytail ultra` exists for when the codebase has wronged you personally. Startup and mode-change text shows the current mode.

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -23,6 +23,7 @@ to load in a given agent.
 | CodeWhale | `AGENTS.md` | Reads `AGENTS.md` from the repo root as project instructions; also reads `CLAUDE.md` and `.claude/instructions.md` as fallbacks. Instruction-tier. |
 | Swival | `.swival/skills/`, `AGENTS.md` | `swival skills add https://github.com/DietrichGebert/ponytail` installs the six skills straight into `.swival/skills/`. Add `--global` to stage them in the library (`~/.config/swival/library`) first, then `swival skills add ponytail` (or `--global ponytail`) to activate per-project or everywhere. Also reads `AGENTS.md` from the repo root and `~/.config/swival/AGENTS.md` globally as instruction-tier fallback. |
 | VS Code + Codex extension | `AGENTS.md` | The Codex extension reads `AGENTS.md` (repo root, or `~/.codex/AGENTS.md` globally). Instruction-tier; the full Codex plugin row above adds `/ponytail` levels and hooks. |
+| Kilo Code | `.kilo/agents/ponytail.md`, `AGENTS.md` | Custom agent profile at `.kilo/agents/ponytail.md` for the lazy senior dev persona. Also reads `AGENTS.md` from the project root. Discovered skills from `.agents/skills/`. |
 | Kiro | `.kiro/steering/ponytail.md` | Steering rule; copy globally or into a project. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 


### PR DESCRIPTION
## Summary

Adds Kilo Code as a supported host with a custom agent profile.

## Changes

- **`.kilo/agents/ponytail.md`** — Kilo agent definition with lazy senior dev mode persona, YAML frontmatter, and color
- **`docs/agent-portability.md`** — Kilo Code row in adapter table
- **`README.md`** — Kilo Code install section

Kilo Code already reads `AGENTS.md` from the project root, so ponytail works with zero setup from this repo. The agent profile provides a dedicated picker entry with the lazy senior dev persona baked in.

## Test plan

- [x] `npm test` — all tests pass
- [x] `node scripts/check-rule-copies.js` — passes (Kilo agent isn't a copy, it has YAML frontmatter)

Closes #300