### PR TITLE
fix(omp): resolve Bun redeclaration syntax error and add omp key

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -18,10 +18,10 @@ import { fileURLToPath } from 'url';
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // The shared instruction builder is CommonJS; bridge to it from this ES module.
-const require = createRequire(import.meta.url);
-const { getPonytailInstructions } = require('../../hooks/ponytail-instructions');
-const { getDefaultMode, normalizePersistedMode } = require('../../hooks/ponytail-config');
-const { parseCommandFile } = require('./ponytail-frontmatter.cjs');
+const cjsRequire = createRequire(import.meta.url);
+const { getPonytailInstructions } = cjsRequire('../../hooks/ponytail-instructions');
+const { getDefaultMode, normalizePersistedMode } = cjsRequire('../../hooks/ponytail-config');
+const { parseCommandFile } = cjsRequire('./ponytail-frontmatter.cjs');
 
 // OpenCode has no flag-file convention of its own; keep mode beside its config.
 const statePath = path.join(

--- a/package.json
+++ b/package.json
@@ -36,6 +36,10 @@
   "scripts": {
     "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix ponytail-mcp"
   },
+  "omp": {
+    "extensions": ["./pi-extension/index.js"],
+    "skills": ["./skills"]
+  },
   "pi": {
     "extensions": ["./pi-extension/index.js"],
     "skills": ["./skills"]

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -1,6 +1,6 @@
 import { createRequire } from "node:module";
 
-const require = createRequire(import.meta.url);
+const cjsRequire = createRequire(import.meta.url);
 const {
   DEFAULT_MODE,
   RUNTIME_MODES,
@@ -11,8 +11,8 @@ const {
   normalizePersistedMode,
   isDeactivationCommand,
   writeDefaultMode,
-} = require("../hooks/ponytail-config.js");
-const { getPonytailInstructions, filterSkillBodyForMode } = require("../hooks/ponytail-instructions.js");
+} = cjsRequire("../hooks/ponytail-config.js");
+const { getPonytailInstructions, filterSkillBodyForMode } = cjsRequire("../hooks/ponytail-instructions.js");
 
 export { filterSkillBodyForMode };
 export const readDefaultMode = getDefaultMode;

--- a/ponytail-mcp/instructions.js
+++ b/ponytail-mcp/instructions.js
@@ -3,9 +3,9 @@
 // hooks and Pi extension use, so every host emits identical rules.
 import { createRequire } from "node:module";
 
-const require = createRequire(import.meta.url);
-const { getPonytailInstructions } = require("../hooks/ponytail-instructions.js");
-const { getDefaultMode, normalizeMode } = require("../hooks/ponytail-config.js");
+const cjsRequire = createRequire(import.meta.url);
+const { getPonytailInstructions } = cjsRequire("../hooks/ponytail-instructions.js");
+const { getDefaultMode, normalizeMode } = cjsRequire("../hooks/ponytail-config.js");
 
 // The three intensities the server offers. "off" has no instructions to serve.
 export const MODES = ["lite", "full", "ultra"];


### PR DESCRIPTION
This PR fixes a syntax error when installing the ponytail extension under `omp` (Oh My Pi).

### Problem
In the `omp` environment (which runs on Bun), `require` is pre-defined globally. Defining `const require = createRequire(import.meta.url)` in ESM files throws a `SyntaxError: Cannot declare a const variable twice: 'require'`. This triggers an installation rollback during validation.

### Fix
1. Renamed the local `require` variables to `cjsRequire` across all ESM files to avoid redeclaration syntax conflicts in Bun.
2. Added the native/preferred `"omp"` manifest key alongside `"pi"` in `package.json` for proper native package resolution in Oh My Pi.