### PR TITLE
fix(opencode): move frontmatter parser out of plugins/ directory (#596)

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -21,7 +21,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const require = createRequire(import.meta.url);
 const { getPonytailInstructions } = require('../../hooks/ponytail-instructions');
 const { getDefaultMode, normalizePersistedMode } = require('../../hooks/ponytail-config');
-const { parseCommandFile } = require('./ponytail-frontmatter.cjs');
+const { parseCommandFile } = require('../ponytail-frontmatter.cjs');
 
 // OpenCode has no flag-file convention of its own; keep mode beside its config.
 const statePath = path.join(

--- a/.opencode/ponytail-frontmatter.cjs
+++ b/.opencode/ponytail-frontmatter.cjs
@@ -2,13 +2,11 @@
 
 // ponytail command-file frontmatter parser.
 //
-// Pulled out of ponytail.mjs so the plugin module's only top-level export is
-// the plugin function itself. OpenCode's legacy plugin loader (the one that
-// runs before v1 plugins are detected) treats every function exported from a
-// plugin module as a plugin; calling the frontmatter parser as one threw
-// "path must be a string or a file descriptor" because it got the plugin
-// context object as its first argument. Keeping the parser in its own module
-// leaves exactly one plugin-shaped export on ponytail.mjs.
+// Lives outside .opencode/plugins/ so OpenCode's legacy plugin loader
+// doesn't discover it. The legacy loader treats every exported function
+// from any file under plugins/ as a plugin; calling parseCommandFile with
+// the plugin context object threw "path must be a string or a file
+// descriptor" (#301, #596).
 
 function parseCommandFile(filePath) {
   const fs = require('fs');

--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -27,7 +27,7 @@ test.before(async () => {
   // OpenCode's legacy loader treats every exported function as a plugin and
   // tried to invoke it with the plugin context object, which crashed. The
   // parser now lives in its own .cjs sibling; require it directly.
-  parseCommandFile = require(path.join(__dirname, '..', '.opencode', 'plugins', 'ponytail-frontmatter.cjs')).parseCommandFile;
+  parseCommandFile = require(path.join(__dirname, '..', '.opencode', 'ponytail-frontmatter.cjs')).parseCommandFile;
 });
 
 function transform(hooks) {


### PR DESCRIPTION
## Problem

Loading the ponytail OpenCode plugin (`@dietrichgebert/ponytail`, installed via `"plugin": ["@dietrichgebert/ponytail"]`) fails at plugin-load time with:

```
error="path must be a string or a file descriptor"
error="The \"path\" argument must be of type string or an instance of Buffer or URL. Received an instance of Object"
```

## Root Cause

`ponytail-frontmatter.cjs` lived inside `.opencode/plugins/`, which OpenCode's legacy plugin loader scans for modules. It found `parseCommandFile` exported from that file and tried to call it as a plugin, passing the plugin context object `{ client: ... }` as the `filePath` argument to `fs.readFileSync`. This is a recurrence of #301 — the extraction worked for `ponytail.mjs` exports but the file stayed in the scanned directory.

## Fix

Moved `ponytail-frontmatter.cjs` from `.opencode/plugins/` to `.opencode/` (outside the scanned directory), updated the two require paths. The `plugins/` directory now contains only `ponytail.mjs` with its single `default` export.

## Verification

- All 8 OpenCode plugin tests pass
- Legacy loader simulation shows zero errors — `plugins/` only contains the plugin function, nothing else to mistakenly invoke
- `package.json` `files` field uses `.opencode/` directory glob, so the moved file is still included in the npm package

Closes #596