### PR TITLE
feat: add native Oh My Pi plugin support

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,6 +155,14 @@ Copilot CLI namespaces plugin commands by plugin name. For example:
 /ponytail:ponytail-review
 ```
 
+### Oh My Pi
+
+```bash
+omp plugin install git:github.com/fogrye/ponytail
+```
+
+OMP loads the native package manifest, the bundled skills, and the `/ponytail` command family.
+
 ### Pi agent harness
 
 ```

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Copilot CLI namespaces plugin commands by plugin name. For example:
 ### Oh My Pi
 
 ```bash
-omp plugin install git:github.com/fogrye/ponytail
+omp plugin install github:DietrichGebert/ponytail
 ```
 
 OMP loads the native package manifest, the bundled skills, and the `/ponytail` command family.

--- a/omp-extension/index.js
+++ b/omp-extension/index.js
@@ -2,5 +2,5 @@ import ponytailExtension from "../pi-extension/index.js";
 
 export default function ompPonytailExtension(pi) {
   pi.setLabel("Ponytail");
-  ponytailExtension(pi);
+  ponytailExtension(pi, { hideStatus: true });
 }

--- a/omp-extension/index.js
+++ b/omp-extension/index.js
@@ -1,0 +1,6 @@
+import ponytailExtension from "../pi-extension/index.js";
+
+export default function ompPonytailExtension(pi) {
+  pi.setLabel("Ponytail");
+  ponytailExtension(pi);
+}

--- a/omp-extension/package.json
+++ b/omp-extension/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ponytail-omp-extension-dev",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test ./test/*.test.js"
+  }
+}

--- a/omp-extension/test/extension.test.js
+++ b/omp-extension/test/extension.test.js
@@ -22,3 +22,31 @@ test("OMP entrypoint labels the extension before loading Ponytail", () => {
   assert.deepEqual(labels, ["Ponytail"]);
   assert.ok(commands.has("ponytail"));
 });
+
+test("OMP entrypoint does not write Ponytail status to the footer", async () => {
+  const events = new Map();
+  const statusWrites = [];
+  const ctx = {
+    sessionManager: { getEntries: () => [] },
+    ui: {
+      notify() {},
+      setStatus: (key, text) => statusWrites.push({ key, text }),
+      theme: { fg: (_color, text) => text },
+    },
+  };
+
+  ompPonytailExtension({
+    on(event, handler) {
+      events.set(event, handler);
+    },
+    registerCommand() {},
+    appendEntry() {},
+    sendUserMessage() {},
+    setLabel() {},
+  });
+
+  await events.get("session_start")({}, ctx);
+  await events.get("agent_start")({}, ctx);
+
+  assert.deepEqual(statusWrites, []);
+});

--- a/omp-extension/test/extension.test.js
+++ b/omp-extension/test/extension.test.js
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import ompPonytailExtension from "../index.js";
+
+test("OMP entrypoint labels the extension before loading Ponytail", () => {
+  const commands = new Map();
+  const labels = [];
+
+  ompPonytailExtension({
+    on() {},
+    registerCommand(name, options) {
+      commands.set(name, options);
+    },
+    appendEntry() {},
+    sendUserMessage() {},
+    setLabel(label) {
+      labels.push(label);
+    },
+  });
+
+  assert.deepEqual(labels, ["Ponytail"]);
+  assert.ok(commands.has("ponytail"));
+});

--- a/package.json
+++ b/package.json
@@ -29,17 +29,18 @@
     ".qoder/",
     ".qoder-plugin/",
     "pi-extension/",
