### PR TITLE
fix: reject review as a default mode (pi-extension + config)

### DIFF
--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -76,7 +76,10 @@ function getClaudeDir() {
 function getDefaultMode() {
   // 1. Environment variable (highest priority)
   const envMode = process.env.PONYTAIL_DEFAULT_MODE;
-  if (envMode && VALID_MODES.includes(envMode.toLowerCase())) {
+  // ponytail: a default must be a runtime level (off/lite/full/ultra); review is
+  // a session-only mode, never a valid default (#377). Validate against
+  // RUNTIME_MODES so a stray env var or config can't make review the default.
+  if (envMode && RUNTIME_MODES.includes(envMode.toLowerCase())) {
     return envMode.toLowerCase();
   }
 
@@ -85,7 +88,7 @@ function getDefaultMode() {
     const configPath = getConfigPath();
     // Strip UTF-8 BOM (common on Windows-saved files) so JSON.parse doesn't choke
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
-    if (config.defaultMode && VALID_MODES.includes(config.defaultMode.toLowerCase())) {
+    if (config.defaultMode && RUNTIME_MODES.includes(config.defaultMode.toLowerCase())) {
       return config.defaultMode.toLowerCase();
     }
   } catch (e) {
@@ -131,7 +134,8 @@ function getHideStatus() {
 }
 
 function writeDefaultMode(mode) {
-  const normalized = normalizeConfigMode(mode);
+  // ponytail: only a runtime level can be a default; review is session-only (#377).
+  const normalized = normalizeMode(mode);
   if (!normalized) return null;
 
   const configPath = getConfigPath();

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -8,7 +8,6 @@ const {
   getQuietStartup,
   getHideStatus,
   normalizeMode,
-  normalizeConfigMode,
   normalizePersistedMode,
   isDeactivationCommand,
   writeDefaultMode,
@@ -50,7 +49,8 @@ export function parsePonytailCommand(text, defaultMode = DEFAULT_MODE) {
   if (primary === "status") return { type: "status" };
 
   if (primary === "default") {
-    const mode = normalizeConfigMode(secondary);
+    // ponytail: a default must be a runtime level; review is session-only (#377).
+    const mode = normalizeMode(secondary);
     return mode ? { type: "set-default", mode } : { type: "invalid", reason: "invalid-default-mode" };
   }
 

--- a/pi-extension/test/helpers.test.js
+++ b/pi-extension/test/helpers.test.js
@@ -23,6 +23,15 @@ test("parsePonytailCommand parses modes, status, and default subcommand", () => 
   assert.deepEqual(parsePonytailCommand("default lite", "full"), { type: "set-default", mode: "lite" });
 });
 
+test("parsePonytailCommand rejects review as a default (session-only mode, #377)", () => {
+  assert.deepEqual(parsePonytailCommand("default review", "full"), { type: "invalid", reason: "invalid-default-mode" });
+});
+
+test("resolveSessionMode still honors review as a session mode (not a default)", () => {
+  const entries = [{ type: "custom", customType: "ponytail-mode", data: { mode: "review" } }];
+  assert.equal(resolveSessionMode(entries, "full"), "review");
+});
+
 test("resolveSessionMode prefers latest persisted session mode", () => {
   const entries = [
     { type: "custom", customType: "ponytail-mode", data: { mode: "lite" } },

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -11,7 +11,7 @@ const root = path.join(__dirname, '..');
 // isShellSafe gates the statusline setup snippet (issue #200): ordinary install
 // paths pass, paths carrying shell metacharacters are rejected so they never get
 // embedded in a shell command.
-const { isShellSafe, writeDefaultMode } = require('../hooks/ponytail-config');
+const { DEFAULT_MODE, getDefaultMode, isShellSafe, writeDefaultMode } = require('../hooks/ponytail-config');
 assert.equal(isShellSafe('C:\\Users\\x\\.claude\\plugins\\ponytail\\hooks\\ponytail-statusline.ps1'), true);
 assert.equal(isShellSafe('/home/u/.claude/plugins/ponytail/hooks/ponytail-statusline.sh'), true);
 assert.equal(isShellSafe('/tmp/a"&calc.exe&"/x.sh'), false);
@@ -411,5 +411,30 @@ assert.equal(JSON.parse(fs.readFileSync(defConfig, 'utf8')).defaultMode, 'lite',
 result = run('ponytail-mode-tracker.js', defEnv, JSON.stringify({ prompt: '/ponytail default review' }));
 assert.equal(result.status, 0, result.stderr);
 assert.equal(JSON.parse(fs.readFileSync(defConfig, 'utf8')).defaultMode, 'lite', 'review must not be accepted as a default');
+
+// review must be refused as a default by the config functions too, not only the
+// mode-tracker command path (#377): writing it is a no-op, and a stray
+// PONYTAIL_DEFAULT_MODE=review falls back to the built-in default.
+const revHome = path.join(temp, 'review-default-home');
+const revConfigDir = path.join(revHome, '.config', 'ponytail');
+fs.mkdirSync(revConfigDir, { recursive: true });
+const revConfigPath = path.join(revConfigDir, 'config.json');
+fs.writeFileSync(revConfigPath, JSON.stringify({ defaultMode: 'lite' }, null, 2));
+
+const prevXdgRev = process.env.XDG_CONFIG_HOME;
+const prevEnvModeRev = process.env.PONYTAIL_DEFAULT_MODE;
+process.env.XDG_CONFIG_HOME = path.join(revHome, '.config');
+try {
+  assert.equal(writeDefaultMode('review'), null, 'writeDefaultMode must refuse review as a default (#377)');
+  assert.equal(JSON.parse(fs.readFileSync(revConfigPath, 'utf8')).defaultMode, 'lite', 'a refused review write must leave the config unchanged');
+
+  delete process.env.PONYTAIL_DEFAULT_MODE;
+  fs.rmSync(revConfigPath);
+  process.env.PONYTAIL_DEFAULT_MODE = 'review';
+  assert.equal(getDefaultMode(), DEFAULT_MODE, 'PONYTAIL_DEFAULT_MODE=review must fall back to the built-in default');
+} finally {
+  if (prevXdgRev === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = prevXdgRev;
+  if (prevEnvModeRev === undefined) delete process.env.PONYTAIL_DEFAULT_MODE; else process.env.PONYTAIL_DEFAULT_MODE = prevEnvModeRev;
+}
 
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
## Problem

`review` is a session-only mode (set by `/ponytail-review`), not a persistent default. The Claude/Codex mode-tracker already refuses it as a default (#377), but two paths slipped through:

1. The Pi extension accepted `/ponytail default review` and persisted it, so the next session started in review with a blank status-bar icon.
2. `getDefaultMode` accepted review from `PONYTAIL_DEFAULT_MODE` or a stale config file.

This is the root cause behind the blank review icon in #554 (and why #565 / #568 tried to add an icon for a state that should not exist in the Pi status bar).

## Fix

Validate the default against `RUNTIME_MODES` (off/lite/full/ultra) in the three default paths: `getDefaultMode`, `writeDefaultMode`, and the Pi `default` command. `review` stays fully valid as a session mode.

## Tests

- Pi: `/ponytail default review` is rejected; review still resolves as a session mode.
- Config: `writeDefaultMode('review')` is a no-op; `PONYTAIL_DEFAULT_MODE=review` falls back to the built-in default.

Full root suite 82/82, Pi suite 22/22, green locally.
