### PR TITLE
test(opencode): guard against re-exporting parseCommandFile (#631)

### DIFF
--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -30,6 +30,18 @@ test.before(async () => {
   parseCommandFile = require(path.join(__dirname, '..', '.opencode', 'plugins', 'ponytail-frontmatter.cjs')).parseCommandFile;
 });
 
+test('plugin module exposes only the default export (regression guard for #631, #301)', async () => {
+  const url = pathToFileURL(path.join(__dirname, '..', '.opencode', 'plugins', 'ponytail.mjs'));
+  const mod = await import(url);
+  const namedExports = Object.keys(mod).filter((k) => k !== 'default');
+  assert.deepEqual(
+    namedExports,
+    [],
+    'ponytail.mjs must not have named exports — OpenCode\'s legacy getLegacyPlugins() ' +
+    'loader calls every exported function as a plugin factory'
+  );
+});
+
 function transform(hooks) {
   const output = { system: [] };
   return hooks['experimental.chat.system.transform']({ model: {} }, output).then(() => output.system);


### PR DESCRIPTION
Relates to #631.

The underlying bug (OpenCode's legacy getLegacyPlugins() loader calling every named export as a plugin factory) was already fixed on main in #301, which moved parseCommandFile into its own .cjs sibling. That fix isn't in any tagged release yet though — checked v4.8.0 through v4.8.4, none include commit 511ddd4.

This adds a regression test that asserts ponytail.mjs has no named exports besides default, so this can't silently regress. Verified it fails against the pre-#301 shape and passes on current main.