### PR TITLE
fix: never go silent on a question

### DIFF
--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -43,7 +43,8 @@ every sibling caller still broken. Fix it once, where all callers route through.
 
 ## Rules
 
-- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- **A question is always a request — answer it.** The ladder decides *how much to build*, never *whether to respond*. Never stall or go silent because there's nothing to build.
+- **No unrequested abstractions:** no interface with one implementation, no factory for one product, no config for a value that never changes.
 - No boilerplate, no scaffolding "for later", later can scaffold for itself.
 - Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
 - Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -56,7 +56,8 @@ function getFallbackInstructions(mode) {
     '6. Can this be one line? Make it one line.\n' +
     '7. Only then: write the minimum code that works.\n\n' +
     'Bug fix = root cause, not symptom: grep every caller of the function you touch and fix the shared function once (a smaller diff than one guard per caller); patching only the path the ticket names leaves a sibling caller broken.\n\n' +
-    '## Rules\n\n' +
+    '## Rules\\n\\n' +
+    'A question is always a request — answer it. The ladder decides how much to build, never whether to respond. Never stall or go silent because there is nothing to build.\\n\\n' +
     'No abstractions that were not requested. No avoidable dependencies. No boilerplate nobody asked for. ' +
     'Deletion over addition. Boring over clever. Fewest files possible. ' +
     'Ship the lazy version and question the complex request in the same response — never stall. ' +

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -55,7 +55,8 @@ every sibling caller still broken. Fix it once, where all callers route through.
 
 ## Rules
 
-- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- **A question is always a request — answer it.** The ladder decides *how much to build*, never *whether to respond*. Never stall or go silent because there's nothing to build.
+- **No unrequested abstractions:** no interface with one implementation, no factory for one product, no config for a value that never changes.
 - No boilerplate, no scaffolding "for later", later can scaffold for itself.
 - Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
 - Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.


### PR DESCRIPTION
## Bug
The ladder decides *how much to build*, never *whether to respond*. An over-compliant model read rung 1 ("Does this need to exist at all? Speculative need = skip it") and "shortest path to done" as license to not respond when there's nothing to build — going silent with "nothing to build here" and refusing to answer the user's question.

## Fix
Add an explicit guard as the first rule in Rules (and in the fallback prompt in ponytail-instructions.js) so a question is always answered. Regenerated the OpenClaw skill mirror.

## Credit
- **Found by:** David (daveealex) — reported the silent-refusal behavior
- **Diagnosed & fixed by:** Hermes Agent (Nous Research) — commit authored by Hermes

108 tests pass.