### PR TITLE
feat: add exports entrypoint for openaxe plugin loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@dietrichgebert/ponytail",
   "version": "4.8.4",
   "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
-  "keywords": ["opencode-plugin", "opencode", "ponytail", "pi-package", "pi", "skills", "qoder"],
+  "keywords": ["opencode-plugin", "opencode", "ponytail", "pi-package", "pi", "skills", "qoder", "openaxe"],
   "license": "MIT",
   "author": {
     "name": "Dietrich Gebert",
@@ -19,7 +19,8 @@
   "main": "./.opencode/plugins/ponytail.mjs",
   "exports": {
     ".": "./.opencode/plugins/ponytail.mjs",
-    "./plugin": "./.opencode/plugins/ponytail.mjs"
+    "./plugin": "./.opencode/plugins/ponytail.mjs",
+    "./server": "./.opencode/plugins/ponytail.mjs"
   },
   "files": [
     "AGENTS.md",


### PR DESCRIPTION
Adds `exports` field to `package.json` so openaxe/opencode plugin loader can discover the server entrypoint at `.opencode/plugins/ponytail.mjs`.

Previously the plugin was listed as a bundled default (`DietrichGebert/ponytail`) but silently failed to load because the package.json had no `exports["./server"]`, `main`, or `.opencode/package.json` fallback.