### PR TITLE
fix: deliver ruleset on mid-session /ponytail switch (#663)

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -64,14 +64,17 @@ function finish() {
       } else if (mode && mode !== 'off') {
         setMode(mode);
         modeSwitched = true;
-        // ponytail: Qoder needs the full ruleset every turn, so when a mode
-        // switch happens we fold the confirmation into the ruleset output
-        // below (one JSON on stdout) instead of emitting two separate writes.
+        // ponytail: a mid-session switch must deliver the ruleset immediately,
+        // not just the confirmation (#663) — otherwise the main thread stays
+        // rule-less until the next SessionStart, even though subagents spawned
+        // meanwhile already see it (ponytail-subagent.js reads the flag
+        // independently). Qoder folds this same way below since it has no
+        // SessionStart to fall back on.
         if (!isQoder) {
           writeHookOutput(
             'UserPromptSubmit',
             mode,
-            'PONYTAIL MODE CHANGED — level: ' + mode,
+            'PONYTAIL MODE CHANGED — level: ' + mode + '\n\n' + getPonytailInstructions(mode),
           );
         }
       } else if (mode === 'off') {

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -76,6 +76,19 @@ assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.readFileSync(codexState, 'utf8'), 'lite');
 output = JSON.parse(result.stdout);
 assert.equal(output.systemMessage, 'PONYTAIL:LITE');
+// #663: Codex shares the same !isQoder mode-switch write path as native
+// Claude, so a mid-session switch must also deliver the ruleset here, not
+// just the systemMessage badge.
+assert.equal(output.hookSpecificOutput.hookEventName, 'UserPromptSubmit');
+assert.match(
+  output.hookSpecificOutput.additionalContext,
+  /PONYTAIL MODE CHANGED — level: lite/,
+);
+assert.match(
+  output.hookSpecificOutput.additionalContext,
+  /You are a lazy senior developer/,
+  'Codex mid-session mode switch must deliver the ruleset immediately, not just the badge (#663)',
+);
 
 // Querying bare @ponytail should report the active level ('lite') without resetting it to default ('ultra')
 result = run(
@@ -428,6 +441,21 @@ result = run('ponytail-mode-tracker.js', defEnv, JSON.stringify({ prompt: '/pony
 assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.readFileSync(defFlag, 'utf8'), 'ultra', 'plain switch must set the session mode');
 assert.equal(JSON.parse(fs.readFileSync(defConfig, 'utf8')).defaultMode, 'lite', 'plain switch must not persist the default');
+// #663: a mid-session switch on native Claude/Codex (non-Qoder) must deliver
+// the ruleset immediately, not just the confirmation — otherwise the main
+// thread stays rule-less until the next SessionStart, while subagents
+// spawned meanwhile (ponytail-subagent.js reads the flag independently)
+// already see it.
+assert.match(
+  result.stdout,
+  /PONYTAIL MODE CHANGED — level: ultra/,
+  'plain switch must still emit the confirmation',
+);
+assert.match(
+  result.stdout,
+  /You are a lazy senior developer/,
+  'mid-session mode switch must deliver the ruleset immediately, not just the confirmation (#663)',
+);
 
 // review is not a valid default (#377) — the command is ignored, config unchanged.
 result = run('ponytail-mode-tracker.js', defEnv, JSON.stringify({ prompt: '/ponytail default review' }));


### PR DESCRIPTION
## Summary

Fixes #663.

The mid-session mode-switch write in `ponytail-mode-tracker.js` only emitted the confirmation string for non-Qoder platforms (native Claude Code, Codex); the actual ruleset injection (`getPonytailInstructions(mode)`) was gated behind `isQoder && !deactivated`. So switching mode mid-session (`/ponytail full`) updated the flag and printed `PONYTAIL MODE CHANGED — level: full`, but the main thread never got the rules until the next `SessionStart` — while subagents spawned in the meantime already saw them (`ponytail-subagent.js` reads the flag independently), producing the split state reported in the issue.

The fix folds `getPonytailInstructions(mode)` into the existing `!isQoder` confirmation write, mirroring the pattern already used on the Qoder branch below it (Qoder has no `SessionStart` to fall back on, so it always folded the ruleset into every `UserPromptSubmit`).

## Root cause

- `hooks/ponytail-mode-tracker.js:70-76` (before fix): mode-switch write for non-Qoder platforms only sent the confirmation string.
- `hooks/ponytail-mode-tracker.js:96-113`: ruleset injection was gated behind `isQoder`, so it never ran for native Claude Code / Codex.
- Reproduced directly: piping `{"prompt":"/ponytail full"}` into the hook showed the flag file updated to `full`, but stdout contained only the confirmation line — no ruleset. Toggling `QODER_SESSION_ID` on the identical input confirmed the same code path emits `header + full ruleset` when `isQoder` is true, isolating the gate as the exact cause.

## Testing notes

- Strengthened the existing native-Claude mid-session-switch test (`tests/hooks.test.js`, the `defEnv` / `/ponytail ultra` case) to assert the ruleset now appears in stdout, not just the flag file — this test already exercised the buggy path but never checked the payload.
- Strengthened the existing Codex mid-session-switch test (`@ponytail lite` case) the same way, closing a gap a 4-persona review (correctness, project-standards, testing, agent-native) surfaced: the fix is gated by the same `!isQoder` boolean for Codex, but the pre-existing test only asserted `systemMessage`, not `hookSpecificOutput.additionalContext`.
- Full suite: `node --test tests/*.test.js` — 82/82 passing.
- Review found no correctness or project-standards issues. One cosmetic/advisory item noted below.

## Known Residuals (accepted, non-blocking)

- **Duplicated header line**: concatenating the confirmation string with `getPonytailInstructions(mode)` produces two adjacent headers (`PONYTAIL MODE CHANGED — level: X` followed by `PONYTAIL MODE ACTIVE — level: X`, since the ruleset body always starts with its own header). This mirrors the exact pattern the pre-existing Qoder fold already used, so it's not a regression — flagged as P3/advisory for a possible future cleanup, not fixed here to keep the diff minimal and scoped to #663.
- **Copilot** has the same underlying bug class (mid-session switches never reach it — its `writeHookOutput` only emits `additionalContext` on `SessionStart`), but that's pre-existing, out of scope for #663, and unaffected by this diff.

## Post-Deploy Monitoring & Validation

No runtime/production monitoring applies — this is a local Node hook script with full unit-test coverage (`node --test tests/*.test.js`) and no deployed service. Validation is the test suite itself; a regression here would show as a failing assertion in `tests/hooks.test.js`, not a runtime signal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)