### PR TITLE
fix(hooks): add matcher to UserPromptSubmit to skip no-op invocations

### DIFF
--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -29,6 +29,7 @@
     ],
     "UserPromptSubmit": [
       {
+        "matcher": "ponytail|normal mode",
         "hooks": [
           {
             "type": "command",


### PR DESCRIPTION
Without a matcher the hook fires on every prompt, spawning a PowerShell process + Node.js startup on Windows even when the prompt has nothing to do with ponytail. On slower machines or under antivirus load this easily exceeds the 5 s timeout and the hook output is silently discarded with:

```
  UserPromptSubmit hook timed out after 5s — output discarded.
```

The mode-tracker only acts on prompts containing "ponytail" (/ponytail, @ponytail, $ponytail, "stop ponytail") or the exact deactivation phrase "normal mode". Adding that as the matcher means the hook is skipped entirely for all other prompts — zero process overhead on the fast path