### PR TITLE
fix: detect Copilot via CLAUDE_PLUGIN_ROOT env var in addition to COPILOT_PLUGIN_DATA

### DIFF
--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -3,7 +3,7 @@ const path = require('path');
 const { getClaudeDir } = require('./ponytail-config');
 
 const STATE_FILE = '.ponytail-active';
-const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA);
+const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA) || Boolean(process.env.CLAUDE_PLUGIN_ROOT);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 
 let stateDir = getClaudeDir();


### PR DESCRIPTION
Fixes #528

Some VS Code Copilot environments set \CLAUDE_PLUGIN_ROOT\ but not \COPILOT_PLUGIN_DATA\, causing \isCopilot\ to return \alse\ and leaking the statusline setup nudge into the session start output.

Updated the check in \hooks/ponytail-runtime.js\ to also look for \CLAUDE_PLUGIN_ROOT\.