### PR TITLE
fix: remove unreachable Claude marketplace schema

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,5 +1,4 @@
 {
-  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
   "name": "ponytail",
   "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
   "owner": {

--- a/tests/package.test.js
+++ b/tests/package.test.js
@@ -21,3 +21,12 @@ test('npm package ships the advertised cleanup script', () => {
     'scripts/uninstall.js is listed in files but missing on disk',
   );
 });
+
+test('Claude marketplace manifest does not depend on an external schema URL', () => {
+  const marketplace = JSON.parse(fs.readFileSync(path.join(root, '.claude-plugin', 'marketplace.json'), 'utf8'));
+  assert.equal(
+    Object.hasOwn(marketplace, '$schema'),
+    false,
+    'Claude Desktop marketplace sync fails when $schema points at an unreachable external URL',
+  );
+});


### PR DESCRIPTION
## Summary

Claude Desktop marketplace sync can fail when `.claude-plugin/marketplace.json` declares a `$schema` URL that does not resolve. The Claude Code CLI tolerates it, but Desktop appears stricter when syncing a marketplace repository.

This removes the external `$schema` field from the Claude marketplace manifest and adds a regression test so it does not come back.

| Q | A |
| --- | --- |
| Branch? | main |
| Bug fix? | yes |
| Issues | Fix #582 |

## Test verification (RED -> GREEN)

RED, test added before the manifest change:

```text
node --test tests/package.test.js
# tests 2
# pass 1
# fail 1
# failing test: Claude marketplace manifest does not depend on an external schema URL
```

GREEN, after removing `$schema`:

```text
node --test tests/package.test.js
# tests 2
# pass 2
# fail 0
```

Revert proof, `$schema` restored while keeping the test:

```text
node --test tests/package.test.js
# tests 2
# pass 1
# fail 1
# failing test: Claude marketplace manifest does not depend on an external schema URL
```

Final local checks:

```text
node --test tests/package.test.js
# tests 2
# pass 2
# fail 0

git diff --check
# passed

node --test tests/*.test.js pi-extension/test/*.test.js
# tests 106
# pass 105
# fail 1
# known baseline/environment failure: csv: correct pandas one-liner passes
```