### PR TITLE
test: skip csv correctness check when pandas is absent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ ponytail-*.gif
 
 # agentic benchmark workspaces (agent output, kept locally for inspection)
 benchmarks/agentic/runs/
+
+# kbcode knowledge base (local agent context, not repo content)
+kb/

--- a/tests/correctness.test.js
+++ b/tests/correctness.test.js
@@ -5,7 +5,17 @@
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
+const { execSync } = require('node:child_process');
 const correctness = require('../benchmarks/correctness');
+
+// CSV checks need pandas installed locally; skip the pandas-dependent test when
+// it's absent so `npm test` is green on a fresh clone without the optional dep.
+let hasPandas = false;
+try {
+  const probe = process.platform === 'win32' ? 'python -c "import pandas"' : 'python3 -c "import pandas"';
+  execSync(probe, { stdio: 'pipe' });
+  hasPandas = true;
+} catch (_) {}
 
 // Helper: wrap code in a fenced block and call the assertion with task vars.
 function check(task, lang, code) {
@@ -74,7 +84,7 @@ test('debounce: immediate-call implementation fails', () => {
 
 // --- CSV sum ---
 
-test('csv: correct pandas one-liner passes', () => {
+(hasPandas ? test : test.skip)('csv: correct pandas one-liner passes', () => {
   const result = check(
     "Write Python code that reads sales.csv and sums the 'amount' column.",
     'python',


### PR DESCRIPTION
Guard the csv correctness test so `npm test` is green on a fresh clone without the optional `pandas` dependency. The `csv: correct pandas one-liner passes` test shells out to pandas; when it's absent the suite reported 1 failure. Now it probes pandas at load and uses `test.skip` when missing (the non-pandas csv test still runs).

Also re-adds `kb/` to `.gitignore` (local agent KB context, not repo content).

Verified: `npm test` → 81 pass, 0 fail, 1 skipped (was 1 fail).