### PR TITLE
Fix Codex hook output schema

### DIFF
--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -43,10 +43,10 @@ function writeHookOutput(event, mode, context = '') {
   if (isCodex) {
     const output = { systemMessage: `PONYTAIL:${mode.toUpperCase()}` };
     if (context) {
-      // ponytail: Codex CLI expects additionalContext at top level, not nested
-      // under hookSpecificOutput. The hookSpecificOutput wrapper is for Claude
-      // Code's SubagentStart. See issue #505.
-      output.additionalContext = context;
+      output.hookSpecificOutput = {
+        hookEventName: event,
+        additionalContext: context,
+      };
     }
     process.stdout.write(JSON.stringify(output));
     return;

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -60,11 +60,12 @@ assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.readFileSync(codexState, 'utf8'), 'ultra');
 let output = JSON.parse(result.stdout);
 assert.equal(output.systemMessage, 'PONYTAIL:ULTRA');
+assert.equal(output.additionalContext, undefined, 'Codex must not emit additionalContext at top level (#573)');
+assert.equal(output.hookSpecificOutput.hookEventName, 'SessionStart');
 assert.match(
-  output.additionalContext,
+  output.hookSpecificOutput.additionalContext,
   /PONYTAIL MODE ACTIVE — level: ultra/,
 );
-assert.equal(output.hookSpecificOutput, undefined, 'Codex should not use hookSpecificOutput (#505)');
 
 result = run(
   'ponytail-mode-tracker.js',
@@ -85,8 +86,10 @@ result = run(
 assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.readFileSync(codexState, 'utf8'), 'lite');
 output = JSON.parse(result.stdout);
+assert.equal(output.additionalContext, undefined, 'Codex must not emit additionalContext at top level (#573)');
+assert.equal(output.hookSpecificOutput.hookEventName, 'UserPromptSubmit');
 assert.match(
-  output.additionalContext,
+  output.hookSpecificOutput.additionalContext,
   /PONYTAIL MODE ACTIVE — level: lite/,
 );
 
@@ -230,8 +233,9 @@ result = run('ponytail-subagent.js', { HOME: subHome, USERPROFILE: subHome, PLUG
 assert.equal(result.status, 0, result.stderr);
 output = JSON.parse(result.stdout);
 assert.equal(output.systemMessage, 'PONYTAIL:FULL');
-assert.ok(output.additionalContext, 'Codex SubagentStart should have additionalContext at top level (#505)');
-assert.match(output.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);
+assert.equal(output.additionalContext, undefined, 'Codex must not emit additionalContext at top level (#573)');
+assert.equal(output.hookSpecificOutput.hookEventName, 'SubagentStart');
+assert.match(output.hookSpecificOutput.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);
 
 // SubagentStart scoping (issue #506): PONYTAIL_SUBAGENT_MATCHER limits the
 // injection to agent types whose name matches the regex. Unset keeps the


### PR DESCRIPTION
## Summary

- restore Codex context output under `hookSpecificOutput` with the matching event name
- cover SessionStart, UserPromptSubmit, and SubagentStart with regression assertions
- reject the schema-invalid top-level `additionalContext` shape in tests

## Why

#508 flattened `additionalContext` onto the output root. Codex command output schemas set `additionalProperties: false` at the root, so Codex rejects that JSON before injecting Ponytail's context.

Fixes #573.

## Validation

- [x] `node tests/hooks.test.js`
- [x] `node --check hooks/ponytail-runtime.js`
- [x] `npm test` (82 root + 20 Pi extension + 3 MCP tests)
- [x] minimal SessionStart schema-shape reproduction: failing before the fix, `PASS` after it

## Notes for reviewers

The change is limited to the shared Codex output branch and its existing hook compatibility tests. It adds no dependencies or unrelated changes.
