### PR TITLE
feat: add PONYTAIL_BADGE env var to hide pi-extension status badge

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -65,6 +65,13 @@ export default function ponytailExtension(pi) {
     const c = ctx || lastCtx;
     if (!c?.ui?.setStatus || !c.ui.theme?.fg) return;
     const theme = c.ui.theme;
+
+    // Env opt-out: PONYTAIL_BADGE=off hides the status badge without disabling the mode
+    if (currentMode !== "off" && process.env.PONYTAIL_BADGE === "off") {
+      c.ui.setStatus("ponytail", "");
+      return;
+    }
+
     if (currentMode === "off") {
       c.ui.setStatus("ponytail", "");
       return;


### PR DESCRIPTION
Fixes #618

Adds \PONYTAIL_BADGE=off\ environment variable opt-out to \syncStatus()\ in \pi-extension/index.js\. When set, the status badge is suppressed while the mode stays active.

Usage:
\\\
PONYTAIL_BADGE=off
\\\

This follows the same pattern as \PONYTAIL_DEFAULT_MODE\ — env var overrides runtime behavior without config file changes.