### PR TITLE
feat: add support for Kimi Code hooks and plugin manifest

### DIFF
--- a/.kimi-plugin/plugin.json
+++ b/.kimi-plugin/plugin.json
@@ -1,0 +1,39 @@
+{
+  "name": "ponytail",
+  "version": "4.8.4",
+  "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
+  "author": {
+    "name": "Dietrich Gebert",
+    "url": "https://github.com/DietrichGebert"
+  },
+  "homepage": "https://github.com/DietrichGebert/ponytail",
+  "repository": "https://github.com/DietrichGebert/ponytail",
+  "license": "MIT",
+  "keywords": ["yagni", "minimalism", "code-review", "productivity"],
+  "skills": "./skills/",
+  "hooks": [
+    {
+      "event": "SessionStart",
+      "matcher": "startup|resume|clear|compact",
+      "command": "node ./hooks/ponytail-activate.js",
+      "timeout": 5
+    },
+    {
+      "event": "SubagentStart",
+      "command": "node ./hooks/ponytail-subagent.js",
+      "timeout": 5
+    },
+    {
+      "event": "UserPromptSubmit",
+      "command": "node ./hooks/ponytail-mode-tracker.js",
+      "timeout": 5
+    }
+  ],
+  "interface": {
+    "displayName": "Ponytail",
+    "shortDescription": "Lazy senior developer mode",
+    "longDescription": "Prefer YAGNI, the standard library, native platform features, and the smallest correct implementation.",
+    "developerName": "Dietrich Gebert",
+    "websiteURL": "https://github.com/DietrichGebert/ponytail"
+  }
+}

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -10,6 +10,7 @@ to load in a given agent.
 |------|-------|-------|
 | Claude Code | `.claude-plugin/plugin.json`, `commands/`, `hooks/claude-codex-hooks.json`, `hooks/` | Full plugin install with session activation, mode tracking, commands, and statusline support. |
 | Codex | `.codex-plugin/plugin.json`, `hooks/claude-codex-hooks.json`, `hooks/`, `skills/` | Plugin install with the same skills plus lifecycle hooks for activation and mode tracking. |
+| Kimi Code | `.kimi-plugin/plugin.json`, `hooks/`, `skills/` | Plugin install with session activation, mode tracking, and subagent hooks. |
 | OpenCode | `.opencode/plugins/ponytail.mjs`, `.opencode/command/`, `hooks/`, `skills/` | Server plugin injects the ruleset each turn via `experimental.chat.system.transform` and persists `/ponytail` switches; reuses the shared instruction builder. |
 | pi | `pi-extension/`, `skills/`, `hooks/` | Package extension: injects the ruleset each turn through the shared instruction builder and registers the `/ponytail` commands. |
 | Hermes Agent | `plugin.yaml`, `__init__.py`, `skills/` | Native Hermes plugin: injects active mode through `pre_llm_call`, rewrites gateway `/ponytail-*` skill commands into agent prompts, registers `/ponytail` mode switching, and exposes bundled skills as `ponytail:<skill>`. |

--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -14,6 +14,7 @@ const {
   clearMode,
   isCodex,
   isCopilot,
+  isKimi,
   setMode,
   writeHookOutput,
 } = require('./ponytail-runtime');
