### PR TITLE
fix: drop bash-only `exec` from hooks so they run under PowerShell (#527, #569)

### DIFF
--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "exec node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\" }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
@@ -19,7 +19,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "exec node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-subagent.js\" }",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
@@ -32,7 +32,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "exec node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\" }",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -53,13 +53,23 @@ test('shared hook commands avoid POSIX-only guard syntax', () => {
   }
 });
 
-test('shared hook commands exec node instead of leaving a wrapper shell behind', () => {
+// Issue #527 / #569: the shared `command` field must be shell-agnostic. `exec`
+// is a bash/zsh builtin with no PowerShell equivalent, but some hosts run
+// `command` through PowerShell on Windows regardless of the commandWindows
+// field — VS Code Copilot always does (it never reads commandWindows), and
+// native Claude Code launched from Git Bash was seen doing the same. `exec
+// node ...` then dies on its first token with CommandNotFoundException, so
+// every hook fails on Windows. Plain `node ...` runs natively in both bash and
+// PowerShell. The wrapper-process pileup that #461 originally used `exec` to
+// avoid is handled separately by each hook's stdin self-exit guard (#443/#477).
+test('shared hook commands are shell-agnostic (no bash-only exec prefix)', () => {
   const commands = commandHooks()
     .map((h) => h.command)
     .filter(Boolean);
   assert.ok(commands.length > 0, 'expected at least one shared command entry');
   for (const cmd of commands) {
-    assert.match(cmd, /^exec node\s+/, `command must replace the shell with node: ${cmd}`);
+    assert.doesNotMatch(cmd, /(^|\s)exec\s/, `command must not use the bash-only 'exec' builtin (breaks under PowerShell): ${cmd}`);
+    assert.match(cmd, /^node\s+/, `command must invoke node directly so it runs in both bash and PowerShell: ${cmd}`);
     assert.doesNotMatch(cmd, /;\s*exit 0$/, `command must not leave a shell wrapper waiting on node: ${cmd}`);
   }
 });


### PR DESCRIPTION
## Problem

On Windows, every ponytail lifecycle hook (`SessionStart`, `SubagentStart`, `UserPromptSubmit`) fails with:

```
exec : The term 'exec' is not recognized as the name of a cmdlet, function, script file, or operable program.
```

This is reported for both VS Code Copilot (#527) and native Claude Code launched from Git Bash (#569). The error is non-blocking but fires on every hook, polluting output.

## Cause

The three shared `command` fields in `hooks/claude-codex-hooks.json` use `exec node "..."`. `exec` is a bash/zsh builtin with no PowerShell equivalent. Some hosts dispatch the `command` field through PowerShell on Windows regardless of the PowerShell-native `commandWindows` field — VS Code Copilot always does (it never reads `commandWindows`), and native Claude Code from Git Bash was reported doing the same (#569). PowerShell then dies on the very first token with `CommandNotFoundException`.

## Fix

Drop the `exec` prefix. Plain `node "..."` runs natively in **both** bash and PowerShell.

Dropping `exec` only gives up the POSIX optimization of replacing the wrapper shell with node. The wrapper-process pileup that #461 originally added `exec` to avoid is already handled separately by each hook's stdin self-exit guard (#443/#477), so there is no regression on Codex/zsh.

## Verification

Reproduced the root cause and confirmed the fix on Windows 10 / PowerShell 5.1:

```
PS> exec node --version
exec : The term 'exec' is not recognized ...   # the reported failure
PS> node --version
v22.22.0                                        # the fix
```

Full test suite is green. Updated `tests/hooks-windows.test.js` so the regression test asserts the shell-agnostic form (no bash-only `exec`, invokes `node` directly) instead of requiring `exec node`.

## Note on #530

#530 also removes `exec`, bundled with a broader change that additionally reworks Copilot detection for #528 — but it is currently in a conflicting state. This PR is a minimal, focused change rebased on `main` that resolves just the `exec`/PowerShell failure and also closes the newly-filed #569. Happy to fold this into #530 instead if you'd prefer to land everything together.

Closes #569
Closes #527
