### PR TITLE
fix: coerce input.arguments to string in OpenCode plugin (#553)

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -84,7 +84,7 @@ export default async ({ client } = {}) => {
     'command.execute.before': async (input) => {
       if (!input || input.command !== 'ponytail') return;
       // `off` is persisted like any mode; the transform reads it and stays silent.
-      const args = (input.arguments || '').trim();
+      const args = String(input.arguments || '').trim();
       const mode = args ? normalizePersistedMode(args) : getDefaultMode();
       if (!mode) return;
       writeMode(mode);

--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -67,6 +67,15 @@ test('unsupported /ponytail arguments do not reset the current mode', async () =
   assert.equal(fs.readFileSync(statePath, 'utf8'), 'ultra');
 });
 
+test('non-string arguments (type coercion) do not crash command.execute.before (#553)', async () => {
+  const hooks = await loadPlugin({});
+  fs.writeFileSync(statePath, 'ultra');
+  await assert.doesNotReject(() =>
+    hooks['command.execute.before']({ command: 'ponytail', arguments: 5, sessionID: 's' }),
+  );
+  assert.equal(fs.readFileSync(statePath, 'utf8'), 'ultra', 'an unrecognized mode must not reset the current one');
+});
+
 test('unrelated commands do not touch the flag', async () => {
   try { fs.unlinkSync(statePath); } catch (e) {}
   const hooks = await loadPlugin({});


### PR DESCRIPTION
## Summary
- `.opencode/plugins/ponytail.mjs`'s `command.execute.before` did `(input.arguments || '').trim()`, which throws a `TypeError` if `input.arguments` is a non-string truthy value (e.g. a number) since `||` doesn't fall through in that case — a full hook crash from a malformed command payload.
- The pi-extension already guards the equivalent spot with `String(args || "").trim()`; matched that here.
- Added a regression test to `tests/opencode-plugin.test.js` (confirmed it fails with the exact reported `TypeError` on the pre-fix code, passes after).

## Test plan
- [x] `node --test tests/*.test.js` — 76 tests pass
- [x] Verified the new test reproduces the reported crash pre-fix and passes post-fix

Closes #553