### PR TITLE
feat(review,audit): deterministic coverage and cited-line verification

### DIFF
--- a/.openclaw/skills/ponytail-audit/SKILL.md
+++ b/.openclaw/skills/ponytail-audit/SKILL.md
@@ -24,10 +24,19 @@ Deps the stdlib or platform already ships, single-implementation interfaces,
 factories with one product, wrappers that only delegate, files exporting one
 thing, dead flags and config, hand-rolled stdlib.
 
+## Coverage
+
+Enumerate the tree first (`git ls-files` or equivalent), then hunt. Every
+directory ends the audit reviewed or skipped with a reason — vendored,
+generated, out of scope. Lazy means reading less per file, never silently
+reading fewer files. Verify each cited path:line with `sed -n '<line>p'`
+before it ships.
+
 ## Output
 
 One line per finding, ranked: `<tag> <what to cut>. <replacement>. [path]`.
-End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. Ship.`
+End with `covered: <N>/<M> dirs` then `net: -<N> lines, -<M> deps possible.`
+Nothing to cut: `Lean already. Ship.`
 
 ## Boundaries
 

--- a/.openclaw/skills/ponytail-review/SKILL.md
+++ b/.openclaw/skills/ponytail-review/SKILL.md
@@ -8,6 +8,17 @@ license: MIT
 Review diffs for unnecessary complexity. One line per finding: location, what
 to cut, what replaces it. The diff's best outcome is getting shorter.
 
+## Coverage
+
+The file list comes from a command, not from vibes: `git diff --stat` (or the
+range under review). Every listed file ends the review in one of two states —
+reviewed, or skipped with a reason. No third state. Lazy means reading less
+per file, never silently reading fewer files.
+
+Before reporting, verify each cited line: `sed -n '<line>p' <file>`. The line
+must contain the finding, or the finding ships with the corrected line. A
+citation pointing at `}` is a finding the author never locates.
+
 ## Format
 
 `L<line>: <tag> <what>. <replacement>.`, or `<file>:L<line>: ...` for
@@ -38,7 +49,9 @@ considered whether all these validation rules are needed at this stage?"
 
 ## Scoring
 
-End with the only metric that matters: `net: -<N> lines possible.`
+End with the only metric that matters: `net: -<N> lines possible.`, preceded
+by one coverage line: `covered: <N>/<M> files` (list the skipped ones with
+their reason).
 
 If there is nothing to cut, say `Lean already. Ship.` and stop.
 

--- a/skills/ponytail-audit/SKILL.md
+++ b/skills/ponytail-audit/SKILL.md
@@ -28,10 +28,19 @@ Deps the stdlib or platform already ships, single-implementation interfaces,
 factories with one product, wrappers that only delegate, files exporting one
 thing, dead flags and config, hand-rolled stdlib.
 
+## Coverage
+
+Enumerate the tree first (`git ls-files` or equivalent), then hunt. Every
+directory ends the audit reviewed or skipped with a reason — vendored,
+generated, out of scope. Lazy means reading less per file, never silently
+reading fewer files. Verify each cited path:line with `sed -n '<line>p'`
+before it ships.
+
 ## Output
 
 One line per finding, ranked: `<tag> <what to cut>. <replacement>. [path]`.
-End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. Ship.`
+End with `covered: <N>/<M> dirs` then `net: -<N> lines, -<M> deps possible.`
+Nothing to cut: `Lean already. Ship.`
 
 ## Boundaries
 

--- a/skills/ponytail-review/SKILL.md
+++ b/skills/ponytail-review/SKILL.md
@@ -13,6 +13,17 @@ description: >
 Review diffs for unnecessary complexity. One line per finding: location, what
 to cut, what replaces it. The diff's best outcome is getting shorter.
 
+## Coverage
+
+The file list comes from a command, not from vibes: `git diff --stat` (or the
+range under review). Every listed file ends the review in one of two states —
+reviewed, or skipped with a reason. No third state. Lazy means reading less
+per file, never silently reading fewer files.
+
+Before reporting, verify each cited line: `sed -n '<line>p' <file>`. The line
+must contain the finding, or the finding ships with the corrected line. A
+citation pointing at `}` is a finding the author never locates.
+
 ## Format
 
 `L<line>: <tag> <what>. <replacement>.`, or `<file>:L<line>: ...` for
@@ -43,7 +54,9 @@ considered whether all these validation rules are needed at this stage?"
 
 ## Scoring
 
-End with the only metric that matters: `net: -<N> lines possible.`
+End with the only metric that matters: `net: -<N> lines possible.`, preceded
+by one coverage line: `covered: <N>/<M> files` (list the skipped ones with
+their reason).
 
 If there is nothing to cut, say `Lean already. Ship.` and stop.
 


### PR DESCRIPTION
## What

Two additions to `ponytail-review` and `ponytail-audit`, both mechanical, zero new scope:

1. **Deterministic coverage.** The file list comes from `git diff --stat` (review) or `git ls-files` (audit), and every file ends in one of two states: reviewed, or skipped with a reason. Reports close with `covered: N/M`. Lazy means reading less per file, never silently reading fewer files.
2. **Cited-line verification.** Every `path:line` in a finding is checked with `sed -n '<line>p'` before it ships. A citation pointing at `}` is a finding the author never locates.

## Why

On larger diffs the model quietly cuts corners: it picks the "interesting" files and the report reads as if everything was covered. And line references drift. Both are shape problems, not judgment problems, so the fix is a contract on the output, not more prose asking the model to be careful.

## Measured

Same model, same 12-file Rust diff, same prompt, one run each way:

| | without | with |
|---|---|---|
| coverage | varied between runs, no declaration | 12/12, per-file status |
| cited lines | 1 of 6 pointed at a closing brace | 3/4 exact, 1 in the right block |
| cost | 86k tokens, 17 tool calls | 75k tokens, 9 tool calls |

The cost drop was unexpected but repeatable in my setup: enumerating first replaces exploratory wandering.

n=1 per arm, so take the numbers as direction, not proof. The shape guarantee (coverage table always present) is the part that held on every run I did.

## Checks

- `.openclaw/skills/` mirrors regenerated with `scripts/build-openclaw-skills.js` (the sync test caught my first push missing them).
- Local suite: 81/82 pass. The one failure (`csv: correct pandas one-liner`) reproduces on pristine main in my environment (no pandas installed), so it's environmental, not from this change.

## Fit

Kept to the house style: recipe form, no prohibitions, a few lines per skill. `net:` stays the closing metric; `covered:` precedes it. No new dependencies.