@@ -42,7 +43,7 @@ try {
 let output = getPonytailInstructions(mode);
 
 // 3. Detect missing statusline config — nudge Claude to help set it up
-if (!isCodex && !isCopilot) try {
+if (!isCodex && !isCopilot && !isKimi) try {
   let hasStatusline = false;
   if (fs.existsSync(settingsPath)) {
     // Strip UTF-8 BOM some editors prepend on Windows (breaks JSON.parse)

--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -15,7 +15,7 @@ function finish() {
   try {
     // Strip UTF-8 BOM some shells prepend when piping (breaks JSON.parse)
     const data = JSON.parse(input.replace(/^\uFEFF/, ''));
-    const prompt = (data.prompt || '').trim().toLowerCase();
+    const prompt = (data.prompt || data.user_prompt || '').trim().toLowerCase();
 
     // Match /ponytail commands
     let modeSwitched = false;

--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -7,11 +7,13 @@ const STATE_FILE = '.ponytail-active';
 const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 const isQoder = !isCopilot && !isCodex && Boolean(process.env.QODER_SESSION_ID);
+const isKimi = !isCopilot && !isCodex && !isQoder && (Boolean(process.env.KIMI_PLUGIN_ROOT) || Boolean(process.env.KIMI_CODE_HOME));
 
 let stateDir = getClaudeDir();
 if (isCodex) stateDir = process.env.PLUGIN_DATA;
 if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA;
 if (isQoder) stateDir = path.join(os.homedir(), '.qoder');
+if (isKimi) stateDir = process.env.KIMI_CODE_HOME || path.join(os.homedir(), '.kimi-code');
 
 const statePath = path.join(stateDir, STATE_FILE);
 
@@ -64,6 +66,11 @@ function writeHookOutput(event, mode, context = '') {
     process.stdout.write(JSON.stringify(output));
     return;
   }
+  if (isKimi) {
+    // Kimi Code appends raw stdout to the context.
+    process.stdout.write(context);
+    return;
+  }
   // Native Claude: SessionStart accepts raw stdout, but SubagentStart needs the
   // hookSpecificOutput JSON form or the context is dropped.
   if (event === 'SubagentStart') {
@@ -79,6 +86,7 @@ module.exports = {
   isCodex,
   isCopilot,
   isQoder,
+  isKimi,
   readMode,
   setMode,
   writeHookOutput,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     ".opencode/",
     ".qoder/",
     ".qoder-plugin/",
+    ".kimi-plugin/",
     "pi-extension/",
     "scripts/uninstall.js",
     "assets/",

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -23,6 +23,7 @@ const VERSION_FILES = [
   '.codex-plugin/plugin.json',   // Codex plugin
   '.devin-plugin/plugin.json',   // Devin CLI plugin
   '.github/plugin/plugin.json',  // Copilot plugin
+  '.kimi-plugin/plugin.json',    // Kimi Code plugin
   '.qoder-plugin/plugin.json',   // Qoder plugin
   'gemini-extension.json',       // Gemini CLI extension
   'package.json',                // pi-package / repo root

--- a/tests/gemini-extension.test.js
+++ b/tests/gemini-extension.test.js
@@ -21,6 +21,7 @@ const VERSIONED_MANIFESTS = [
   '.claude-plugin/plugin.json',
   '.codex-plugin/plugin.json',
   '.github/plugin/plugin.json',
+  '.kimi-plugin/plugin.json',
 ];
 // Gemini auto-discovers these by directory; the manifest is only useful if they exist.
 const REUSED_COMMANDS = ['commands/ponytail.toml', 'commands/ponytail-review.toml'];

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -37,6 +37,8 @@ delete process.env.COPILOT_PLUGIN_DATA;
 // A leaked subagent matcher would scope the inject-into-every-subagent assertions.
 delete process.env.PONYTAIL_SUBAGENT_MATCHER;
 delete process.env.QODER_SESSION_ID;
+delete process.env.KIMI_PLUGIN_ROOT;
+delete process.env.KIMI_CODE_HOME;
 
 const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-hooks-'));
 // Runs on normal exit and on assertion-throw exit; force makes it idempotent.
@@ -458,5 +460,48 @@ try {
   if (prevXdgRev === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = prevXdgRev;
   if (prevEnvModeRev === undefined) delete process.env.PONYTAIL_DEFAULT_MODE; else process.env.PONYTAIL_DEFAULT_MODE = prevEnvModeRev;
 }
+
+// Kimi Code tests
+const kimiHome = path.join(temp, 'kimi-home');
+const kimiState = path.join(kimiHome, '.kimi-code', '.ponytail-active');
+fs.mkdirSync(path.dirname(kimiState), { recursive: true });
+
+const kimiEnv = {
+  HOME: kimiHome,
+  USERPROFILE: kimiHome,
+  KIMI_PLUGIN_ROOT: path.join(temp, 'kimi-plugin'),
+  PONYTAIL_DEFAULT_MODE: 'ultra',
+};
+
+// 1. SessionStart activate hook
+result = run('ponytail-activate.js', kimiEnv);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.readFileSync(kimiState, 'utf8'), 'ultra');
+assert.match(result.stdout, /PONYTAIL MODE ACTIVE — level: ultra/);
+
+// 2. UserPromptSubmit tracker hook (prompt field)
+result = run(
+  'ponytail-mode-tracker.js',
+  kimiEnv,
+  JSON.stringify({ prompt: '@ponytail lite' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.readFileSync(kimiState, 'utf8'), 'lite');
+assert.match(result.stdout, /PONYTAIL MODE CHANGED — level: lite/);
+
+// 3. UserPromptSubmit tracker hook (user_prompt field)
+result = run(
+  'ponytail-mode-tracker.js',
+  kimiEnv,
+  JSON.stringify({ user_prompt: '@ponytail ultra' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.readFileSync(kimiState, 'utf8'), 'ultra');
+assert.match(result.stdout, /PONYTAIL MODE CHANGED — level: ultra/);
+
+// 4. SubagentStart hook
+result = run('ponytail-subagent.js', kimiEnv);
+assert.equal(result.status, 0, result.stderr);
+assert.match(result.stdout, /PONYTAIL MODE ACTIVE — level: ultra/);
 
 console.log('hook compatibility checks passed');

--- a/tests/kimi-plugin.test.js
+++ b/tests/kimi-plugin.test.js
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+// Smoke test for the Kimi Code plugin adapter: verify manifest, rules, and skills
+// wiring are present and consistent.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const SKILL_DIRS = [
+  'ponytail',
+  'ponytail-review',
+  'ponytail-audit',
+  'ponytail-debt',
+  'ponytail-gain',
+  'ponytail-help',
+];
+
+function readJSON(relPath) {
+  return JSON.parse(fs.readFileSync(path.join(root, relPath), 'utf8'));
+}
+
+test('kimi plugin manifest exists and has required fields', () => {
+  const manifest = readJSON('.kimi-plugin/plugin.json');
+  assert.equal(manifest.name, 'ponytail');
+  assert.ok(manifest.version, 'manifest must declare a version');
+  assert.ok(manifest.description, 'manifest must declare a description');
+  assert.ok(manifest.author, 'manifest must declare an author');
+  assert.equal(manifest.license, 'MIT');
+  assert.equal(manifest.skills, './skills/');
+  assert.ok(Array.isArray(manifest.hooks), 'hooks must be an array');
+  assert.equal(manifest.hooks.length, 3);
+  
+  // Verify registered hooks
+  const events = manifest.hooks.map(h => h.event);
+  assert.ok(events.includes('SessionStart'));
+  assert.ok(events.includes('SubagentStart'));
+  assert.ok(events.includes('UserPromptSubmit'));
+
+  const activateHook = manifest.hooks.find(h => h.event === 'SessionStart');
+  assert.equal(activateHook.command, 'node ./hooks/ponytail-activate.js');
+  assert.equal(activateHook.matcher, 'startup|resume|clear|compact');
+  assert.equal(activateHook.timeout, 5);
+
+  const subagentHook = manifest.hooks.find(h => h.event === 'SubagentStart');
+  assert.equal(subagentHook.command, 'node ./hooks/ponytail-subagent.js');
+  assert.equal(subagentHook.timeout, 5);
+
+  const trackerHook = manifest.hooks.find(h => h.event === 'UserPromptSubmit');
+  assert.equal(trackerHook.command, 'node ./hooks/ponytail-mode-tracker.js');
+  assert.equal(trackerHook.timeout, 5);
+});
+
+test('kimi manifest points at skills that actually ship', () => {
+  const manifest = readJSON('.kimi-plugin/plugin.json');
+  const skillsDir = path.join(root, manifest.skills);
+  assert.ok(fs.existsSync(skillsDir), 'skills/ directory must exist');
+
+  for (const skill of SKILL_DIRS) {
+    const skillFile = path.join(skillsDir, skill, 'SKILL.md');
+    assert.ok(
+      fs.existsSync(skillFile),
+      `missing skill: skills/${skill}/SKILL.md`,
+    );
+  }
+});
+
+test('kimi runtime environment detection works', () => {
+  const { isKimi } = require('../hooks/ponytail-runtime');
+  // isKimi is false in test process as KIMI_PLUGIN_ROOT / KIMI_CODE_HOME are unset
+  assert.equal(isKimi, false);
+});


### PR DESCRIPTION
This PR implements full support for Kimi Code hooks and plugin configuration, enabling Ponytail mode tracking, activation, and subagent instructions injection.

### Key Changes
- **Manifest**: Created `.kimi-plugin/plugin.json` mapping Kimi Code metadata, display properties, and lifecycle hooks (`SessionStart`, `SubagentStart`, `UserPromptSubmit`).
- **Runtime**: Modified `hooks/ponytail-runtime.js` to detect Kimi Code environment, resolve configuration directory to `~/.kimi-code`, and write raw output to `stdout`.
- **Statusline Nudge**: Modified `hooks/ponytail-activate.js` to skip statusline setup checks when running inside Kimi Code.
- **Mode Tracking**: Modified `hooks/ponytail-mode-tracker.js` to read either `prompt` or `user_prompt` (Kimi Code snake_case payload format) to track switches.
- **Consistency & Testing**:
  - Registered `.kimi-plugin/plugin.json` in version consistency checks (`check-versions.js`) and tests (`gemini-extension.test.js`).
  - Added dedicated `tests/kimi-plugin.test.js` smoke test.
  - Added new test coverage in `tests/hooks.test.js` simulating Kimi Code session activation, prompt parsing, and subagent hook runs.
- **Packaging & Docs**: Included `.kimi-plugin/` in npm files (`package.json`) and documented support in `docs/agent-portability.md`.

### Verification
All automated tests run and pass successfully:
```bash
npm test