### PR TITLE
fix: read ponytail MCP package version

### DIFF
--- a/ponytail-mcp/index.js
+++ b/ponytail-mcp/index.js
@@ -11,7 +11,7 @@ import { z } from "zod";
 import { MODES, buildInstructions, resolveMode } from "./instructions.js";
 
 const { version } = JSON.parse(
-  await fs.promises.readFile(new URL("../package.json", import.meta.url), "utf8")
+  await fs.promises.readFile(new URL("./package.json", import.meta.url), "utf8")
 );
 const server = new McpServer({ name: "ponytail", version });
 

--- a/ponytail-mcp/test/server.test.js
+++ b/ponytail-mcp/test/server.test.js
@@ -1,0 +1,15 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import test from "node:test";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const serverSource = fs.readFileSync(path.join(__dirname, "..", "index.js"), "utf8");
+
+test("server version is read from ponytail-mcp/package.json", () => {
+  assert.ok(
+    serverSource.includes('new URL("./package.json", import.meta.url)'),
+    "MCP server must use ponytail-mcp/package.json, not the repo root package.json",
+  );
+});


### PR DESCRIPTION
## Summary

`ponytail-mcp/index.js` should report the version from `ponytail-mcp/package.json`, the package it serves from. It was reading the repository root package instead, which only works while both package versions happen to stay aligned.

This switches the runtime read to the MCP package's own `package.json` and adds a regression test for that path.

| Q | A |
| --- | --- |
| Branch? | main |
| Bug fix? | yes |
| Issues | Fix #535 |

## Test verification (RED -> GREEN)

RED, test added before the fix:

```text
npm test --prefix ponytail-mcp
# tests 4
# pass 3
# fail 1
# failing test: server version is read from ponytail-mcp/package.json
```

GREEN, after the fix:

```text
npm test --prefix ponytail-mcp
# tests 4
# pass 4
# fail 0
```

Revert proof, production path reverted while keeping the test:

```text
npm test --prefix ponytail-mcp
# tests 4
# pass 3
# fail 1
# failing test: server version is read from ponytail-mcp/package.json
```

Final local checks:

```text
npm test --prefix ponytail-mcp
# tests 4
# pass 4
# fail 0

git diff --check
# passed

node --test tests/*.test.js pi-extension/test/*.test.js
# tests 105
# pass 104
# fail 1
# known baseline/environment failure: csv: correct pandas one-liner passes
```