### PR TITLE
fix: read MCP server version from package.json instead of hardcoding 0.1.0

### DIFF
--- a/ponytail-mcp/index.js
+++ b/ponytail-mcp/index.js
@@ -3,13 +3,15 @@
 // prompt (user-invoked) and a tool (for hosts that pull context via tools).
 // It does NOT replace the always-on adapters; it's the clean option for hosts
 // whose only injection point is the prompt menu (see #70).
+import { readFileSync } from "node:fs";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { z } from "zod";
 
 import { MODES, buildInstructions, resolveMode } from "./instructions.js";
 
-const server = new McpServer({ name: "ponytail", version: "0.1.0" });
+const { version } = JSON.parse(readFileSync(new URL("./package.json", import.meta.url), "utf8"));
+const server = new McpServer({ name: "ponytail", version });
 
 const modeArg = z
   .enum(MODES)


### PR DESCRIPTION
Fixes #535

The MCP server version was hardcoded to \