### PR TITLE
fix: resolve silent deactivation, probe timeout, and stdin swallowing

### DIFF
--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -52,7 +52,7 @@ let pythonCmd;
 function python() {
   if (pythonCmd) return pythonCmd;
   for (const cmd of ['python3', 'python']) {
-    if (exec(`${cmd} -c "import sys"`).ok) {
+    if (exec(`${cmd} -c "import sys"`, { timeout: 5000 }).ok) {
       pythonCmd = cmd;
       return pythonCmd;
     }

--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -13,6 +13,7 @@ function finish() {
   if (done) return;
   done = true;
   try {
+    if (!input.trim()) return;
     // Strip UTF-8 BOM some shells prepend when piping (breaks JSON.parse)
     const data = JSON.parse(input.replace(/^\uFEFF/, ''));
     const prompt = (data.prompt || '').trim().toLowerCase();

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -171,12 +171,12 @@ export default function ponytailExtension(pi) {
     handler: (_args, ctx) => sendAlias("/skill:ponytail-help", "", ctx),
   });
 
-  pi.on("input", async (event) => {
+  pi.on("input", async (event, ctx) => {
     if (event?.source === "extension") return;
 
     const text = String(event?.text || "");
     if (currentMode !== "off" && isDeactivationCommand(text)) {
-      setMode("off");
+      setMode("off", ctx);
     }
   });
 

--- a/tests/correctness.test.js
+++ b/tests/correctness.test.js
@@ -120,13 +120,11 @@ print(351)`,
     assert.equal(timedOut.pass, false);
     assert.match(timedOut.reason, /ETIMEDOUT|timed out/i);
 
-    process.env.PONYTAIL_CORRECTNESS_TIMEOUT_MS = '1000';
+    process.env.PONYTAIL_CORRECTNESS_TIMEOUT_MS = '5000';
     const completed = check(
       "Write Python code that reads sales.csv and sums the 'amount' column.",
       'python',
-      `import time
-time.sleep(0.05)
-print(351)`,
+      `import time\ntime.sleep(0.05)\nprint(351)`,
     );
     assert.equal(completed.pass, true);
     assert.equal(completed.score, 1);


### PR DESCRIPTION
This PR cleans up a few minor structural leaks in the background

1. **Silent Deactivation (`pi-extension/index.js`)**: Fixed a bug where typing "stop ponytail" or "normal mode" deactivated the ruleset silently. The input event listener was dropping the `ctx` object, so `setMode("off")` couldn't trigger the UI notification. Wired `ctx` through so the user actually gets a visual confirmation that it turned off.

2. **Python Probe Timeout Trap (`benchmarks/correctness.js`)**: The environment probe for the Python command was lazily evaluating its timeout. If a test temporarily dropped the timeout to 1ms *before* the probe fired, both the `python3` and `python` checks would fail. It would then wrongly fall back to `python3`, breaking tests on Windows machines where only `python.exe` exists. Hardcoded a 5000ms timeout specifically for the initialization probe so it's immune to test modifications. Also bumped the correctness test timeout from 1s to 5s to stop flakiness on slower Windows machines during pandas startup.

3. **Stdin JSON Parse Swallow (`hooks/ponytail-mode-tracker.js`)**: Added a quick guard rail to prevent `JSON.parse('')` from throwing a SyntaxError if stdin receives completely empty input (like from a pipe hiccup or PowerShell swallowing the stream).