### PR TITLE
Fix review mode icon and VS Code Copilot detection

### DIFF
--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -4,13 +4,23 @@ const os = require('os');
 const { getClaudeDir, getConfigDir } = require('./ponytail-config');
 
 const STATE_FILE = '.ponytail-active';
-const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
+const hasCopilotEnv = Boolean(process.env.COPILOT_PLUGIN_DATA);
+// VS Code Copilot never sets COPILOT_PLUGIN_DATA; it only injects
+// CLAUDE_PLUGIN_ROOT. Fall back to sniffing the plugin install path
+// (…/agent-plugins/…/.vscode/…) so Copilot-under-VS-Code is still detected.
+const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT || '';
+const isVSCodeCopilot = !hasCopilotEnv &&
+  pluginRoot.split(/[\\/]+/).includes('agent-plugins') &&
+  pluginRoot.toLowerCase().includes('.vscode');
+const isCopilot = hasCopilotEnv || isVSCodeCopilot;
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 const isQoder = !isCopilot && !isCodex && Boolean(process.env.QODER_SESSION_ID);
 
 let stateDir = getClaudeDir();
 if (isCodex) stateDir = process.env.PLUGIN_DATA;
-if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA;
+// Only trust COPILOT_PLUGIN_DATA when it's actually set — the VS Code
+// fallback above can mark isCopilot true with no such env var present.
+if (hasCopilotEnv) stateDir = process.env.COPILOT_PLUGIN_DATA;
 if (isQoder) stateDir = path.join(os.homedir(), '.qoder');
 
 const statePath = path.join(stateDir, STATE_FILE);

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -81,7 +81,7 @@ export default function ponytailExtension(pi) {
       c.ui.setStatus("ponytail", "");
       return;
     }
-    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥" };
+    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥", review: "📋" };
     const icon = levelIcons[currentMode] || "";
     const label = currentMode.toUpperCase();
     const indicator = isActive ? theme.fg("accent", "●") : theme.fg("dim", "○");


### PR DESCRIPTION
## Summary

Two small fixes bundled together since they touch adjacent code paths:

### 1. Missing `review` icon in statusline (`pi-extension/index.js`)

`review` is a valid mode in `VALID_MODES` but was missing from the
`levelIcons` map, so switching to review mode left a blank icon in the
statusline:

Added `review: "📋"` alongside the existing `lite`/`full`/`ultra` entries.

### 2. VS Code Copilot not detected, causing a false statusline nudge (`hooks/ponytail-runtime.js`)

`isCopilot` was derived solely from `COPILOT_PLUGIN_DATA`. VS Code Copilot
never sets that env var — it only injects `CLAUDE_PLUGIN_ROOT` — so under
VS Code Copilot, ponytail incorrectly assumed native Claude Code CLI and
emitted a `STATUSLINE SETUP NEEDED` nudge pointing users at
`~/.claude/settings.json`'s `statusLine` key, which VS Code Copilot doesn't
read. Pure noise.

**Repro:** install ponytail into
`~/.vscode/agent-plugins/github.com/DietrichGebert/ponytail`, don't set
`statusLine` in `~/.claude/settings.json`, start a new Copilot chat — the
SessionStart hook output ends with the setup nudge even though it's
irrelevant on that host.

**Fix:** fall back to sniffing `CLAUDE_PLUGIN_ROOT` for an
`agent-plugins` + `.vscode` path segment when `COPILOT_PLUGIN_DATA` is
unset, so VS Code Copilot is still correctly identified.

Also guarded the `stateDir` override: it previously read
`process.env.COPILOT_PLUGIN_DATA` whenever `isCopilot` was true, which
under the new fallback path (where that env var is genuinely absent)
would have set `stateDir = undefined`. Now it only overrides `stateDir`
when `COPILOT_PLUGIN_DATA` is actually present, falling back to
`getClaudeDir()` otherwise.

## Testing

- Confirmed the `levelIcons` lookup resolves for all four `VALID_MODES`
  values.
- Confirmed `isCopilot`/`stateDir` logic against both the native
  `COPILOT_PLUGIN_DATA` path and the new `CLAUDE_PLUGIN_ROOT` fallback
  path, with `COPILOT_PLUGIN_DATA` unset in the latter case.

**Env for original repro:** ponytail 4.8.4 · VS Code Copilot
(agent-plugins install) · Windows 11