+    "omp-extension/",
     "scripts/uninstall.js",
     "assets/",
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix ponytail-mcp"
+    "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix omp-extension && npm test --prefix ponytail-mcp"
   },
   "omp": {
     "name": "Ponytail",
     "description": "Lazy senior dev mode with persistent modes and bundled skills.",
-    "extensions": ["./pi-extension/index.js"]
+    "extensions": ["./omp-extension/index.js"]
   },
   "pi": {
     "extensions": ["./pi-extension/index.js"],

--- a/package.json
+++ b/package.json
@@ -36,6 +36,11 @@
   "scripts": {
     "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix ponytail-mcp"
   },
+  "omp": {
+    "name": "Ponytail",
+    "description": "Lazy senior dev mode with persistent modes and bundled skills.",
+    "extensions": ["./pi-extension/index.js"]
+  },
   "pi": {
     "extensions": ["./pi-extension/index.js"],
     "skills": ["./skills"]

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -61,7 +61,6 @@ export function parsePonytailCommand(text, defaultMode = DEFAULT_MODE) {
 export { writeDefaultMode };
 
 export default function ponytailExtension(pi) {
-  pi.setLabel?.("Ponytail");
   let currentMode = DEFAULT_MODE;
   let configuredDefaultMode = getDefaultMode();
   let hideStatus = getHideStatus();

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -61,6 +61,7 @@ export function parsePonytailCommand(text, defaultMode = DEFAULT_MODE) {
 export { writeDefaultMode };
 
 export default function ponytailExtension(pi) {
+  pi.setLabel?.("Ponytail");
   let currentMode = DEFAULT_MODE;
   let configuredDefaultMode = getDefaultMode();
   let hideStatus = getHideStatus();

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -60,10 +60,10 @@ export function parsePonytailCommand(text, defaultMode = DEFAULT_MODE) {
 
 export { writeDefaultMode };
 
-export default function ponytailExtension(pi) {
+export default function ponytailExtension(pi, { hideStatus: forceHideStatus = false } = {}) {
   let currentMode = DEFAULT_MODE;
   let configuredDefaultMode = getDefaultMode();
-  let hideStatus = getHideStatus();
+  let hideStatus = forceHideStatus || getHideStatus();
   let isActive = false;
   let lastCtx = null;
 
@@ -183,7 +183,7 @@ export default function ponytailExtension(pi) {
   pi.on("session_start", async (_event, ctx) => {
     const entries = ctx?.sessionManager?.getBranch?.() || ctx?.sessionManager?.getEntries?.() || [];
     configuredDefaultMode = getDefaultMode();
-    hideStatus = getHideStatus();
+    hideStatus = forceHideStatus || getHideStatus();
     currentMode = resolveSessionMode(entries, configuredDefaultMode);
     syncStatus(ctx);
     if (!getQuietStartup()) {

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -11,7 +11,6 @@ function createPiHarness() {
   const commands = new Map();
   const appendedEntries = [];
   const sentUserMessages = [];
-  const labels = [];
 
   const pi = {
     on(eventName, handler) {
@@ -26,13 +25,13 @@ function createPiHarness() {
     sendUserMessage(text, options) {
       sentUserMessages.push({ text, options });
     },
-    setLabel(label) {
-      labels.push(label);
+    setLabel() {
+      throw new Error("Pi runtime actions are unavailable during extension loading");
     },
   };
 
   ponytailExtension(pi);
-  return { events, commands, labels, appendedEntries, sentUserMessages };
+  return { events, commands, appendedEntries, sentUserMessages };
 }
 
 function createCommandContext(overrides = {}) {
@@ -62,10 +61,13 @@ function withTempConfig(fn) {
     });
 }
 
-test("extension registers Ponytail commands", () => {
-  const { commands, labels } = createPiHarness();
+test("Pi entrypoint does not invoke runtime actions during load", () => {
+  assert.doesNotThrow(() => createPiHarness());
+});
 
-  assert.deepEqual(labels, ["Ponytail"]);
+test("extension registers Ponytail commands", () => {
+  const { commands } = createPiHarness();
+
   assert.deepEqual([...commands.keys()].sort(), ["ponytail", "ponytail-audit", "ponytail-debt", "ponytail-gain", "ponytail-help", "ponytail-review"]);
 });
 

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -11,6 +11,7 @@ function createPiHarness() {
   const commands = new Map();
   const appendedEntries = [];
   const sentUserMessages = [];
+  const labels = [];
 
   const pi = {
     on(eventName, handler) {
@@ -25,10 +26,13 @@ function createPiHarness() {
     sendUserMessage(text, options) {
       sentUserMessages.push({ text, options });
     },
+    setLabel(label) {
+      labels.push(label);
+    },
   };
 
   ponytailExtension(pi);
-  return { events, commands, appendedEntries, sentUserMessages };
+  return { events, commands, labels, appendedEntries, sentUserMessages };
 }
 
 function createCommandContext(overrides = {}) {
@@ -59,8 +63,9 @@ function withTempConfig(fn) {
 }
 
 test("extension registers Ponytail commands", () => {
-  const { commands } = createPiHarness();
+  const { commands, labels } = createPiHarness();
 
+  assert.deepEqual(labels, ["Ponytail"]);
   assert.deepEqual([...commands.keys()].sort(), ["ponytail", "ponytail-audit", "ponytail-debt", "ponytail-gain", "ponytail-help", "ponytail-review"]);
 });
 


### PR DESCRIPTION
## Summary
- add an OMP-native package manifest and entrypoint
- keep the shared Pi entrypoint free of OMP-only runtime actions
- retain Pi support and cover both loaders with regression tests

## Verification
- `npm test --prefix pi-extension` — 24 passing
- `npm test --prefix omp-extension` — 1 passing
- installed `github:fogrye/ponytail#fix/oh-my-pi-plugin-entrypoint` through OMP in an isolated data root; the native manifest resolves to `./omp-extension/index.js`
- hub-launched `omp --mode json --no-session --print /ponytail ultra` exited 0 without an agent turn

`npm test` still stops at its pre-existing benchmark test because this environment lacks its undeclared `pandas` dependency.