### PR TITLE
fix(codex): drop SessionStart systemMessage that renders as a yellow warning (#605)

### DIFF
--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -41,7 +41,13 @@ function writeHookOutput(event, mode, context = '') {
     return;
   }
   if (isCodex) {
-    const output = { systemMessage: `PONYTAIL:${mode.toUpperCase()}` };
+    // No systemMessage: Codex maps it to a yellow `warning:` entry (and de-greens the
+    // completed-hook bullet), reading as an error every session (#605). The mode still
+    // shows via the additionalContext "hook context:" line — active level when on,
+    // "PONYTAIL MODE OFF" when off (that path passes context too).
+    // ponytail: if openai/codex#16933 lands and hides additionalContext, restore a
+    // non-warning mode signal here.
+    const output = {};
     if (context) {
       output.hookSpecificOutput = {
         hookEventName: event,

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -59,7 +59,7 @@ let result = run('ponytail-activate.js', codexEnv);
 assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.readFileSync(codexState, 'utf8'), 'ultra');
 let output = JSON.parse(result.stdout);
-assert.equal(output.systemMessage, 'PONYTAIL:ULTRA');
+assert.equal(output.systemMessage, undefined, 'Codex must not emit systemMessage — Codex renders it as a yellow warning: line (#605)');
 assert.equal(output.additionalContext, undefined, 'Codex must not emit additionalContext at top level (#573)');
 assert.equal(output.hookSpecificOutput.hookEventName, 'SessionStart');
 assert.match(
@@ -75,7 +75,12 @@ result = run(
 assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.readFileSync(codexState, 'utf8'), 'lite');
 output = JSON.parse(result.stdout);
-assert.equal(output.systemMessage, 'PONYTAIL:LITE');
+assert.equal(output.systemMessage, undefined, 'Codex must not emit systemMessage (#605)');
+assert.match(
+  output.hookSpecificOutput.additionalContext,
+  /level: lite/,
+  'mode still surfaces via the hook context line',
+);
 
 // Querying bare @ponytail should report the active level ('lite') without resetting it to default ('ultra')
 result = run(
@@ -101,7 +106,12 @@ result = run(
 assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.existsSync(codexState), false);
 output = JSON.parse(result.stdout);
-assert.equal(output.systemMessage, 'PONYTAIL:OFF');
+assert.equal(output.systemMessage, undefined, 'Codex must not emit systemMessage (#605)');
+assert.match(
+  output.hookSpecificOutput.additionalContext,
+  /PONYTAIL MODE OFF/,
+  'deactivation still surfaces via the hook context line',
+);
 
 // A request that merely mentions "normal mode" must not deactivate ponytail.
 result = run('ponytail-mode-tracker.js', codexEnv, JSON.stringify({ prompt: '@ponytail lite' }));
@@ -243,14 +253,14 @@ assert.equal(result.status, 0, result.stderr);
 assert.equal(result.stdout, '', 'SubagentStart must stay silent when ponytail is off');
 
 // Codex shares claude-codex-hooks.json, so SubagentStart is reachable under Codex
-// too — assert the codex branch emits the badge plus hookSpecificOutput.
+// too — assert the codex branch emits hookSpecificOutput and no systemMessage (#605).
 const subCodex = path.join(temp, 'sub-codex');
 fs.mkdirSync(subCodex, { recursive: true });
 fs.writeFileSync(path.join(subCodex, '.ponytail-active'), 'full');
 result = run('ponytail-subagent.js', { HOME: subHome, USERPROFILE: subHome, PLUGIN_DATA: subCodex });
 assert.equal(result.status, 0, result.stderr);
 output = JSON.parse(result.stdout);
-assert.equal(output.systemMessage, 'PONYTAIL:FULL');
+assert.equal(output.systemMessage, undefined, 'Codex must not emit systemMessage (#605)');
 assert.equal(output.additionalContext, undefined, 'Codex must not emit additionalContext at top level (#573)');
 assert.equal(output.hookSpecificOutput.hookEventName, 'SubagentStart');
 assert.match(output.hookSpecificOutput.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);


### PR DESCRIPTION
## Problem

On Codex, every SessionStart shows ponytail's mode as a yellow `warning:` line that reads like an error (#605):

```
• SessionStart hook (completed)
  warning: PONYTAIL:FULL
  hook context: PONYTAIL MODE ACTIVE — level: full
```

This is distinct from #331 / openai/codex#16933 (Codex rendering `additionalContext`) — this line is ponytail's own `systemMessage`.

## Fix

Drop `systemMessage` in the `isCodex` branch of `hooks/ponytail-runtime.js`. Codex maps a hook `systemMessage` to a `Warning` entry, and any `Warning` entry also de-greens the completed-hook bullet (codex `tui/src/history_cell/hook_cell.rs`). Removing it:

- drops the `warning:` line,
- greens the completed-hook bullet,
- keeps every state visible via the `hook context:` line — `level: <mode>` when on, `PONYTAIL MODE OFF` when off (that path passes context too), since Codex renders `additionalContext`.

So no loss of visibility, only the alarming styling goes. The `isCodex` branch is now identical to `isQoder` — glad to dedup them if you'd prefer.

## Tests

`npm test` — updated the codex assertions in `tests/hooks.test.js` to assert no `systemMessage` and confirm the mode/off state still surfaces via `additionalContext`. (The pre-existing `tests/correctness.test.js` csv failure is unrelated — it fails on clean `main` here too.)

Fixes #605
