### PR TITLE
fix: add missing status bar icon for review mode (#554)

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -79,7 +79,7 @@ export default function ponytailExtension(pi) {
       c.ui.setStatus("ponytail", "");
       return;
     }
-    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥" };
+    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥", review: "📋" };
     const icon = levelIcons[currentMode] || "";
     const label = currentMode.toUpperCase();
     const indicator = isActive ? theme.fg("accent", "●") : theme.fg("dim", "○");


### PR DESCRIPTION
## Summary
- `levelIcons` in `pi-extension/index.js` only mapped `lite`/`full`/`ultra`, even though `review` has been a valid mode (`VALID_MODES` in `hooks/ponytail-config.js`) for a while. The status bar showed a blank icon slot when in review mode.
- Added `review: "📋"` to the map, as suggested in the issue.

## Test plan
- [x] `node --test tests/*.test.js` — 76 tests pass
- [x] `npm test --prefix pi-extension` — 20 tests pass

Closes #554