### PR TITLE
fix: the script passes user-controlled cli arguments... in...

### DIFF
--- a/scripts/publish-openclaw-skills.js
+++ b/scripts/publish-openclaw-skills.js
@@ -59,9 +59,8 @@ for (const slug of slugs) {
     '--tags', 'latest',
     ...passthrough,
   ];
-  const cmdline = args.map(quote).join(' ');
-  console.log(`\n$ ${cmdline}`);
-  const res = spawnSync(cmdline, { stdio: 'inherit', cwd: root, shell: true });
+  console.log(`\n$ ${args.map(quote).join(' ')}`);
+  const res = spawnSync(args[0], args.slice(1), { stdio: 'inherit', cwd: root });
   if (res.status !== 0) {
     console.error(
       `\nPublish failed for "${slug}" (exit ${res.status}). ` +


### PR DESCRIPTION
## Summary
Fix high severity security issue in `scripts/publish-openclaw-skills.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `scripts/publish-openclaw-skills.js:49` |
| **Assessment** | Likely exploitable |

**Description**: The script passes user-controlled CLI arguments directly into a shell command via spawnSync with shell: true. The quote() function only wraps strings containing non-word characters in double quotes, which is insufficient to prevent shell injection on both POSIX and Windows systems.

## Evidence

**Exploitation scenario**: An attacker who can execute this script passes crafted arguments like: node scripts/publish-openclaw-skills.js '--version $(whoami > /tmp/pwned)' or on Windows: node.

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `scripts/publish-openclaw-skills.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
