### PR TITLE
fix: preserve combined statusLine on uninstall

### DIFF
--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -9,6 +9,8 @@ const fs = require('fs');
 const path = require('path');
 const { getConfigPath, getClaudeDir } = require('../hooks/ponytail-config');
 
+const STATUSLINE_SCRIPT = 'ponytail-statusline';
+
 function removeIfExists(filePath, label) {
   try {
     fs.unlinkSync(filePath);
@@ -26,25 +28,24 @@ try {
   const raw = fs.readFileSync(settingsPath, 'utf8').replace(/^\uFEFF/, '');
   const settings = JSON.parse(raw);
   const cmd = settings.statusLine && settings.statusLine.command;
-  // Only remove the statusLine if ponytail owns the whole command. If the user
-  // combined it with another statusline (e.g. caveman && ponytail), deleting the
-  // key or the command field would destroy the other plugin's part, so leave it
-  // and tell them to strip ponytail's segment by hand.
+  // Only remove the parts ponytail owns. If the user combined statuslines
+  // (e.g. caveman && ponytail), keep the other plugin's command intact.
   // ponytail: splits on && / ; to detect other segments — good enough; a user
   // piping statuslines together is on their own.
-  if (typeof cmd === 'string' && cmd.includes('ponytail-statusline')) {
-    const others = cmd
+  if (typeof cmd === 'string' && cmd.includes(STATUSLINE_SCRIPT)) {
+    const parts = cmd
       .split(/&&|;/)
       .map((s) => s.trim())
-      .filter((s) => s && !s.includes('ponytail-statusline'));
+      .filter(Boolean);
+    const others = parts.filter((s) => !s.includes(STATUSLINE_SCRIPT));
     if (others.length === 0) {
       delete settings.statusLine;
       fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
       console.log(`Removed ponytail statusLine entry from ${settingsPath}`);
     } else {
-      console.log(
-        `Left your combined statusLine in ${settingsPath} untouched; remove the ponytail-statusline part by hand.`,
-      );
+      settings.statusLine.command = others.join(' && ');
+      fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');
+      console.log(`Removed ponytail statusLine segment from ${settingsPath}`);
     }
   }
 } catch (e) {

--- a/tests/uninstall.test.js
+++ b/tests/uninstall.test.js
@@ -80,8 +80,8 @@ assert.equal(result.status, 0, result.stderr);
 const settingsAfter3 = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
 assert.equal(
   settingsAfter3.statusLine.command,
-  'bash ~/caveman-statusline.sh && bash /p/ponytail-statusline.sh',
-  'a combined statusLine must be left untouched, not partially destroyed',
+  'bash ~/caveman-statusline.sh',
+  'a combined statusLine must keep the non-ponytail command',
 );
 
 // #434: a malformed settings.json must not crash the script mid-cleanup. It


### PR DESCRIPTION
## Summary

`scripts/uninstall.js` removed Ponytail-owned `statusLine` entries, but a combined command containing another tool plus `ponytail-statusline` was left untouched. That avoided deleting the other tool, but it also left Ponytail installed in the combined status line.

This changes uninstall to remove only the Ponytail-owned command segment and keep the remaining command segments intact.

| Q | A |
| --- | --- |
| Branch? | main |
| Bug fix? | yes |
| Issues | Refs #502, uninstall statusLine part |

## Test verification (RED -> GREEN)

RED, test added before the fix:

```text
node --test tests/uninstall.test.js
# tests 1
# pass 0
# fail 1
```

GREEN, after the fix:

```text
node --test tests/uninstall.test.js
# tests 1
# pass 1
# fail 0
```

Revert proof, production fix reverted while keeping the test:

```text
node --test tests/uninstall.test.js
# tests 1
# pass 0
# fail 1
```

Final local checks:

```text
node --test tests/uninstall.test.js
# tests 1
# pass 1
# fail 0

npm test
# pass 70
# fail 1
# known baseline: csv: correct pandas one-liner passes

npm test --prefix pi-extension
# pass 19
# fail 0
```