### PR TITLE
fix(pi): add missing review mode icon to status bar

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -69,7 +69,7 @@ export default function ponytailExtension(pi) {
       c.ui.setStatus("ponytail", "");
       return;
     }
-    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥" };
+    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥", review: "📋" };
     const icon = levelIcons[currentMode] || "";
     const label = currentMode.toUpperCase();
     const indicator = isActive ? theme.fg("accent", "●") : theme.fg("dim", "○");

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -152,6 +152,20 @@ test("status bar renders the mode and flips active on agent_start", async () => 
   assert.match(statusWrites.at(-1).text, /●.*ULTRA/);
 }));
 
+test("status bar shows the review mode icon", async () => withTempConfig(async () => {
+  const { events } = createPiHarness();
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "review" } }] },
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_color, text) => text } },
+  });
+
+  await events.get("session_start")({ reason: "resume" }, ctx);
+  await events.get("agent_start")({}, ctx);
+
+  assert.match(statusWrites.at(-1).text, /📋.*REVIEW/);
+}));
+
 test("status bar stays silent when ui lacks a theme", async () => withTempConfig(async () => {
   const { events } = createPiHarness();
   const calls = [];


### PR DESCRIPTION
levelIcons in pi-extension/index.js mapped lite/full/ultra to an emoji but omitted review, even though review is a valid mode (VALID_MODES in ponytail-config.js). Switching to review mode left the status bar badge with a blank where the icon should be.

Closes #554