### PR TITLE
fix: strip brackets from Skill-invoked /ponytail args

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -23,7 +23,10 @@ function finish() {
     if (/^[/@$]ponytail/.test(prompt)) {
       const parts = prompt.split(/\s+/);
       const cmd = parts[0].replace(/^[@$]/, '/');
-      const arg = parts[1] || '';
+      // Claude Code's Skill invocation relays the arg wrapped in literal
+      // brackets ("ponytail:ponytail [lite]"), unlike a plain slash command.
+      // Strip them so 'lite'/'full'/'ultra'/'off' still match.
+      const arg = (parts[1] || '').replace(/^\[+|\]+$/g, '');
 
       let mode = null;
       let isReportOnly = false;

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -459,4 +459,26 @@ try {
   if (prevEnvModeRev === undefined) delete process.env.PONYTAIL_DEFAULT_MODE; else process.env.PONYTAIL_DEFAULT_MODE = prevEnvModeRev;
 }
 
+// Claude Code's Skill invocation relays the arg wrapped in literal brackets
+// ("ponytail:ponytail [lite]"), unlike a plain slash command. Before the fix,
+// the bracketed token never matched 'lite'/'full'/'ultra'/'off' and silently
+// fell back to the default mode instead of switching.
+const skillArgHome = path.join(temp, 'skill-arg-home');
+const skillArgEnv = { HOME: skillArgHome, USERPROFILE: skillArgHome };
+const skillArgFlag = path.join(skillArgHome, '.claude', '.ponytail-active');
+
+result = run(
+  'ponytail-mode-tracker.js',
+  skillArgEnv,
+  JSON.stringify({ prompt: '/ponytail:ponytail [lite]' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(
+  fs.readFileSync(skillArgFlag, 'utf8'),
+  'lite',
+  'bracket-wrapped Skill arg must switch mode, not silently fall back to default',
+);
+// Native Claude writes UserPromptSubmit output as raw stdout, not JSON (see writeHookOutput).
+assert.match(result.stdout, /PONYTAIL MODE CHANGED — level: lite/);
+
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
## Summary
- Claude Code's Skill invocation (as opposed to a plain slash command) relays the mode argument wrapped in literal brackets, e.g. the prompt text becomes `ponytail:ponytail [lite]` rather than `/ponytail lite`.
- `ponytail-mode-tracker.js` split the prompt on whitespace and compared the raw token directly against `'lite'`/`'full'`/`'ultra'`/`'off'`. The bracketed token (`"[lite]"`) never matched, so the `else` branch fired and silently fell back to `getDefaultMode()` — meaning `/ponytail lite` run as a Skill left the session on `full` with no error, no matter what mode was requested.
- Fix strips leading/trailing brackets from the extracted arg before comparing.

Confirmed by reproducing directly: piping `{"prompt": "/ponytail:ponytail [lite]"}` into the hook produced `PONYTAIL MODE CHANGED — level: full` before the fix, `level: lite` after.

## Test plan
- [x] Added a regression test to `tests/hooks.test.js` asserting a bracket-wrapped arg switches mode correctly.
- [x] Verified the new test fails on the pre-fix hook (via `git stash`) and passes after.
- [x] `node --test tests/hooks.test.js tests/hooks-windows.test.js` — all 7 pass.