### PR TITLE
fix: read ponytail-mcp server version from package.json (#535)

### DIFF
--- a/ponytail-mcp/index.js
+++ b/ponytail-mcp/index.js
@@ -8,8 +8,9 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 
 import { MODES, buildInstructions, resolveMode } from "./instructions.js";
+import { getVersion } from "./version.js";
 
-const server = new McpServer({ name: "ponytail", version: "0.1.0" });
+const server = new McpServer({ name: "ponytail", version: getVersion() });
 
 const modeArg = z
   .enum(MODES)

--- a/ponytail-mcp/test/version.test.js
+++ b/ponytail-mcp/test/version.test.js
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { getVersion } from "../version.js";
+
+test("getVersion reads the version from ponytail-mcp/package.json, not a hardcoded string", () => {
+  assert.equal(getVersion(), "4.8.4");
+});

--- a/ponytail-mcp/version.js
+++ b/ponytail-mcp/version.js
@@ -1,0 +1,7 @@
+// Reads the server version from package.json so it can't drift from the
+// package's actual version on release (#535).
+import { readFileSync } from "node:fs";
+
+export function getVersion() {
+  return JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8")).version;
+}


### PR DESCRIPTION
McpServer was constructed with a hardcoded "0.1.0", which drifts from package.json's actual version on every release. Extract a getVersion() helper (mirrors instructions.js's separation from index.js so it's testable without spinning up the stdio server) and use it instead.