### PR TITLE
fix(hooks): don't emit a second JSON object on Qoder report-only /pon…

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -56,11 +56,15 @@ function finish() {
       }
 
       if (isReportOnly) {
-        writeHookOutput(
-          'UserPromptSubmit',
-          mode,
-          'PONYTAIL MODE ACTIVE — level: ' + mode,
-        );
+        // On Qoder the ruleset block below already reports; a second write
+        // here would put two JSON objects on stdout.
+        if (!isQoder) {
+          writeHookOutput(
+            'UserPromptSubmit',
+            mode,
+            'PONYTAIL MODE ACTIVE — level: ' + mode,
+          );
+        }
       } else if (mode && mode !== 'off') {
         setMode(mode);
         modeSwitched = true;

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -354,6 +354,23 @@ assert.match(
   /PONYTAIL MODE ACTIVE — level: full/,
 );
 
+// Bare `/ponytail` on Qoder is report-only: there's no SessionStart, so the
+// double-duty block below emits the full ruleset as the report. A second
+// confirmation here would push two JSON objects to stdout. The point is that
+// the user still gets the ruleset back as one object.
+result = run(
+  'ponytail-mode-tracker.js',
+  qoderEnv,
+  JSON.stringify({ prompt: '/ponytail' }),
+);
+assert.equal(result.status, 0, result.stderr);
+output = JSON.parse(result.stdout);
+assert.equal(output.hookSpecificOutput.hookEventName, 'UserPromptSubmit');
+assert.match(
+  output.hookSpecificOutput.additionalContext,
+  /PONYTAIL MODE ACTIVE — level: full/,
+);
+
 // /ponytail ultra: mode tracker updates flag and injects ultra ruleset.
 result = run(
   'ponytail-mode-tracker.js',


### PR DESCRIPTION
…ytail

On Qoder there's no SessionStart, so UserPromptSubmit does double duty: it reports the current mode for a bare `/ponytail`, and it also emits the full ruleset. Both paths wrote a JSON object to stdout, so the hook output was two concatenated objects — unparseable, and the ruleset the user actually wanted never made it through.

Skip the report-only confirmation on Qoder; the ruleset block already covers it. Other hosts are untouched. Added a regression test asserting a single parseable JSON object for that case.