### PR TITLE
docs: FAQ entry on using caveman with ponytail

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -233,6 +233,9 @@ El benchmark de correctness lanza Python para las verificaciones de email y CSV;
 
 ## FAQ
 
+**¿Puedo usarlo junto con [caveman](https://github.com/JuliusBrussee/caveman)?**
+Sí, y deberías. Caveman achica lo que el agente dice; ponytail achica lo que construye. Mitades distintas, sin solapamiento: caveman deja el código intacto byte por byte, ponytail no se mete con la prosa. Charla concisa sobre código mínimo.
+
 **¿Necesita un archivo de configuración?**
 No. Un opcional `~/.config/ponytail/config.json` o la variable `PONYTAIL_DEFAULT_MODE` pueden fijar el nivel default, pero nada es obligatorio.
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,9 @@ The correctness benchmark spawns Python for email and CSV checks; `python3` is t
 
 ## FAQ
 
+**Can I use it with [caveman](https://github.com/JuliusBrussee/caveman)?**
+Yes, and you should. Caveman shrinks what the agent says; ponytail shrinks what it builds. Different halves, no overlap: caveman leaves code byte-for-byte exact, ponytail stays out of the prose. Terse talk about minimal code.
+
 **Does it need a config file?**
 No. An optional `~/.config/ponytail/config.json` or `PONYTAIL_DEFAULT_MODE` env var can set the default level, but nothing is required.
 


### PR DESCRIPTION
Recurring question: can you run caveman and ponytail together? The answer was already in the skill file — `skills/ponytail/SKILL.md` says "pair with Caveman for terse prose" — but never made it into the README.

Added as the first FAQ entry in both `README.md` and `README.es.md`:

> **Can I use it with [caveman](https://github.com/JuliusBrussee/caveman)?**
> Yes, and you should. Caveman shrinks what the agent says; ponytail shrinks what it builds. Different halves, no overlap: caveman leaves code byte-for-byte exact, ponytail stays out of the prose. Terse talk about minimal code.

The "different halves" claim is each skill's own rule, not a courtesy — caveman's docs state it keeps code "byte-for-byte exact", and ponytail's ruleset cedes prose. Left the benchmark numbers out; the caveman control-arm row above already carries "not a substitute".

Docs only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)