### PR TITLE
fix: bare /ponytail reports the level instead of setting it on pi and OpenCode (#639)

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -88,9 +88,15 @@ export default async ({ client } = {}) => {
     // synchronous store if same-turn switching ever matters.
     'command.execute.before': async (input) => {
       if (!input || input.command !== 'ponytail') return;
-      // `off` is persisted like any mode; the transform reads it and stays silent.
       const args = String(input.arguments || '').trim();
-      const mode = args ? normalizePersistedMode(args) : getDefaultMode();
+      // Bare /ponytail reports the current level; it must not overwrite the
+      // session mode with the default (matches Claude Code and the README, #639).
+      if (!args) {
+        log('info', 'ponytail ' + readMode());
+        return;
+      }
+      // `off` is persisted like any mode; the transform reads it and stays silent.
+      const mode = normalizePersistedMode(args);
       if (!mode) return;
       writeMode(mode);
       log('info', 'ponytail ' + mode);

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -37,11 +37,12 @@ export function resolveSessionMode(entries, fallbackMode = DEFAULT_MODE) {
 }
 
 export function parsePonytailCommand(text, defaultMode = DEFAULT_MODE) {
-  const fallback = normalizePersistedMode(defaultMode) || DEFAULT_MODE;
   const normalizedText = String(text || "").trim().toLowerCase();
 
   if (!normalizedText) {
-    return { type: "set-mode", mode: fallback === "off" ? "full" : fallback };
+    // Bare /ponytail reports the current level; it must not change the mode
+    // (matches Claude Code and the documented behavior, #639).
+    return { type: "status" };
   }
 
   const [primary, secondary] = normalizedText.split(/\s+/);

--- a/pi-extension/test/helpers.test.js
+++ b/pi-extension/test/helpers.test.js
@@ -13,8 +13,10 @@ import {
   writeDefaultMode,
 } from "../index.js";
 
-test("parsePonytailCommand falls back to full when invoked bare and default is off", () => {
-  assert.deepEqual(parsePonytailCommand("", "off"), { type: "set-mode", mode: "full" });
+test("parsePonytailCommand reports the current level when invoked bare (#639)", () => {
+  // Bare /ponytail must report, not set — matching Claude Code and the README.
+  assert.deepEqual(parsePonytailCommand("", "off"), { type: "status" });
+  assert.deepEqual(parsePonytailCommand("", "ultra"), { type: "status" });
 });
 
 test("parsePonytailCommand parses modes, status, and default subcommand", () => {

--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -77,6 +77,14 @@ test('unsupported /ponytail arguments do not reset the current mode', async () =
   assert.equal(fs.readFileSync(statePath, 'utf8'), 'ultra');
 });
 
+test('bare /ponytail reports the level without overwriting the session mode (#639)', async () => {
+  const hooks = await loadPlugin({});
+  fs.writeFileSync(statePath, 'ultra');
+  // No arguments used to persist getDefaultMode() (full), dropping the live level.
+  await hooks['command.execute.before']({ command: 'ponytail', arguments: '', sessionID: 's' });
+  assert.equal(fs.readFileSync(statePath, 'utf8'), 'ultra');
+});
+
 test('unrelated commands do not touch the flag', async () => {
   try { fs.unlinkSync(statePath); } catch (e) {}
   const hooks = await loadPlugin({});


### PR DESCRIPTION
## Problem

The README documents a bare `/ponytail` (no argument) as **report-only**:

> `/ponytail [lite | full | ultra | off]` — Set the intensity, or turn it off. No argument reports the current level.

Claude Code honors this (`ponytail-mode-tracker.js` sets `isReportOnly` for a bare command). But the **pi** and **OpenCode** adapters diverged and *wrote* a mode instead — so checking your level with a bare `/ponytail` silently changed it:

- **pi** (`pi-extension/index.js`): an empty command returned `{ type: "set-mode", mode: fallback }`, dropping the session from e.g. `ULTRA` back to the configured default.
- **OpenCode** (`.opencode/plugins/ponytail.mjs`): a no-arg command persisted `getDefaultMode()` over whatever the session was on.

### Repro (pi)
1. `/ponytail ultra` → status shows `🔥 ULTRA`.
2. `/ponytail` (to check the level, as the README says you can).
3. Status drops to `⚡ FULL` and it notifies "Ponytail mode set to full."

## Fix

Make both adapters report instead of set on a bare command:

- **pi**: return `{ type: "status" }` — reusing the existing status handler that prints `current • default`, no mode change.
- **OpenCode**: log the current level via `readMode()` and return early, without writing the flag.

Mode-changing arguments (`lite` / `full` / `ultra` / `off` / `default <mode>`) are unaffected. Claude Code and Qoder already behave correctly and are untouched.

## Tests

Added a regression test on each side asserting a bare command leaves the active mode untouched:
- `pi-extension/test/helpers.test.js` — bare `parsePonytailCommand("")` returns `{ type: "status" }`.
- `tests/opencode-plugin.test.js` — bare `/ponytail` with the flag on `ultra` keeps it on `ultra`.

Full suite green (the one unrelated `csv … pandas` failure is the known missing-pandas environment issue, addressed separately by #613).

Closes #639
