### PR TITLE
fix: Claude Desktop (Cowork) marketplace sync — schema-clean Claude hook config

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,5 @@
     "name": "Dietrich Gebert",
     "url": "https://github.com/DietrichGebert"
   },
-  "hooks": "./hooks/claude-codex-hooks.json"
+  "hooks": "./hooks/claude-hooks.json"
 }

--- a/hooks/claude-hooks.json
+++ b/hooks/claude-hooks.json
@@ -1,0 +1,41 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
+            "timeout": 5,
+            "statusMessage": "Loading ponytail mode..."
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"",
+            "timeout": 5,
+            "statusMessage": "Loading ponytail mode..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
+            "timeout": 5,
+            "statusMessage": "Tracking ponytail mode..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -13,10 +13,12 @@ const { spawn } = require('child_process');
 
 const root = path.join(__dirname, '..');
 const HOOKS_JSON = 'hooks/claude-codex-hooks.json';
-const HOST_PLUGIN_MANIFESTS = [
-  '.claude-plugin/plugin.json',
-  '.codex-plugin/plugin.json',
-];
+const HOST_PLUGIN_MANIFEST_HOOKS = {
+  // Issue #582: the Claude marketplace validator rejects non-standard hook
+  // fields (commandWindows), so Claude gets a schema-clean copy of the config.
+  '.claude-plugin/plugin.json': 'hooks/claude-hooks.json',
+  '.codex-plugin/plugin.json': HOOKS_JSON,
+};
 // cmd.exe variable syntax (%FOO%); PowerShell leaves it literal, breaking the path.
 const CMD_VAR_SYNTAX = /%[A-Za-z_][A-Za-z0-9_]*%/;
 // PowerShell 5.1 rejects these POSIX shell guards when a host runs `command`.
@@ -106,9 +108,36 @@ test('ponytail-mode-tracker self-exits when stdin never closes (no freeze)', asy
   assert.equal(code, 0, 'hook must exit cleanly when stdin never closes');
 });
 
-test('Claude and Codex manifests point at the shared host-specific hook config', () => {
-  for (const rel of HOST_PLUGIN_MANIFESTS) {
+test('host manifests point at their host-specific hook config', () => {
+  for (const [rel, hooksFile] of Object.entries(HOST_PLUGIN_MANIFEST_HOOKS)) {
     const manifest = JSON.parse(fs.readFileSync(path.join(root, rel), 'utf8'));
-    assert.equal(manifest.hooks, `./${HOOKS_JSON}`, `${rel} must not rely on root hooks auto-discovery`);
+    assert.equal(manifest.hooks, `./${hooksFile}`, `${rel} must not rely on root hooks auto-discovery`);
   }
+});
+
+// Issue #582: Claude Desktop (Cowork) marketplace sync validates hook configs
+// server-side and rejects any field it does not know. commandWindows is a
+// Codex-only extension, so the Claude config must never carry it — otherwise
+// the whole marketplace fails to sync with status failed_content.
+test('Claude hook config only uses fields the marketplace schema accepts', () => {
+  const config = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'claude-hooks.json'), 'utf8'));
+  const hooks = Object.values(config.hooks).flat().flatMap((entry) => entry.hooks);
+  assert.ok(hooks.length > 0, 'expected at least one Claude hook entry');
+  for (const hook of hooks) {
+    assert.equal(hook.commandWindows, undefined, 'commandWindows is rejected by the Claude marketplace validator (issue #582)');
+  }
+});
+
+// The Claude config is a schema-clean mirror of the shared one: same events,
+// same commands. Guards against the two files drifting apart.
+test('Claude hook config stays in sync with the shared config', () => {
+  const shared = JSON.parse(fs.readFileSync(path.join(root, HOOKS_JSON), 'utf8'));
+  const claude = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'claude-hooks.json'), 'utf8'));
+  const strip = (config) => Object.fromEntries(
+    Object.entries(config.hooks).map(([event, entries]) => [event, entries.map((entry) => ({
+      ...entry,
+      hooks: entry.hooks.map(({ commandWindows, ...rest }) => rest),
+    }))]),
+  );
+  assert.deepEqual(strip(claude), strip(shared), 'hooks/claude-hooks.json must mirror the shared config (minus commandWindows)');
 });


### PR DESCRIPTION
## Summary

Fix #582 — adding this repo as a marketplace in Claude Desktop (Cowork) fails with "Marketplace sync failed".

## Root cause

Sync is validated **server-side** by Anthropic's marketplace service. It rejects the plugin because the hook config referenced by `.claude-plugin/plugin.json` uses the non-standard `commandWindows` field:

```
status: failed_content — "Unknown hook field(s) ['commandWindows'] in 'SessionStart' matcher 0 hook 0.
Hooks must only use fields the approval UI can display" (same for SubagentStart / UserPromptSubmit)
```

The `$schema` URL (#586's theory) is unrelated: the validator parses `marketplace.json` with `$schema` present without complaint and proceeds to plugin validation.

## Change

- Add `hooks/claude-hooks.json` — a copy of the shared config minus `commandWindows` (schema-clean for the Claude validator).
- - Point `.claude-plugin/plugin.json` at it. `.codex-plugin` keeps `hooks/claude-codex-hooks.json` with `commandWindows` intact, so Codex/Windows behavior is unchanged.
- - Tests: manifest expectations updated, plus two regression tests — Claude config must never carry `commandWindows`, and it must stay a mirror of the shared config (guards against drift).
Simply deleting `commandWindows` from the shared file was rejected as an option: it would drop the Windows-specific PowerShell guard for Codex hosts and break `tests/hooks-windows.test.js`.

## Test plan

- `node --test tests/*.test.js` — 84/84 pass.
- - Verified end-to-end: a branch with this change syncs successfully in Claude Desktop "Add marketplace", and the plugin installs and activates (hooks fire on SessionStart).