### PR TITLE
fix(hooks): silence off-mode SessionStart

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -26,8 +26,6 @@ const mode = getDefaultMode();
 // "off" mode — skip activation entirely, don't write flag or emit rules
 if (mode === 'off') {
   clearMode();
-  const hookOutput = (isCodex || isCopilot) ? '' : 'OK';
-  writeHookOutput('SessionStart', 'off', hookOutput);
   process.exit(0);
 }
 

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -46,6 +46,43 @@ const home = path.join(temp, 'home');
 const pluginData = path.join(temp, 'plugin-data');
 fs.mkdirSync(home, { recursive: true });
 
+// Off-mode SessionStart must clear stale state without emitting model-visible
+// output on any harness.
+for (const { label, env, statePath } of [
+  {
+    label: 'Claude',
+    env: { HOME: home, USERPROFILE: home, PONYTAIL_DEFAULT_MODE: 'off' },
+    statePath: path.join(home, '.claude', '.ponytail-active'),
+  },
+  {
+    label: 'Codex',
+    env: {
+      HOME: home,
+      USERPROFILE: home,
+      PLUGIN_DATA: pluginData,
+      PONYTAIL_DEFAULT_MODE: 'off',
+    },
+    statePath: path.join(pluginData, '.ponytail-active'),
+  },
+  {
+    label: 'Copilot',
+    env: {
+      HOME: home,
+      USERPROFILE: home,
+      COPILOT_PLUGIN_DATA: path.join(temp, 'copilot-off-data'),
+      PONYTAIL_DEFAULT_MODE: 'off',
+    },
+    statePath: path.join(temp, 'copilot-off-data', '.ponytail-active'),
+  },
+]) {
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, 'full');
+  const offResult = run('ponytail-activate.js', env);
+  assert.equal(offResult.status, 0, offResult.stderr);
+  assert.equal(offResult.stdout, '', `${label} SessionStart must stay silent when ponytail is off`);
+  assert.equal(fs.existsSync(statePath), false, `${label} stale mode state must be cleared`);
+}
+
 // USERPROFILE alongside HOME: os.homedir() reads USERPROFILE on Windows, HOME on POSIX.
 const codexEnv = {
   HOME: home,


### PR DESCRIPTION
## Summary

- Emit no SessionStart stdout when the configured mode is `off`.
- Preserve stale mode-state cleanup.
- Cover native Claude, Codex, and Copilot with one regression check.

## Why

The native Claude off branch currently passes `OK` to the output formatter. This creates model-visible startup context even though off mode promises no output. Codex and Copilot also format the empty context into structured stdout.

Skipping the formatter in the shared off branch makes all three harnesses silent while leaving active-mode output unchanged.

## Verification

- The new check fails on unmodified `main` with actual Claude stdout `OK`.
- `node --test tests/hooks.test.js`
- Remaining root tests excluding the baseline-broken pandas correctness probe: 68 passed.
- `npm test --prefix pi-extension`: 23 passed.
- `npm test --prefix ponytail-mcp`: 3 passed.

The full root command has one existing local failure in `csv: correct pandas one-liner passes`. The same failure reproduces on unmodified `main`.
