### PR TITLE
fix(hermes): reject review as a default mode

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -50,12 +50,12 @@ def _config_dir() -> Path:
 
 
 def _default_mode() -> str:
-    env_mode = _normalize_config_mode(os.environ.get("PONYTAIL_DEFAULT_MODE"))
+    env_mode = _normalize_runtime_mode(os.environ.get("PONYTAIL_DEFAULT_MODE"))
     if env_mode:
         return env_mode
     try:
         data = json.loads((_config_dir() / "config.json").read_text(encoding="utf-8"))
-        file_mode = _normalize_config_mode(data.get("defaultMode"))
+        file_mode = _normalize_runtime_mode(data.get("defaultMode"))
         if file_mode:
             return file_mode
     except Exception:

--- a/tests/hermes-plugin.test.js
+++ b/tests/hermes-plugin.test.js
@@ -149,6 +149,31 @@ print(json.dumps({
   assert.match(data.status_after, /Ponytail mode: ultra/);
 });
 
+test('Hermes rejects review as a default while keeping explicit review mode', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-review-default-'));
+  fs.mkdirSync(path.join(tmp, 'ponytail'), { recursive: true });
+  fs.writeFileSync(path.join(tmp, 'ponytail', 'config.json'), JSON.stringify({ defaultMode: 'review' }));
+  const output = python(String.raw`
+import importlib.util, json, os
+spec = importlib.util.spec_from_file_location('ponytail_hermes_plugin', '__init__.py')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+env_default = mod.build_injected_context(None)
+del os.environ['PONYTAIL_DEFAULT_MODE']
+file_default = mod.build_injected_context(None)
+explicit_review = mod.build_injected_context('review')
+print(json.dumps({
+    'env_default': env_default,
+    'file_default': file_default,
+    'explicit_review': explicit_review,
+}))
+`, { XDG_CONFIG_HOME: tmp, PONYTAIL_DEFAULT_MODE: 'review' });
+  const data = JSON.parse(output);
+  assert.match(data.env_default, /PONYTAIL MODE ACTIVE — level: full/);
+  assert.match(data.file_default, /PONYTAIL MODE ACTIVE — level: full/);
+  assert.match(data.explicit_review, /PONYTAIL MODE ACTIVE — level: review/);
+});
+
 test('Hermes plugin review mode injects the real review skill body', () => {
   const output = python(String.raw`
 import importlib.util, json


### PR DESCRIPTION
## Summary

- Fixes: With PONYTAIL_DEFAULT_MODE=review or defaultMode set to review, every Hermes LLM call receives the review-only ruleset instead of falling back to the full runtime mode.
- Root cause: Hermes _default_mode validates persistent defaults with _normalize_config_mode, whose domain intentionally includes the explicit session-only review mode, rather than _normalize_runtime_mode.

## Regression evidence

- Before: `node --test tests/hermes-plugin.test.js` exited `1`

- After: `node --test tests/hermes-plugin.test.js` exited `0`

## Verification

- `npm test`
- `node scripts/check-rule-copies.js`
- `node scripts/check-versions.js`
- `python3 -m py_compile __init__.py`
- `git diff --check`

## Scope

- 2 files changed, +27 / -2 lines

## Authorship

This fix was developed with AI assistance and was validated with the regression and project checks listed above.
