### PR TITLE
fix: add missing icon for review mode in status bar

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -73,7 +73,7 @@ export default function ponytailExtension(pi) {
       c.ui.setStatus("ponytail", "");
       return;
     }
-    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥" };
+    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥", review: "📋" };
     const icon = levelIcons[currentMode] || "";
     const label = currentMode.toUpperCase();
     const indicator = isActive ? theme.fg("accent", "●") : theme.fg("dim", "○");


### PR DESCRIPTION
Heyaaaaa all : )

Quick one — `review` mode was missing its icon in the status bar. Every other mode has one (🌿 lite, ⚡ full, 🔥 ultra) but review was showing a blank. Just added 📋 to the map.

Fixes #554.