### PR TITLE
feat: add Command Code support (#244)

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,14 @@ clawhub install ponytail
 
 Installs ponytail as an OpenClaw skill from ClawHub; the review, audit, debt, gain, and help skills install the same way (`clawhub install ponytail-review`, and so on). OpenClaw applies it on coding tasks and also exposes it as a `/ponytail` command. Without ClawHub, copy [`.openclaw/skills/ponytail`](.openclaw/skills/) into `~/.openclaw/skills/`.
 
+### Command Code
+
+```bash
+cmd skills add https://github.com/DietrichGebert/ponytail
+```
+
+All six ponytail skills (`ponytail`, `ponytail-review`, `ponytail-audit`, `ponytail-debt`, `ponytail-gain`, `ponytail-help`) are available as `/` slash commands. Command Code also reads `AGENTS.md` from the project root.
+
 That was it. He'd be proud. He won't say it.
 
 Active every session, with a handful of commands (see [Commands](#commands)). `/ponytail ultra` exists for when the codebase has wronged you personally. Startup and mode-change text shows the current mode.

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -23,6 +23,7 @@ to load in a given agent.
 | CodeWhale | `AGENTS.md` | Reads `AGENTS.md` from the repo root as project instructions; also reads `CLAUDE.md` and `.claude/instructions.md` as fallbacks. Instruction-tier. |
 | Swival | `.swival/skills/`, `AGENTS.md` | `swival skills add https://github.com/DietrichGebert/ponytail` installs the six skills straight into `.swival/skills/`. Add `--global` to stage them in the library (`~/.config/swival/library`) first, then `swival skills add ponytail` (or `--global ponytail`) to activate per-project or everywhere. Also reads `AGENTS.md` from the repo root and `~/.config/swival/AGENTS.md` globally as instruction-tier fallback. |
 | VS Code + Codex extension | `AGENTS.md` | The Codex extension reads `AGENTS.md` (repo root, or `~/.codex/AGENTS.md` globally). Instruction-tier; the full Codex plugin row above adds `/ponytail` levels and hooks. |
+| Command Code | `AGENTS.md` | Install skills: `cmd skills add https://github.com/DietrichGebert/ponytail`. Also auto-discovers `.agents/skills/` and reads `AGENTS.md`. All six skills available as `/` slash commands. |
 | Kiro | `.kiro/steering/ponytail.md` | Steering rule; copy globally or into a project. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 


### PR DESCRIPTION
## Summary

Adds [Command Code](https://commandcode.ai) as a supported host. Command Code supports the Agent Skills open standard, so our existing `skills/` directory works directly.

## Changes

- **`README.md`** — Command Code install section with `cmd skills add` command
- **`docs/agent-portability.md`** — Command Code row in adapter table

## Usage

```bash
cmd skills add https://github.com/DietrichGebert/ponytail
```

All six ponytail skills (`ponytail`, `ponytail-review`, `ponytail-audit`, `ponytail-debt`, `ponytail-gain`, `ponytail-help`) are available as `/` slash commands. Command Code also reads `AGENTS.md` from the project root.

## Test plan

- [x] `npm test` — all tests pass
- [x] `node scripts/check-rule-copies.js` — passes

Closes #244