### PR TITLE
fix: track plugin.yaml in the version-consistency check

### DIFF
--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -26,12 +26,21 @@ const VERSION_FILES = [
   'gemini-extension.json',       // Gemini CLI extension
   'package.json',                // pi-package / repo root
   'ponytail-mcp/package.json',   // MCP server (private, internal-only)
+  'plugin.yaml',                 // Hermes Agent plugin manifest
 ];
+
+// plugin.yaml is bumped by hand at release time same as the rest (see
+// c99757a), but it's YAML, not JSON \u2014 pull just the top-level `version:`
+// line rather than pull in a YAML dependency for one field.
+function readYamlVersion(raw) {
+  return raw.match(/^version:\s*["']?(\d+\.\d+\.\d+)["']?\s*$/m)?.[1];
+}
 
 function readVersion(relPath) {
   try {
     // Strip a UTF-8 BOM some Windows editors prepend (breaks JSON.parse).
     const raw = fs.readFileSync(path.join(root, relPath), 'utf8').replace(/^\uFEFF/, '');
+    if (relPath.endsWith('.yaml') || relPath.endsWith('.yml')) return readYamlVersion(raw);
     return JSON.parse(raw).version;
   } catch (e) {
     throw new Error(`${relPath}: ${e.message}`);

--- a/tests/check-versions.test.js
+++ b/tests/check-versions.test.js
@@ -1,0 +1,25 @@
+#!/usr/bin/env node
+// Regression test: plugin.yaml (the Hermes Agent manifest) declares its own
+// version and is bumped by hand at release time same as the other manifests
+// (see c99757a), but was missing from VERSION_FILES — so it could drift
+// unnoticed, the exact failure mode check-versions.js exists to catch
+// (#260/#262).
+
+const assert = require('node:assert/strict');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const root = path.join(__dirname, '..');
+
+const result = spawnSync(process.execPath, [path.join(root, 'scripts', 'check-versions.js')], {
+  encoding: 'utf8',
+});
+
+assert.equal(result.status, 0, result.stderr);
+assert.match(
+  result.stdout,
+  /All 8 version files pinned/,
+  'plugin.yaml must be tracked alongside the other 7 manifests',
+);
+
+console.log('check-versions.js tracks plugin.yaml');


### PR DESCRIPTION
check-versions.js pins seven manifests to one shared version, but plugin.yaml (the Hermes Agent plugin manifest) was never in that list even though it carries its own version field and is bumped by hand at release time same as the rest (c99757a). A release that bumped the other seven and forgot plugin.yaml would pass the check silently -- exactly the drift-goes-unnoticed failure mode this script exists to catch (#260/#262), just on a file it didn't know to look at.

Added a minimal top-level `version:` line reader for the one YAML manifest rather than pull in a YAML parsing dependency for a single field, and a regression test that fails if plugin.yaml drops back out of VERSION_FILES.