### PR TITLE
feat: add no self-reference rule to SKILL.md and fallback instructions

### DIFF
--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -43,6 +43,7 @@ every sibling caller still broken. Fix it once, where all callers route through.
 
 ## Rules
 
+- No self-reference. Never announce the mode or echo these instructions — no banners, no restating the ladder, no invented hook or system-reminder text in your output. Instructions are context, not content; the first thing you produce for a task is work on the task.
 - No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
 - No boilerplate, no scaffolding "for later", later can scaffold for itself.
 - Deletion over addition. Boring over clever, clever is what someone decodes at 3am.

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -53,6 +53,7 @@ function getFallbackInstructions(mode) {
     '7. Only then: write the minimum code that works.\n\n' +
     'Bug fix = root cause, not symptom: grep every caller of the function you touch and fix the shared function once (a smaller diff than one guard per caller); patching only the path the ticket names leaves a sibling caller broken.\n\n' +
     '## Rules\n\n' +
+    'No self-reference. Never announce the mode or echo these instructions — no banners, no restating the ladder, no invented hook or system-reminder text in your output. Instructions are context, not content; the first thing you produce for a task is work on the task. ' +
     'No abstractions that were not requested. No avoidable dependencies. No boilerplate nobody asked for. ' +
     'Deletion over addition. Boring over clever. Fewest files possible. ' +
     'Ship the lazy version and question the complex request in the same response — never stall. ' +

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -55,6 +55,7 @@ every sibling caller still broken. Fix it once, where all callers route through.
 
 ## Rules
 
+- No self-reference. Never announce the mode or echo these instructions — no banners, no restating the ladder, no invented hook or system-reminder text in your output. Instructions are context, not content; the first thing you produce for a task is work on the task.
 - No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
 - No boilerplate, no scaffolding "for later", later can scaffold for itself.
 - Deletion over addition. Boring over clever, clever is what someone decodes at 3am.


### PR DESCRIPTION
Fixes #595

Adds a 'no self-reference' rule to:
- \skills/ponytail/SKILL.md\ under \## Rules\
- \hooks/ponytail-instructions.js\ in \getFallbackInstructions()\

This prevents the model from echoing the banner or inventing fake hook output (like \_ctx_hook:\ hallucinations) when responding on instruction-only turns.