### PR TITLE
fix(qoder): expand ${QODER_PLUGIN_ROOT} in plugin hook commands

### DIFF
--- a/hooks/qoder-hooks.json
+++ b/hooks/qoder-hooks.json
@@ -1,12 +1,12 @@
 {
-  "_comment": "Reference template — copy the 'hooks' object into your .qoder/settings.json or ~/.qoder/settings.json. Replace PONYTAIL_DIR with the path to your ponytail checkout (e.g. ~/.qoder/plugins/ponytail or the npm global install path).",
+  "_comment": "Loaded live by .qoder-plugin/plugin.json (\"hooks\": \"./hooks/qoder-hooks.json\"). Qoder expands ${QODER_PLUGIN_ROOT} — the plugin install root — at runtime; see https://docs.qoder.com/en/cli/plugins#writing-plugin-hooks.",
   "hooks": {
     "UserPromptSubmit": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node PONYTAIL_DIR/hooks/ponytail-mode-tracker.js"
+            "command": "node \"${QODER_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node PONYTAIL_DIR/hooks/ponytail-subagent.js"
+            "command": "node \"${QODER_PLUGIN_ROOT}/hooks/ponytail-subagent.js\""
           }
         ]
       }


### PR DESCRIPTION
.qoder-plugin/plugin.json loads hooks/qoder-hooks.json as a live plugin
hook config, but the two commands contained the literal placeholder
PONYTAIL_DIR. Qoder never expands PONYTAIL_DIR, so it ran the string
verbatim:

  node <cwd>/PONYTAIL_DIR/hooks/ponytail-mode-tracker.js
  Error: Cannot find module '...MODULE_NOT_FOUND'

surfacing in Qoder as a non-blocking UserPromptSubmit hook error on
every prompt, with the ponytail ruleset never injected -- a functional
silent failure despite the non-blocking status.

Qoder expands ${QODER_PLUGIN_ROOT} (the plugin install root) in plugin
hook commands at runtime [1], the same mechanism the sibling
hooks/claude-codex-hooks.json already uses via ${CLAUDE_PLUGIN_ROOT}.
Swap the placeholder for that variable in both commands and reword the
now-stale _comment: the file is loaded live by the plugin manifest, not
copied into settings.json as a template.

commandWindows / timeout / statusMessage from claude-codex-hooks.json
are intentionally not mirrored: the Qoder plugin-hook docs document only
"type" and "command" hook keys [1], so adding the rest would be
unverified speculation.

Verified: with QODER_PLUGIN_ROOT set, both hook scripts exit 0 and the
mode-tracker emits the "PONYTAIL MODE ACTIVE -- level: full" banner plus
the full ruleset (its isQoder double-duty branch), restoring ponytail
behavior under Qoder.

[1] https://docs.qoder.com/en/cli/plugins#writing-plugin-hooks