### PR TITLE
fix: guard against non-string input.arguments in OpenCode plugin

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -92,7 +92,7 @@ export default async ({ client } = {}) => {
     'command.execute.before': async (input) => {
       if (!input || input.command !== 'ponytail') return;
       // `off` is persisted like any mode; the transform reads it and stays silent.
-      const mode = normalizePersistedMode((input.arguments || '').trim()) || getDefaultMode();
+      const mode = normalizePersistedMode(String(input.arguments || '').trim()) || getDefaultMode();
       writeMode(mode);
       log('info', 'ponytail ' + mode);
     },


### PR DESCRIPTION
Heyaaaaa all : )

Spotted a type coercion bug in the OpenCode plugin — if `input.arguments` ever comes in as something other than a string (like a number), `.trim()` blows up because the `||` fallback only catches falsy values.

The pi-extension already does this right with `String(args || "").trim()`, so I just matched the same pattern here. One-line fix, prevents the hook from crashing.

```js
// Before — 💥 if input.arguments is truthy but not a string
const mode = normalizePersistedMode((input.arguments || '').trim()) || getDefaultMode();

// After — safe for any type
const mode = normalizePersistedMode(String(input.arguments || '').trim()) || getDefaultMode();
```

Fixes #553.