### PR TITLE
feat: add native Oh My Pi plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Copilot CLI namespaces plugin commands by plugin name. For example:
 /ponytail:ponytail-review
 ```
 
+### Oh My Pi
+
+```bash
+omp plugin install git:github.com/fogrye/ponytail
+```
+
+OMP loads the native package manifest, the bundled skills, and the `/ponytail` command family.
+
 ### Pi agent harness
 
 ```

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
   "scripts": {
     "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix ponytail-mcp"
   },
+  "omp": {
+    "name": "Ponytail",
+    "description": "Lazy senior dev mode with persistent modes and bundled skills.",
+    "extensions": ["./pi-extension/index.js"]
+  },
   "pi": {
     "extensions": ["./pi-extension/index.js"],
     "skills": ["./skills"]

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -61,6 +61,7 @@ export function parsePonytailCommand(text, defaultMode = DEFAULT_MODE) {
 export { writeDefaultMode };
 
 export default function ponytailExtension(pi) {
+  pi.setLabel?.("Ponytail");
   let currentMode = DEFAULT_MODE;
   let configuredDefaultMode = getDefaultMode();
   let hideStatus = getHideStatus();

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -11,6 +11,7 @@ function createPiHarness() {
   const commands = new Map();
   const appendedEntries = [];
   const sentUserMessages = [];
+  const labels = [];
 
   const pi = {
     on(eventName, handler) {
@@ -25,10 +26,13 @@ function createPiHarness() {
     sendUserMessage(text, options) {
       sentUserMessages.push({ text, options });
     },
+    setLabel(label) {
+      labels.push(label);
+    },
   };
 
   ponytailExtension(pi);
-  return { events, commands, appendedEntries, sentUserMessages };
+  return { events, commands, labels, appendedEntries, sentUserMessages };
 }
 
 function createCommandContext(overrides = {}) {
@@ -59,8 +63,9 @@ function withTempConfig(fn) {
 }
 
 test("extension registers Ponytail commands", () => {
-  const { commands } = createPiHarness();
+  const { commands, labels } = createPiHarness();
 
+  assert.deepEqual(labels, ["Ponytail"]);
   assert.deepEqual([...commands.keys()].sort(), ["ponytail", "ponytail-audit", "ponytail-debt", "ponytail-gain", "ponytail-help", "ponytail-review"]);
 });
 


### PR DESCRIPTION
## Summary
- add the native `package.json#omp` extension manifest while retaining the legacy Pi manifest
- label the runtime extension in OMP and document installation from this fork
- cover label registration in the extension test harness

## Verification
- `npm test --prefix pi-extension`
- linked the package in an isolated OMP data root; `omp plugin list --json` reported the native manifest and `omp plugin doctor --json` reported the plugin healthy
- hub-launched `omp --mode json --no-session --print /ponytail ultra` exited 0 with no agent turn, confirming the local slash command was loaded and handled

`npm test` is blocked only by the pre-existing benchmark test's undeclared `pandas` dependency (`ModuleNotFoundError`).