### PR TITLE
fix(pi): add missing review icon to status bar (#554)

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -81,7 +81,7 @@ export default function ponytailExtension(pi) {
       c.ui.setStatus("ponytail", "");
       return;
     }
-    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥" };
+    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥", review: "📋" };
     const icon = levelIcons[currentMode] || "";
     const label = currentMode.toUpperCase();
     const indicator = isActive ? theme.fg("accent", "●") : theme.fg("dim", "○");

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -179,6 +179,21 @@ test("status bar renders the mode and flips active on agent_start", async () => 
   assert.match(statusWrites.at(-1).text, /●.*ULTRA/);
 }));
 
+test("status bar shows an icon for review mode, not a blank (#554)", async () => withTempConfig(async () => {
+  const { events } = createPiHarness();
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "review" } }] },
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_color, text) => text } },
+  });
+
+  await events.get("session_start")({ reason: "resume" }, ctx);
+  await events.get("agent_start")({}, ctx);
+
+  assert.match(statusWrites.at(-1).text, /REVIEW/);
+  assert.doesNotMatch(statusWrites.at(-1).text, /ponytail: {2}REVIEW/, "review mode must render an icon, not a blank");
+}));
+
 test("status bar stays silent when ui lacks a theme", async () => withTempConfig(async () => {
   const { events } = createPiHarness();
   const calls = [];


### PR DESCRIPTION
levelIcons only covered lite/full/ultra, so switching to review mode left the status bar with a blank spot where the icon should be.