### PR TITLE
[FIX-642]: docs: close dialog on delete in Radix modal example (#642)

### DIFF
--- a/examples/modal-dialog.md
+++ b/examples/modal-dialog.md
@@ -28,7 +28,9 @@ export function DeleteModal({ onConfirm, onCancel }) {
             <Dialog.Close asChild>
               <button onClick={onCancel}>Cancel</button>
             </Dialog.Close>
-            <button className="btn-danger" onClick={onConfirm}>Delete</button>
+            <Dialog.Close asChild>
+              <button className="btn-danger" onClick={onConfirm}>Delete</button>
+            </Dialog.Close>
           </div>
         </Dialog.Content>
       </Dialog.Portal>


### PR DESCRIPTION
This updates the Radix dialog example in examples/modal-dialog.md to make the behavior consistent.

Previously, the Cancel button closed the dialog while the Delete button did not. Wrapping the Delete button with Dialog.Close aligns it with the Cancel action and the native HTML example shown later in the document, without changing the overall purpose of the example.

Closes #642.