### PR TITLE
fix(benchmarks): prevent csv correctness harness from crashing on rai…

### DIFF
--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -194,16 +194,17 @@ os.chdir(r"${path.dirname(csvPath)}")
 # Capture print output
 import io
 _stdout = sys.stdout
-sys.stdout = io.StringIO()
+_captured = io.StringIO()
+sys.stdout = _captured
 
 try:
 ${patched.split('\n').map((l) => '    ' + l).join('\n')}
 except Exception as e:
     sys.stdout = _stdout
-    # If it needs sales.csv in cwd, write it there and retry
-    pass
+    print("FAIL: exception while running: " + repr(str(e)[:200]))
+    sys.exit(1)
 
-output = sys.stdout.getvalue()
+output = _captured.getvalue()
 sys.stdout = _stdout
 
 # Check output contains the number 351 (100.5 + 200.0 + 50.5)

--- a/tests/correctness.test.js
+++ b/tests/correctness.test.js
@@ -74,13 +74,16 @@ test('debounce: immediate-call implementation fails', () => {
 
 // --- CSV sum ---
 
-test('csv: correct pandas one-liner passes', () => {
+test('csv: correct stdlib one-liner passes', () => {
   const result = check(
     "Write Python code that reads sales.csv and sums the 'amount' column.",
     'python',
-    `import pandas as pd
-df = pd.read_csv('sales.csv')
-print(df['amount'].sum())`,
+    `import csv
+total = 0.0
+with open('sales.csv') as f:
+    for row in csv.DictReader(f):
+        total += float(row['amount'])
+print(total)`,
   );
   assert.equal(result.pass, true);
   assert.equal(result.score, 1);


### PR DESCRIPTION
## Summary
The `csv()` correctness harness in benchmarks/correctness.js crashed with
`AttributeError: '_io.TextIOWrapper' object has no attribute 'getvalue'`
whenever the generated code raised inside its `try:` block. The `except`
branch restored `sys.stdout` to the real stream, then the next line called
`.getvalue()` on it — so the real error was swallowed and masked by a
misleading Python traceback.

## Fix
Keep a reference to the captured `StringIO` buffer (`_captured`) and emit a
clean `FAIL` on exception instead of silently `pass`-ing.

## Test plan
- A correct non-pandas CSV implementation still scores pass (351).
- Generated CSV code that raises now returns a clean fail instead of crashing.