### PR TITLE
fix: catch fs errors when writing default mode in pi-extension

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -114,13 +114,17 @@ export default function ponytailExtension(pi) {
       }
 
       if (parsed.type === "set-default") {
-        const written = writeDefaultMode(parsed.mode);
-        if (written) {
-          configuredDefaultMode = getDefaultMode();
-          const message = configuredDefaultMode === written
-            ? `Default Ponytail mode set to ${written}.`
-            : `Saved default ${written}, but env override keeps default at ${configuredDefaultMode}.`;
-          ctx?.ui?.notify?.(message, "info");
+        try {
+          const written = writeDefaultMode(parsed.mode);
+          if (written) {
+            configuredDefaultMode = getDefaultMode();
+            const message = configuredDefaultMode === written
+              ? `Default Ponytail mode set to ${written}.`
+              : `Saved default ${written}, but env override keeps default at ${configuredDefaultMode}.`;
+            ctx?.ui?.notify?.(message, "info");
+          }
+        } catch (e) {
+          ctx?.ui?.notify?.(`Failed to save default mode: ${e.message}`, "error");
         }
         return;
       }


### PR DESCRIPTION
Heyaaaaa all : )

The `/ponytail default <mode>` handler wasn't catching filesystem errors from `writeDefaultMode()`. If something goes wrong writing the config (permissions, disk full, whatever), it was just an unhandled promise rejection with no user feedback.

Wrapped it in a try-catch so the user actually gets a notification when things go sideways instead of wondering why their default didn't save.

Fixes #555.