### PR TITLE
fix: handle fs errors when writing the default mode (#555)

### DIFF
--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -135,15 +135,21 @@ function writeDefaultMode(mode) {
   if (!normalized) return null;
 
   const configPath = getConfigPath();
-  fs.mkdirSync(path.dirname(configPath), { recursive: true });
-  let config = {};
   try {
-    config = JSON.parse(fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
-    if (!config || typeof config !== 'object' || Array.isArray(config)) config = {};
-  } catch (_) {}
-  config.defaultMode = normalized;
-  fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
-  return normalized;
+    fs.mkdirSync(path.dirname(configPath), { recursive: true });
+    let config = {};
+    try {
+      config = JSON.parse(fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
+      if (!config || typeof config !== 'object' || Array.isArray(config)) config = {};
+    } catch (_) {}
+    config.defaultMode = normalized;
+    fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
+    return normalized;
+  } catch (_) {
+    // Permission errors, full disk, etc. \u2014 callers treat a falsy return as
+    // "not written" (#555), same sentinel as an invalid mode above.
+    return null;
+  }
 }
 
 module.exports = {

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -127,6 +127,8 @@ export default function ponytailExtension(pi) {
             ? `Default Ponytail mode set to ${written}.`
             : `Saved default ${written}, but env override keeps default at ${configuredDefaultMode}.`;
           ctx?.ui?.notify?.(message, "info");
+        } else {
+          ctx?.ui?.notify?.("Could not save the default mode — check permissions on the ponytail config file.", "error");
         }
         return;
       }

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -248,6 +248,16 @@ try {
   else process.env.XDG_CONFIG_HOME = prevXdg;
 }
 
+// writeDefaultMode must not throw on an fs failure (e.g. EACCES, full disk);
+// it returns null instead so callers can report the failure (#555).
+const origWriteFileSync = fs.writeFileSync;
+fs.writeFileSync = () => { throw new Error('EACCES: permission denied'); };
+try {
+  assert.equal(writeDefaultMode('ultra'), null, 'writeDefaultMode must swallow fs errors and return null');
+} finally {
+  fs.writeFileSync = origWriteFileSync;
+}
+
 // #329: `/ponytail default <mode>` persists the default to config (survives
 // restart), while a plain switch stays session-scoped and never touches config.
 const defHome = path.join(temp, 'default-cmd-home');


### PR DESCRIPTION
## Summary
- `writeDefaultMode()` in `hooks/ponytail-config.js` did an unguarded `mkdirSync` + `writeFileSync`; a permission error or full disk threw inside the pi-extension's `async` command handler as an unhandled rejection, so the user saw no feedback at all.
- Fixed at the shared function (not just the one call site) so every caller benefits: wrapped the fs calls in try/catch, returning `null` on failure — the same sentinel already used for an invalid mode.
- The pi-extension handler (the only caller with access to `ctx.ui.notify`) now notifies the user when `writeDefaultMode` returns falsy, instead of silently doing nothing.
- Added a regression test to `tests/hooks.test.js` that monkeypatches `fs.writeFileSync` to throw and asserts `writeDefaultMode` returns `null` instead of throwing.

## Test plan
- [x] `node --test tests/*.test.js` — 75 tests pass
- [x] `npm test --prefix pi-extension` — 20 tests pass
- [x] Verified the new test fails on the pre-fix code and passes after

Closes #555