### PR TITLE
fix(hooks): preserve mode on invalid arguments

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -50,8 +50,6 @@ function finish() {
         else if (arg === '') {
           isReportOnly = true;
           mode = readMode() || getDefaultMode();
-        } else {
-          mode = getDefaultMode();
         }
       }
 

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -429,6 +429,13 @@ assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.readFileSync(defFlag, 'utf8'), 'ultra', 'plain switch must set the session mode');
 assert.equal(JSON.parse(fs.readFileSync(defConfig, 'utf8')).defaultMode, 'lite', 'plain switch must not persist the default');
 
+// An unsupported mode is a no-op: it must not reset the active session mode
+// to the configured default.
+result = run('ponytail-mode-tracker.js', defEnv, JSON.stringify({ prompt: '/ponytail ulta' }));
+assert.equal(result.status, 0, result.stderr);
+assert.equal(result.stdout, '');
+assert.equal(fs.readFileSync(defFlag, 'utf8'), 'ultra', 'invalid mode must preserve the active session mode');
+
 // review is not a valid default (#377) — the command is ignored, config unchanged.
 result = run('ponytail-mode-tracker.js', defEnv, JSON.stringify({ prompt: '/ponytail default review' }));
 assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
## Summary

Unsupported `/ponytail` mode arguments currently replace the active session mode with the configured default.

For example, when the active mode is `ultra` and the configured default is `lite`:

```text
/ponytail ulta
```

silently changes the session to `lite`.

This PR makes unsupported arguments a no-op and adds a regression test proving that the active mode is preserved.

## Root cause

The command parser assigned `getDefaultMode()` to every unsupported argument:

```js
} else {
  mode = getDefaultMode();
}
```

The normal mode-write path then persisted that fallback as if the user had explicitly selected it.

## Fix

Unsupported arguments now leave `mode` unset.

The existing downstream `if (mode)` guard prevents output and state mutation, while valid modes and bare status queries keep their existing behavior.

## Verification

```text
node --test tests/hooks.test.js
npm test
git diff --check
```
