### PR TITLE
fix: drain Codex SessionStart stdin

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -94,3 +94,6 @@ try {
 } catch (e) {
   // Silent fail — stdout closed/EPIPE at hook exit must not surface as a hook failure
 }
+
+process.stdin.resume();
+setTimeout(() => process.exit(0), 1000).unref();

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -8,6 +8,7 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { spawn } = require('child_process');
 
@@ -104,6 +105,32 @@ test('ponytail-mode-tracker self-exits when stdin never closes (no freeze)', asy
   });
 
   assert.equal(code, 0, 'hook must exit cleanly when stdin never closes');
+});
+
+test('ponytail-activate drains large Codex SessionStart stdin without EPIPE', async () => {
+  const hook = path.join(root, 'hooks', 'ponytail-activate.js');
+  const pluginData = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-stdin-'));
+  const child = spawn(process.execPath, [hook], {
+    env: {
+      ...process.env,
+      PLUGIN_DATA: pluginData,
+      PONYTAIL_DEFAULT_MODE: 'full',
+    },
+    stdio: ['pipe', 'ignore', 'ignore'],
+  });
+  const exitCode = new Promise((resolve) => child.once('close', resolve));
+  await new Promise((resolve) => setTimeout(resolve, 50));
+  const writeError = await new Promise((resolve) => {
+    child.stdin.once('error', resolve);
+    child.stdin.end(
+      JSON.stringify({ transcript: 'x'.repeat(2_000_000) }),
+      (error) => resolve(error),
+    );
+  });
+
+  assert.equal(writeError, null);
+  assert.equal(await exitCode, 0);
+  fs.rmSync(pluginData, { recursive: true, force: true });
 });
 
 test('Claude and Codex manifests point at the shared host-specific hook config', () => {


### PR DESCRIPTION
## Summary

- keep the SessionStart hook alive while Codex finishes writing stdin
- discard unused input instead of closing the pipe early
- retain the existing 1-second fallback so Windows wrappers cannot freeze the session

## Why

Codex can write a large SessionStart payload after this hook has already emitted its output. Exiting immediately closes the read end and makes Codex report `failed to write hook stdin: Broken pipe (os error 32)`.

## Tests

- `node --test tests/hooks.test.js tests/hooks-windows.test.js` (8/8 passed)
- `node --check hooks/ponytail-activate.js`
- full root suite: 83/84 passed; the unrelated pandas correctness benchmark exceeded its existing 1-second subprocess timeout