### PR TITLE
fix(qoder): persist off mode across prompts

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -75,7 +75,9 @@ function finish() {
           );
         }
       } else if (mode === 'off') {
-        clearMode();
+        if (isQoder) setMode('off');
+        else clearMode();
+
         deactivated = true;
         writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
       }
@@ -83,7 +85,9 @@ function finish() {
 
     // Detect deactivation
     if (!modeSwitched && !deactivated && isDeactivationCommand(prompt)) {
-      clearMode();
+      if (isQoder) setMode('off');
+      else clearMode();
+
       deactivated = true;
       writeHookOutput('UserPromptSubmit', 'off', 'PONYTAIL MODE OFF');
     }

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -368,16 +368,26 @@ assert.match(
   /PONYTAIL MODE CHANGED — level: ultra/,
 );
 
-// "stop ponytail": deactivates, clears flag, no ruleset output.
+// "stop ponytail": deactivates and persists off so a later prompt does
+// not mistake the missing flag for first-run initialization.
 result = run(
-  'ponytail-mode-tracker.js',
-  qoderEnv,
-  JSON.stringify({ prompt: 'stop ponytail' }),
+    'ponytail-mode-tracker.js',
+    qoderEnv,
+    JSON.stringify({ prompt: 'stop ponytail' }),
 );
 assert.equal(result.status, 0, result.stderr);
-assert.equal(fs.existsSync(qoderState), false, 'flag must be cleared after stop ponytail');
+assert.equal(fs.readFileSync(qoderState, 'utf8'), 'off');
 output = JSON.parse(result.stdout);
 assert.equal(output.hookSpecificOutput.additionalContext, 'PONYTAIL MODE OFF');
+
+result = run(
+    'ponytail-mode-tracker.js',
+    qoderEnv,
+    JSON.stringify({ prompt: 'write another function' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(result.stdout, '', 'Qoder must stay off on later prompts');
+assert.equal(fs.readFileSync(qoderState, 'utf8'), 'off');
 
 // Subagent injection via PreToolUse (task|Task matcher): when ponytail is
 // active, the subagent hook injects the ruleset. Qoder shares the same


### PR DESCRIPTION
## Summary

On Qoder, turning Ponytail off only lasted for the current hook invocation. The next ordinary prompt treated the missing state file as first-run initialization and restored the configured default mode.

This change:

- persists the literal `off` state on Qoder;
- applies the same behavior to `/ponytail off`, `stop ponytail`, and `normal mode`;
- adds a regression test proving that a later ordinary prompt does not reactivate Ponytail.

## Root cause

Qoder has no `SessionStart`, so its `UserPromptSubmit` path initializes the default mode whenever `readMode()` returns no state:

```js
if (isQoder && !deactivated) {
  let currentMode = readMode();
  if (!currentMode) {
    currentMode = getDefaultMode();
  }
}
```

The deactivation paths previously called `clearMode()`. That made an intentionally disabled Qoder session indistinguishable from a session that had not been initialized yet.

## Fix

For Qoder, deactivation now stores `off` with `setMode('off')`.

Other hosts retain the existing `clearMode()` behavior, so the change is scoped to Qoder.

## Verification

```text
node --test tests/hooks.test.js
npm test
git diff --check
```
