### PR TITLE
fix(uninstall): remove statusline nudge flag

### DIFF
--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -21,6 +21,7 @@ function removeIfExists(filePath, label) {
 }
 
 removeIfExists(path.join(getClaudeDir(), '.ponytail-active'), 'mode flag');
+removeIfExists(path.join(getClaudeDir(), '.ponytail-statusline-nudged'), 'statusline nudge flag');
 removeIfExists(getConfigPath(), 'config file');
 
 const settingsPath = path.join(getClaudeDir(), 'settings.json');

--- a/tests/uninstall.test.js
+++ b/tests/uninstall.test.js
@@ -27,6 +27,9 @@ fs.mkdirSync(claudeDir, { recursive: true });
 const flagPath = path.join(claudeDir, '.ponytail-active');
 fs.writeFileSync(flagPath, 'full');
 
+const nudgeFlagPath = path.join(claudeDir, '.ponytail-statusline-nudged');
+fs.writeFileSync(nudgeFlagPath, '');
+
 const configDir = path.join(temp, 'config-home', 'ponytail');
 fs.mkdirSync(configDir, { recursive: true });
 const configPath = path.join(configDir, 'config.json');
@@ -46,6 +49,7 @@ const env = {
 let result = runUninstall(env);
 assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.existsSync(flagPath), false, 'mode flag must be removed');
+assert.equal(fs.existsSync(nudgeFlagPath), false, 'statusline nudge flag must be removed');
 assert.equal(fs.existsSync(configPath), false, 'config file must be removed');
 
 const settingsAfter = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));


### PR DESCRIPTION
## Summary

The uninstall script removes Ponytail's active-mode flag and configuration, but leaves this internal marker behind:

```text
~/.claude/.ponytail-statusline-nudged
```

This marker suppresses the one-time status-line setup notice. After uninstalling and later reinstalling Ponytail, a clean installation can therefore skip the notice even when no Ponytail status line is configured.

This PR removes the marker during uninstall and extends the uninstall regression test to cover it.

## Root cause

`hooks/ponytail-activate.js` creates `.ponytail-statusline-nudged`, but `scripts/uninstall.js` did not include it in Ponytail-owned state cleanup.

## Fix

Delete `.ponytail-statusline-nudged` alongside `.ponytail-active`.

The existing configuration and combined-status-line cleanup behavior is unchanged.

## Verification

```text
node --test tests/uninstall.test.js
npm test
git diff --check
```