### PR TITLE
feat: add ChatGPT Skill adapter

### DIFF
--- a/.chatgpt/ponytail/SKILL.md
+++ b/.chatgpt/ponytail/SKILL.md
@@ -24,7 +24,7 @@ Choose the narrowest path that matches the request:
 - Whole-repository complexity audit: read `references/ponytail-audit.md`. Rank the largest cuts first and do not edit unless asked.
 - Deferred-shortcut ledger: read `references/ponytail-debt.md`. Search comment-form `ponytail:` markers, skip vendored/build directories, and report or persist the ledger as requested.
 - Impact scoreboard: read `references/ponytail-gain.md`. Present published benchmark figures as benchmarks, never as measured savings for the current repository.
-- Usage help: read `references/ponytail-help.md`, but replace host-specific install/update instructions with ChatGPT's Skills UI terminology.
+- Usage, installation, update, removal, commands, or mode help: read `references/chatgpt-host.md` first. Use `references/ponytail-help.md` only for the shared level and action descriptions; ignore its host-specific install, update, persistence, and configuration sections.
 
 If one request combines modes, apply implementation rules first, then add only the requested review, audit, or ledger output.
 
@@ -35,7 +35,7 @@ If one request combines modes, apply implementation rules first, then add only t
 - `ponytail ultra`: prefer deletion and YAGNI aggressively while honoring explicit requirements and safety boundaries.
 - `ponytail off`, `stop ponytail`, or `normal mode`: stop applying Ponytail until the user re-enables it.
 
-Keep mode state in the conversation. Do not create config files, status-line files, lifecycle hooks, or persistent flags; those belong to other host adapters and ChatGPT does not execute them.
+Keep mode state in the conversation. Slash-like forms such as `/ponytail-review` are text triggers, not registered ChatGPT slash commands. Do not create config files, status-line files, lifecycle hooks, or persistent flags; those belong to other host adapters and ChatGPT does not execute them.
 
 ## Working method
 

--- a/.chatgpt/ponytail/SKILL.md
+++ b/.chatgpt/ponytail/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: ponytail
+description: >
+  Apply Ponytail's pragmatic senior-developer workflow to coding tasks:
+  implement, fix, refactor, design, choose dependencies, or simplify code by
+  stopping at the first solution that actually works. Also handle Ponytail's
+  over-engineering review, whole-repository audit, deferred-debt ledger,
+  impact scoreboard, help, and lite/full/ultra/off mode requests. Use whenever
+  the user asks for minimal code, YAGNI, the simplest or shortest solution,
+  less boilerplate, fewer dependencies, deletion of over-engineering, or
+  explicitly mentions ponytail. Do not apply to unrelated non-coding requests.
+---
+
+# Ponytail for ChatGPT
+
+Apply the core behavior in `references/ponytail.md` to coding tasks unless the user has turned Ponytail off in the current conversation.
+
+## Dispatch
+
+Choose the narrowest path that matches the request:
+
+- Implementation, bug fix, refactor, design, or dependency choice: read `references/ponytail.md`.
+- Over-engineering review of a diff or selected code: read `references/ponytail-review.md`. Report findings only unless the user asks to apply them.
+- Whole-repository complexity audit: read `references/ponytail-audit.md`. Rank the largest cuts first and do not edit unless asked.
+- Deferred-shortcut ledger: read `references/ponytail-debt.md`. Search comment-form `ponytail:` markers, skip vendored/build directories, and report or persist the ledger as requested.
+- Impact scoreboard: read `references/ponytail-gain.md`. Present published benchmark figures as benchmarks, never as measured savings for the current repository.
+- Usage help: read `references/ponytail-help.md`, but replace host-specific install/update instructions with ChatGPT's Skills UI terminology.
+
+If one request combines modes, apply implementation rules first, then add only the requested review, audit, or ledger output.
+
+## Conversation-scoped modes
+
+- `ponytail lite`: build what was requested and name a lazier alternative in one line.
+- `ponytail` or `ponytail full`: enforce the full ladder. This is the default.
+- `ponytail ultra`: prefer deletion and YAGNI aggressively while honoring explicit requirements and safety boundaries.
+- `ponytail off`, `stop ponytail`, or `normal mode`: stop applying Ponytail until the user re-enables it.
+
+Keep mode state in the conversation. Do not create config files, status-line files, lifecycle hooks, or persistent flags; those belong to other host adapters and ChatGPT does not execute them.
+
+## Working method
+
+1. Read the task and every code path the change actually touches.
+2. Trace callers and data flow before choosing a small edit.
+3. Climb the Ponytail ladder and stop at the first rung that fully satisfies the task.
+4. Preserve trust-boundary validation, data-loss prevention, security, accessibility, explicit requirements, and real-hardware calibration.
+5. Leave one small runnable check for non-trivial new logic when the repository permits it. Do not add a testing framework for a tiny change.
+6. Prefer the smallest correct diff and the fewest files.
+7. State skipped complexity and the trigger for adding it later in no more than three short lines unless the user requested a report or walkthrough.

--- a/.chatgpt/ponytail/agents/openai.yaml
+++ b/.chatgpt/ponytail/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Ponytail"
+  short_description: "Minimal coding, review, audit, and debt cleanup"
+  brand_color: "#8FD14F"

--- a/.chatgpt/ponytail/references/chatgpt-host.md
+++ b/.chatgpt/ponytail/references/chatgpt-host.md
@@ -1,0 +1,27 @@
+# ChatGPT host behavior
+
+Use this reference as the authority for ChatGPT-specific installation, commands, mode state, updates, and removal. Do not reuse host behavior from Claude Code, Codex, OpenCode, Copilot CLI, or other adapters.
+
+## Use
+
+ChatGPT can select Ponytail automatically for coding requests. Users can also type these text triggers:
+
+- `ponytail lite`, `ponytail full`, `ponytail ultra`, or `ponytail off`
+- `/ponytail-review`, `/ponytail-audit`, `/ponytail-debt`, `/ponytail-gain`, or `/ponytail-help`
+- `stop ponytail` or `normal mode`
+
+Slash-like forms are messages, not registered ChatGPT slash-menu commands.
+
+## State
+
+Mode is scoped to the current conversation. Default to full when Ponytail is first used unless the user explicitly selects another level. Do not read or create `PONYTAIL_DEFAULT_MODE`, `~/.config/ponytail/config.json`, mode flags, statusline files, or lifecycle hooks.
+
+## Install and update
+
+The upload bundle is a ZIP whose top-level directory is `ponytail/`. In ChatGPT, the user opens **Plugins → Skills → Create → Upload from your computer** and selects the ZIP. Availability and admin controls depend on the user's current ChatGPT plan and workspace settings.
+
+To update, the user builds a newer ZIP and replaces or re-uploads the Skill. Personal Skills may need to be added separately on different ChatGPT surfaces.
+
+## Remove
+
+Delete the uploaded Ponytail Skill from **Plugins → Skills**. No local Ponytail state needs cleanup because this adapter writes none.

--- a/.chatgpt/ponytail/references/ponytail-audit.md
+++ b/.chatgpt/ponytail/references/ponytail-audit.md
@@ -1,0 +1,31 @@
+
+ponytail-review, repo-wide. Scan the whole tree instead of a diff. Rank
+findings biggest cut first.
+
+## Tags
+
+Same as ponytail-review:
+
+- `delete:` dead code, unused flexibility, speculative feature. Replacement: nothing.
+- `stdlib:` hand-rolled thing the standard library ships. Name the function.
+- `native:` dependency or code doing what the platform already does. Name the feature.
+- `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `shrink:` same logic, fewer lines. Show the shorter form.
+
+## Hunt
+
+Deps the stdlib or platform already ships, single-implementation interfaces,
+factories with one product, wrappers that only delegate, files exporting one
+thing, dead flags and config, hand-rolled stdlib.
+
+## Output
+
+One line per finding, ranked: `<tag> <what to cut>. <replacement>. [path]`.
+End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. Ship.`
+
+## Boundaries
+
+Scope: over-engineering and complexity only. Correctness bugs, security holes,
+and performance are explicitly out of scope. Route them to a normal review
+pass. Lists findings, applies nothing. One-shot.
+"stop ponytail-audit" or "normal mode" to revert.

--- a/.chatgpt/ponytail/references/ponytail-debt.md
+++ b/.chatgpt/ponytail/references/ponytail-debt.md
@@ -1,0 +1,35 @@
+
+Every deliberate ponytail shortcut is marked with a `ponytail:` comment naming
+its ceiling and upgrade path. This collects them into one ledger so a deferral
+can't quietly become permanent.
+
+## Scan
+
+Grep the repo for comment markers, skipping `node_modules`, `.git`, and build
+output:
+
+`grep -rnE '(#|//) ?ponytail:' .`  (add other comment prefixes if your stack uses them)
+
+Each hit is one ledger row. The comment prefix keeps prose that merely mentions
+the convention out of the ledger.
+
+## Output
+
+One row per marker, grouped by file:
+
+`<file>:<line>, <what was simplified>. ceiling: <the limit named>. upgrade: <the trigger to revisit>.`
+
+The convention is `ponytail: <ceiling>, <upgrade path>`, so pull the ceiling
+and the trigger straight from the comment. Want an owner per row too? add
+`git blame -L<line>,<line>`.
+
+Flag the rot risk: any `ponytail:` comment that names no upgrade path or
+trigger gets a `no-trigger` tag, those are the ones that silently rot.
+
+End with `<N> markers, <M> with no trigger.` Nothing found: `No ponytail: debt. Clean ledger.`
+
+## Boundaries
+
+Reads and reports only, changes nothing. To persist it, ask and it writes the
+ledger to a file (e.g. `PONYTAIL-DEBT.md`). One-shot. "stop ponytail-debt" or
+"normal mode" to revert.

--- a/.chatgpt/ponytail/references/ponytail-gain.md
+++ b/.chatgpt/ponytail/references/ponytail-gain.md
@@ -1,0 +1,41 @@
+
+# Ponytail Gain
+
+Display this scoreboard when invoked. One-shot: do NOT change mode, write flag
+files, or persist anything.
+
+The figures are the published benchmark medians (5 everyday tasks: email
+validator, debounce, CSV sum, countdown timer, rate limiter; three models:
+Haiku, Sonnet, Opus). They are measured, not computed from the current repo.
+Source: `benchmarks/` and the README.
+
+## Scoreboard
+
+Render plain ASCII bars. The bar length shows the measured range; the label
+carries the exact figure:
+
+```
+  ponytail gain                     benchmark median · 5 tasks · 3 models
+
+  Lines of code   no-skill  ████████████████████  100%
+                  ponytail  ██▌·················    6–20%   ▼ 80–94%
+  Cost            no-skill  ████████████████████  100%
+                  ponytail  █████▌··············   23–53%  ▼ 47–77%
+  Speed           ponytail  ▸ 3–6× faster
+
+  This repo:  /ponytail-debt  (shortcuts you deferred)
+              /ponytail-audit (what's still cuttable)
+```
+
+## Honesty boundary
+
+These are benchmark medians, not this repo. NEVER print a per-repo savings
+number ("you saved X lines/tokens here"): the unbuilt version was never
+written, so there is no real baseline to subtract from in a live repo. The
+only real per-repo figures come from `/ponytail-debt` (a counted ledger), and
+this card points there instead of inventing one.
+
+## Boundaries
+
+One-shot display. Edits nothing, changes no mode.
+"stop ponytail" or "normal mode": revert.

--- a/.chatgpt/ponytail/references/ponytail-help.md
+++ b/.chatgpt/ponytail/references/ponytail-help.md
@@ -1,0 +1,64 @@
+
+# Ponytail Help
+
+Display this reference card when invoked. One-shot, do NOT change mode,
+write flag files, or persist anything.
+
+## Levels
+
+| Level | Trigger | What change |
+|-------|---------|-------------|
+| **Lite** | `/ponytail lite` | Build what's asked, name the lazier alternative in one line. |
+| **Full** | `/ponytail` | The ladder enforced: YAGNI → stdlib → native → one line → minimum. Default. |
+| **Ultra** | `/ponytail ultra` | YAGNI extremist. Deletion before addition. Challenges requirements before building. |
+
+Level sticks until changed or session end.
+
+## Skills
+
+| Skill | Trigger | What it does |
+|-------|---------|--------------|
+| **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
+| **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
+| **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit: ranked list of what to delete. |
+| **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` shortcut comments into a tracked ledger. |
+| **ponytail-gain** | `/ponytail-gain` | Measured-impact scoreboard: less code, less cost, more speed. |
+| **ponytail-help** | `/ponytail-help` | This card. |
+
+Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
+and OpenCode use the slash-command forms above (OpenCode ships all six as
+slash commands).
+
+## Deactivate
+
+Say "stop ponytail" or "normal mode". Resume anytime with `/ponytail`.
+`/ponytail off` also works.
+
+## Configure Default Mode
+
+Default mode = `full`, auto-active every session. Change it:
+
+**Environment variable** (highest priority):
+```bash
+export PONYTAIL_DEFAULT_MODE=ultra
+```
+
+**Config file** (`~/.config/ponytail/config.json`, Windows: `%APPDATA%\ponytail\config.json`):
+```json
+{ "defaultMode": "lite" }
+```
+
+Set `"off"` to disable auto-activation on session start, activate manually
+with `/ponytail` when wanted.
+
+Resolution: env var > config file > `full`.
+
+## Update
+
+Enable auto-update once: open `/plugin`, go to Marketplaces, pick ponytail, Enable auto-update. Claude Code then pulls new versions at startup (run `/reload-plugins` when it prompts). Manual refresh: `/plugin marketplace update ponytail` then `/reload-plugins`.
+
+If `/plugin` is not recognized, your Claude Code is out of date. Update it (`npm install -g @anthropic-ai/claude-code@latest`, or `brew upgrade claude-code`) and restart. Other hosts use their own update flow.
+
+## More
+
+Full docs + examples: https://github.com/DietrichGebert/ponytail

--- a/.chatgpt/ponytail/references/ponytail-review.md
+++ b/.chatgpt/ponytail/references/ponytail-review.md
@@ -1,0 +1,46 @@
+
+Review diffs for unnecessary complexity. One line per finding: location, what
+to cut, what replaces it. The diff's best outcome is getting shorter.
+
+## Format
+
+`L<line>: <tag> <what>. <replacement>.`, or `<file>:L<line>: ...` for
+multi-file diffs.
+
+Tags:
+
+- `delete:` dead code, unused flexibility, speculative feature. Replacement: nothing.
+- `stdlib:` hand-rolled thing the standard library ships. Name the function.
+- `native:` dependency or code doing what the platform already does. Name the feature.
+- `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `shrink:` same logic, fewer lines. Show the shorter form.
+
+## Examples
+
+❌ "This EmailValidator class might be more complex than necessary, have you
+considered whether all these validation rules are needed at this stage?"
+
+✅ `L12-38: stdlib: 27-line validator class. "@" in email, 1 line, real validation is the confirmation mail.`
+
+✅ `L4: native: moment.js imported for one format call. Intl.DateTimeFormat, 0 deps.`
+
+✅ `repo.py:L88: yagni: AbstractRepository with one implementation. Inline it until a second one exists.`
+
+✅ `L52-71: delete: retry wrapper around an idempotent local call. Nothing replaces it.`
+
+✅ `L30-44: shrink: manual loop builds dict. dict(zip(keys, values)), 1 line.`
+
+## Scoring
+
+End with the only metric that matters: `net: -<N> lines possible.`
+
+If there is nothing to cut, say `Lean already. Ship.` and stop.
+
+## Boundaries
+
+Scope: over-engineering and complexity only. Correctness bugs, security holes,
+and performance are explicitly out of scope. Route them to a normal review
+pass, not this one. A single smoke test or `assert`-based
+self-check is the ponytail minimum, not bloat, never flag it for deletion.
+Does not apply the fixes, only lists them.
+"stop ponytail-review" or "normal mode": revert to verbose review style.

--- a/.chatgpt/ponytail/references/ponytail.md
+++ b/.chatgpt/ponytail/references/ponytail.md
@@ -1,0 +1,102 @@
+
+# Ponytail
+
+You are a lazy senior developer. Lazy means efficient, not careless. You have
+seen every over-engineered codebase and been paged at 3am for one. The best
+code is the code never written.
+
+## Persistence
+
+ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
+unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
+Switch: `/ponytail lite|full|ultra`.
+
+## The ladder
+
+Stop at the first rung that holds:
+
+1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
+2. **Already in this codebase?** A helper, util, type, or pattern that already lives here → reuse it. Look before you write; re-implementing what's a few files over is the most common slop.
+3. **Stdlib does it?** Use it.
+4. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
+5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
+6. **Can it be one line?** One line.
+7. **Only then:** the minimum code that works.
+
+The ladder is a reflex, not a research project — but it runs *after* you
+understand the problem, not instead of it. Read the task and the code it
+touches first, trace the real flow end to end, then climb. Two rungs work →
+take the higher one and move on. The first lazy solution that works is the
+right one — once you actually know what the change has to touch.
+
+**Bug fix = root cause, not symptom.** A report names a symptom. Before you
+edit, grep every caller of the function you're about to touch. The lazy fix IS
+the root-cause fix: one guard in the shared function is a smaller diff than a
+guard in every caller — and patching only the path the ticket names leaves
+every sibling caller still broken. Fix it once, where all callers route through.
+
+## Rules
+
+- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
+- No boilerplate, no scaffolding "for later", later can scaffold for itself.
+- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
+- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
+- Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path (`# ponytail: global lock, per-account locks if throughput matters`).
+
+## Output
+
+Code first. Then at most three short lines: what was skipped, when to add it.
+No essays, no feature tours, no design notes. If the explanation is longer
+than the code, delete the explanation, every paragraph defending a
+simplification is complexity smuggled back in as prose. Explanation the user
+explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
+give it in full, the rule is only against unrequested prose.
+
+Pattern: `[code] → skipped: [X], add when [Y].`
+
+## Intensity
+
+| Level | What change |
+|-------|------------|
+| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
+| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
+| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
+
+Example: "Add a cache for these API responses."
+- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
+- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
+- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
+
+## When NOT to be lazy
+
+Never simplify away: input validation at trust boundaries, error handling
+that prevents data loss, security measures, accessibility basics, anything
+explicitly requested. User insists on the full version → build it, no
+re-arguing.
+
+Never lazy about understanding the problem. The ladder shortens the
+solution, never the reading. Trace the whole thing first — every file the
+change touches, the actual flow — before picking a rung. Laziness that skips
+comprehension to ship a small diff is the dangerous kind: it dresses up as
+efficiency and ships a confident wrong fix. Read fully, then be lazy.
+
+Hardware is never the ideal on paper: a real clock drifts, a real sensor
+reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
+just less code, the physical world needs tuning a minimal model can't see.
+
+Lazy code without its check is unfinished. Non-trivial logic (a branch, a
+loop, a parser, a money/security path) leaves ONE runnable check behind, the
+smallest thing that fails if the logic breaks: an `assert`-based
+`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
+fixtures, no per-function suites unless asked. Trivial one-liners need no
+test, YAGNI applies to tests too.
+
+## Boundaries
+
+Ponytail governs what you build, not how you talk (pair with Caveman for
+terse prose). "stop ponytail" / "normal mode": revert. Level persists until
+changed or session end.
+
+The shortest path to done is the right path.

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ ponytail-*.gif
 
 # agentic benchmark workspaces (agent output, kept locally for inspection)
 benchmarks/agentic/runs/
+
+# Generated ChatGPT upload archive
+dist/ponytail-chatgpt-skill.zip

--- a/README.md
+++ b/README.md
@@ -155,6 +155,20 @@ Copilot CLI namespaces plugin commands by plugin name. For example:
 /ponytail:ponytail-review
 ```
 
+### ChatGPT
+
+Build the single upload bundle from the canonical six Ponytail skills:
+
+```bash
+npm run pack:chatgpt
+```
+
+Then open **Plugins → Skills → Create → Upload from your computer** in ChatGPT and select `dist/ponytail-chatgpt-skill.zip`.
+
+ChatGPT automatically selects the Skill for relevant coding requests. You can also type `ponytail lite`, `ponytail full`, `ponytail ultra`, `/ponytail-review`, `/ponytail-audit`, `/ponytail-debt`, `/ponytail-gain`, or `/ponytail-help`. These slash-like forms are text triggers, not registered slash-menu commands.
+
+Unlike the lifecycle-hook adapters, ChatGPT keeps mode only in the current conversation and writes no config, mode flag, or statusline state. See [ChatGPT Skill Adapter](docs/chatgpt.md) for availability, updates, removal, architecture, and maintenance.
+
 ### Pi agent harness
 
 ```
@@ -250,9 +264,9 @@ That was it. He'd be proud. He won't say it.
 
 Active every session, with a handful of commands (see [Commands](#commands)). `/ponytail ultra` exists for when the codebase has wronged you personally. Startup and mode-change text shows the current mode.
 
-Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`.
+Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`. ChatGPT is the exception: its uploaded Skill keeps mode only in the current conversation and does not read these local settings.
 
-While active, the ruleset is also injected into every subagent spawned via the Agent tool. To scope that to specific agent types (say, keep it off read-only search agents), set the `PONYTAIL_SUBAGENT_MATCHER` env var to a regex tested against the subagent's `agent_type`. It is unanchored and case-insensitive: `explore|general` matches either, `^general$` is exact, and plugin agent types look like `plugin:name`. Unset means inject into every subagent (the default); an invalid regex, or a subagent whose type the platform doesn't report, also falls back to injecting.
+While active, the ruleset is also injected into every subagent spawned via the Agent tool. To scope that to specific agent types (say, keep it off read-only search agents), set the `PONYTAIL_SUBAGENT_MATCHER` env var to a regex tested against the subagent's `agent_type`. It is unanchored and case-insensitive: `explore|general` matches either, `^general$` is exact, and plugin agent types look like `plugin:name`. Unset means inject into every subagent (the default); an invalid regex, or a subagent whose type the platform doesn't report, also falls back to injecting. ChatGPT does not run this lifecycle-hook subagent injection; its Skill instructions remain available to ChatGPT within the conversation.
 
 Cursor, Windsurf, Cline, GitHub Copilot Chat (the VS Code, JetBrains, and Visual Studio editor extension, not the standalone Copilot CLI covered under [Install](#install)), Aider, Kiro, Zed, CodeWhale, Swival, Qoder: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/), [`.qoder/rules/`](.qoder/rules/)).
 
@@ -276,11 +290,12 @@ Which files map to which agent: [Agent portability](docs/agent-portability.md).
 |------|---------|
 | Claude Code | `/plugin remove ponytail` |
 | Codex | `codex plugin remove ponytail` |
+| ChatGPT | Delete the uploaded Skill from **Plugins → Skills** |
 | Devin CLI | `devin plugins remove ponytail` |
 | Pi agent | `pi uninstall ponytail` |
 | Cursor / Windsurf / Cline / Qoder / etc. | Delete the copied rule file |
 
-These remove the plugin's own files. They leave behind a small amount of state ponytail writes outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` to clean those up too. **Run it before the host remove command above** — the script is itself a plugin file, so removing the plugin first deletes it (or run it from a separate clone of this repo). It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched.
+These remove the plugin's own files. They leave behind a small amount of state ponytail writes outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` to clean those up too. **Run it before the host remove command above** — the script is itself a plugin file, so removing the plugin first deletes it (or run it from a separate clone of this repo). It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched. ChatGPT writes none of this local state, so deleting its uploaded Skill is enough.
 
 ## Commands
 
@@ -293,7 +308,7 @@ These remove the plugin's own files. They leave behind a small amount of state p
 | `/ponytail-gain` | Show the measured impact scoreboard (less code, less cost, more speed) from the benchmark. |
 | `/ponytail-help` | Quick reference for the commands above. |
 
-Commands need a skill-capable host (Claude Code, Codex, Devin CLI, OpenCode, Gemini, pi, Swival, Hermes Agent, Qoder). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
+Commands need a skill-capable host (Claude Code, Codex, ChatGPT, Devin CLI, OpenCode, Gemini, pi, Swival, Hermes Agent, Qoder). In Codex they're skills, invoke with `@` (`@ponytail-review`). In ChatGPT, slash-like forms are text triggers and the Skill may also activate automatically. The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
 
 ## Development
 
@@ -306,6 +321,15 @@ npm test
 
 The OpenClaw skill package (`.openclaw/skills/`) is generated from `skills/`; rerun `node scripts/build-openclaw-skills.js` after changing a skill, the test suite fails if it is stale. To publish the skills to ClawHub, run `clawhub login` once, then `node scripts/publish-openclaw-skills.js` (it publishes all six at the `package.json` version; pass `--dry-run` to preview).
 
+The ChatGPT adapter is also generated from `skills/`, but combines all six behaviors into one upload entrypoint. After changing a canonical skill, run:
+
+```bash
+npm run build:chatgpt
+npm run pack:chatgpt
+```
+
+The first command refreshes `.chatgpt/ponytail/`; the second also writes `dist/ponytail-chatgpt-skill.zip`. `npm test` checks canonical-body parity, ChatGPT-specific host help, npm package inclusion, and the generated ZIP structure.
+
 The correctness benchmark spawns Python for email and CSV checks; `python3` is tried before `python`. CSV checks need `pandas` installed locally.
 
 ## FAQ
@@ -314,7 +338,7 @@ The correctness benchmark spawns Python for email and CSV checks; `python3` is t
 Yes, and you should. Caveman shrinks what the agent says; ponytail shrinks what it builds. Different halves, no overlap: caveman leaves code byte-for-byte exact, ponytail stays out of the prose. Terse talk about minimal code.
 
 **Does it need a config file?**
-No. An optional `~/.config/ponytail/config.json` or `PONYTAIL_DEFAULT_MODE` env var can set the default level, but nothing is required.
+No. An optional `~/.config/ponytail/config.json` or `PONYTAIL_DEFAULT_MODE` env var can set the default level for lifecycle-hook hosts, but nothing is required. ChatGPT uses conversation-scoped mode instead.
 
 **What if I really need the 120-line cache class?**
 You don't. Insist anyway and he'll build it. Slowly. Correctly. While looking at you.

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -10,6 +10,7 @@ to load in a given agent.
 |------|-------|-------|
 | Claude Code | `.claude-plugin/plugin.json`, `commands/`, `hooks/claude-codex-hooks.json`, `hooks/` | Full plugin install with session activation, mode tracking, commands, and statusline support. |
 | Codex | `.codex-plugin/plugin.json`, `hooks/claude-codex-hooks.json`, `hooks/`, `skills/` | Plugin install with the same skills plus lifecycle hooks for activation and mode tracking. |
+| ChatGPT | `.chatgpt/ponytail/`, `scripts/build-chatgpt-skill.js`, `scripts/package-chatgpt-skill.js`, `skills/` | Standard single-Skill upload. One root `SKILL.md` dispatches core, review, audit, debt, gain, and help; generated references preserve the canonical skill bodies. Modes are conversation-scoped and no lifecycle hooks or local state run. |
 | OpenCode | `.opencode/plugins/ponytail.mjs`, `.opencode/command/`, `hooks/`, `skills/` | Server plugin injects the ruleset each turn via `experimental.chat.system.transform` and persists `/ponytail` switches; reuses the shared instruction builder. |
 | pi | `pi-extension/`, `skills/`, `hooks/` | Package extension: injects the ruleset each turn through the shared instruction builder and registers the `/ponytail` commands. |
 | Hermes Agent | `plugin.yaml`, `__init__.py`, `skills/` | Native Hermes plugin: injects active mode through `pre_llm_call`, rewrites gateway `/ponytail-*` skill commands into agent prompts, registers `/ponytail` mode switching, and exposes bundled skills as `ponytail:<skill>`. |
@@ -36,6 +37,29 @@ to load in a given agent.
 Keep adapters thin. When a host supports skills or hooks, point it at the
 existing `skills/` and `hooks/` files. When a host only supports project
 instructions, keep its copied rule text aligned with `AGENTS.md`.
+
+## ChatGPT Adapter
+
+ChatGPT accepts a user-uploaded Skill directory, but the Ponytail distribution
+has six canonical `SKILL.md` entrypoints. The adapter therefore exposes one
+root `.chatgpt/ponytail/SKILL.md` and copies each canonical skill body into a
+non-entrypoint reference file. This preserves all six behaviors without
+presenting six separate uploaded skills or nested `SKILL.md` files.
+
+`references/chatgpt-host.md` is intentionally host-specific. It overrides the
+Claude/Codex configuration and update instructions that remain in the shared
+help body. ChatGPT mode state is conversation-scoped; it does not use hooks,
+statusline state, `PONYTAIL_DEFAULT_MODE`, or the local Ponytail config file.
+
+Build and package it with:
+
+```bash
+npm run build:chatgpt
+npm run pack:chatgpt
+```
+
+See [ChatGPT Skill Adapter](chatgpt.md) for installation, usage, update, removal,
+and maintenance details.
 
 ## Portable Behavior
 

--- a/docs/chatgpt.md
+++ b/docs/chatgpt.md
@@ -1,0 +1,102 @@
+# ChatGPT Skill Adapter
+
+Ponytail ships a ChatGPT-specific adapter in `.chatgpt/ponytail/`. It follows the Agent Skills directory format while exposing the six canonical Ponytail behaviors through one uploaded Skill.
+
+## Build and package
+
+From the repository root:
+
+```bash
+npm run pack:chatgpt
+```
+
+This regenerates the adapter from `skills/` and writes:
+
+```text
+dist/ponytail-chatgpt-skill.zip
+```
+
+Build without creating an archive:
+
+```bash
+npm run build:chatgpt
+```
+
+The packaging command uses Python 3's standard-library `zipfile` module. It tries `python3`, `python`, and Windows' `py -3` launcher, in that order.
+
+## Install in ChatGPT
+
+1. Open **Plugins** in the ChatGPT sidebar.
+2. Open **Skills**.
+3. Choose **Create**, then **Upload from your computer**.
+4. Select `dist/ponytail-chatgpt-skill.zip`.
+
+ChatGPT availability and workspace controls can change. See [OpenAI's Skills in ChatGPT documentation](https://help.openai.com/en/articles/20001066-skills-in-chatgpt) for the current plans, admin settings, and upload UI.
+
+## Use
+
+ChatGPT can select Ponytail automatically for coding requests. Explicit text triggers also work:
+
+```text
+ponytail full
+ponytail ultra
+/ponytail-review
+/ponytail-audit
+/ponytail-debt
+/ponytail-gain
+/ponytail-help
+stop ponytail
+```
+
+The slash-like forms above are messages, not registered slash-menu commands.
+
+The uploaded Skill provides:
+
+- the core minimal-implementation ladder
+- diff-focused over-engineering review
+- repository-wide complexity audit
+- `ponytail:` deferred-debt collection
+- the published benchmark scoreboard
+- Ponytail usage and mode help
+
+## ChatGPT host semantics
+
+ChatGPT differs from plugin hosts such as Claude Code, Codex, OpenCode, and Copilot CLI:
+
+- mode is scoped to the current conversation
+- no lifecycle hooks run on session start or prompt submission
+- no statusline or local mode flag is created
+- `PONYTAIL_DEFAULT_MODE` and `~/.config/ponytail/config.json` do not configure the uploaded Skill
+- commands are natural-language or slash-like text triggers, not host-registered commands
+- the six canonical skills are routed through one root `SKILL.md`, because one upload should expose one Ponytail Skill
+
+To update Ponytail, build a fresh ZIP from the newer checkout and replace or re-upload the Skill in ChatGPT. To remove it, delete the uploaded Skill from **Plugins → Skills**. Personal Skills may need to be added separately on different ChatGPT surfaces; consult the current OpenAI documentation above.
+
+## Layout
+
+```text
+.chatgpt/ponytail/
+├── SKILL.md
+├── agents/openai.yaml
+└── references/
+    ├── chatgpt-host.md
+    ├── ponytail.md
+    ├── ponytail-review.md
+    ├── ponytail-audit.md
+    ├── ponytail-debt.md
+    ├── ponytail-gain.md
+    └── ponytail-help.md
+```
+
+`SKILL.md` is the only Skill entrypoint. The six `ponytail*.md` references are generated from the bodies of the canonical `skills/*/SKILL.md` files. `chatgpt-host.md` contains the host-specific behavior that must not be inherited from Claude, Codex, or other adapters.
+
+## Maintenance
+
+After changing a canonical skill:
+
+```bash
+npm run build:chatgpt
+node --test tests/chatgpt-skill.test.js
+```
+
+The tests fail when generated references drift, when another nested `SKILL.md` appears, when host-specific instructions leak into ChatGPT help, or when packaging no longer produces a single-entrypoint ZIP.

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@dietrichgebert/ponytail",
   "version": "4.8.4",
   "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
-  "keywords": ["opencode-plugin", "opencode", "ponytail", "pi-package", "pi", "skills", "qoder"],
+  "keywords": ["opencode-plugin", "opencode", "ponytail", "pi-package", "pi", "skills", "qoder", "chatgpt"],
   "license": "MIT",
   "author": {
     "name": "Dietrich Gebert",
@@ -28,13 +28,18 @@
     ".opencode/",
     ".qoder/",
     ".qoder-plugin/",
+    ".chatgpt/",
     "pi-extension/",
+    "scripts/build-chatgpt-skill.js",
+    "scripts/package-chatgpt-skill.js",
     "scripts/uninstall.js",
     "assets/",
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix ponytail-mcp"
+    "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix ponytail-mcp",
+    "build:chatgpt": "node scripts/build-chatgpt-skill.js",
+    "pack:chatgpt": "node scripts/package-chatgpt-skill.js"
   },
   "pi": {
     "extensions": ["./pi-extension/index.js"],
@@ -44,4 +49,3 @@
     "access": "public"
   }
 }
-

--- a/scripts/build-chatgpt-skill.js
+++ b/scripts/build-chatgpt-skill.js
@@ -1,0 +1,60 @@
+#!/usr/bin/env node
+// Generate a single ChatGPT-uploadable Skill source tree from the canonical
+// skills/. ChatGPT accepts the Agent Skills format, but one uploaded bundle
+// should expose one SKILL.md entrypoint. This adapter routes Ponytail's six
+// skills through one root entrypoint and keeps each canonical body as a
+// reference, so the behavior stays in sync without shipping nested SKILL.md
+// files that would be detected as separate skills.
+//
+// Run: node scripts/build-chatgpt-skill.js
+// Then package: cd .chatgpt && python3 -m zipfile -c skill.zip ponytail
+
+const fs = require('fs');
+const path = require('path');
+
+const ROOT = path.join(__dirname, '..');
+const OUT = path.join(ROOT, '.chatgpt', 'ponytail');
+const NAMES = [
+  'ponytail',
+  'ponytail-review',
+  'ponytail-audit',
+  'ponytail-debt',
+  'ponytail-gain',
+  'ponytail-help',
+];
+
+const ENTRYPOINT = fs.readFileSync(path.join(OUT, 'SKILL.md'), 'utf8').replace(/\r\n/g, '\n');
+const OPENAI_YAML = `interface:\n  display_name: "Ponytail"\n  short_description: "Minimal coding, review, audit, and debt cleanup"\n  brand_color: "#8FD14F"\n`;
+
+function sourceBody(name) {
+  const source = fs.readFileSync(path.join(ROOT, 'skills', name, 'SKILL.md'), 'utf8').replace(/\r\n/g, '\n');
+  const frontmatter = source.match(/^---\n[\s\S]*?\n---\n?/);
+  if (!frontmatter) throw new Error(`skills/${name}/SKILL.md has no frontmatter`);
+  return source.slice(frontmatter[0].length);
+}
+
+function renderFiles() {
+  const files = new Map([
+    ['SKILL.md', ENTRYPOINT],
+    ['agents/openai.yaml', OPENAI_YAML],
+  ]);
+  for (const name of NAMES) files.set(`references/${name}.md`, sourceBody(name));
+  return files;
+}
+
+function outPath(relativePath) {
+  return path.join(OUT, relativePath);
+}
+
+function writeFiles() {
+  for (const [relativePath, content] of renderFiles()) {
+    const target = outPath(relativePath);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+    console.log('wrote', path.relative(ROOT, target).replace(/\\/g, '/'));
+  }
+}
+
+module.exports = { ENTRYPOINT, NAMES, OPENAI_YAML, OUT, outPath, renderFiles, sourceBody, writeFiles };
+
+if (require.main === module) writeFiles();

--- a/scripts/build-chatgpt-skill.js
+++ b/scripts/build-chatgpt-skill.js
@@ -1,13 +1,10 @@
 #!/usr/bin/env node
 // Generate a single ChatGPT-uploadable Skill source tree from the canonical
-// skills/. ChatGPT accepts the Agent Skills format, but one uploaded bundle
-// should expose one SKILL.md entrypoint. This adapter routes Ponytail's six
-// skills through one root entrypoint and keeps each canonical body as a
-// reference, so the behavior stays in sync without shipping nested SKILL.md
-// files that would be detected as separate skills.
+// skills/. One uploaded bundle exposes one SKILL.md entrypoint, which routes
+// Ponytail's six behaviors through canonical bodies copied as references.
 //
-// Run: node scripts/build-chatgpt-skill.js
-// Then package: cd .chatgpt && python3 -m zipfile -c skill.zip ponytail
+// Run: npm run build:chatgpt
+// Package: npm run pack:chatgpt
 
 const fs = require('fs');
 const path = require('path');
@@ -25,6 +22,34 @@ const NAMES = [
 
 const ENTRYPOINT = fs.readFileSync(path.join(OUT, 'SKILL.md'), 'utf8').replace(/\r\n/g, '\n');
 const OPENAI_YAML = `interface:\n  display_name: "Ponytail"\n  short_description: "Minimal coding, review, audit, and debt cleanup"\n  brand_color: "#8FD14F"\n`;
+const CHATGPT_HOST = `# ChatGPT host behavior
+
+Use this reference as the authority for ChatGPT-specific installation, commands, mode state, updates, and removal. Do not reuse host behavior from Claude Code, Codex, OpenCode, Copilot CLI, or other adapters.
+
+## Use
+
+ChatGPT can select Ponytail automatically for coding requests. Users can also type these text triggers:
+
+- \`ponytail lite\`, \`ponytail full\`, \`ponytail ultra\`, or \`ponytail off\`
+- \`/ponytail-review\`, \`/ponytail-audit\`, \`/ponytail-debt\`, \`/ponytail-gain\`, or \`/ponytail-help\`
+- \`stop ponytail\` or \`normal mode\`
+
+Slash-like forms are messages, not registered ChatGPT slash-menu commands.
+
+## State
+
+Mode is scoped to the current conversation. Default to full when Ponytail is first used unless the user explicitly selects another level. Do not read or create \`PONYTAIL_DEFAULT_MODE\`, \`~/.config/ponytail/config.json\`, mode flags, statusline files, or lifecycle hooks.
+
+## Install and update
+
+The upload bundle is a ZIP whose top-level directory is \`ponytail/\`. In ChatGPT, the user opens **Plugins → Skills → Create → Upload from your computer** and selects the ZIP. Availability and admin controls depend on the user's current ChatGPT plan and workspace settings.
+
+To update, the user builds a newer ZIP and replaces or re-uploads the Skill. Personal Skills may need to be added separately on different ChatGPT surfaces.
+
+## Remove
+
+Delete the uploaded Ponytail Skill from **Plugins → Skills**. No local Ponytail state needs cleanup because this adapter writes none.
+`;
 
 function sourceBody(name) {
   const source = fs.readFileSync(path.join(ROOT, 'skills', name, 'SKILL.md'), 'utf8').replace(/\r\n/g, '\n');
@@ -37,6 +62,7 @@ function renderFiles() {
   const files = new Map([
     ['SKILL.md', ENTRYPOINT],
     ['agents/openai.yaml', OPENAI_YAML],
+    ['references/chatgpt-host.md', CHATGPT_HOST],
   ]);
   for (const name of NAMES) files.set(`references/${name}.md`, sourceBody(name));
   return files;
@@ -47,6 +73,7 @@ function outPath(relativePath) {
 }
 
 function writeFiles() {
+  fs.rmSync(OUT, { recursive: true, force: true });
   for (const [relativePath, content] of renderFiles()) {
     const target = outPath(relativePath);
     fs.mkdirSync(path.dirname(target), { recursive: true });
@@ -55,6 +82,16 @@ function writeFiles() {
   }
 }
 
-module.exports = { ENTRYPOINT, NAMES, OPENAI_YAML, OUT, outPath, renderFiles, sourceBody, writeFiles };
+module.exports = {
+  CHATGPT_HOST,
+  ENTRYPOINT,
+  NAMES,
+  OPENAI_YAML,
+  OUT,
+  outPath,
+  renderFiles,
+  sourceBody,
+  writeFiles,
+};
 
 if (require.main === module) writeFiles();

--- a/scripts/package-chatgpt-skill.js
+++ b/scripts/package-chatgpt-skill.js
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+// Build Ponytail's single ChatGPT Skill and package it as an uploadable ZIP.
+// Uses Python's standard-library zipfile module so the repository needs no
+// additional npm dependency just to create an archive.
+
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const ROOT = path.join(__dirname, '..');
+const CHATGPT_DIR = path.join(ROOT, '.chatgpt');
+const DEFAULT_ARCHIVE = path.join(ROOT, 'dist', 'ponytail-chatgpt-skill.zip');
+
+function findPython() {
+  const candidates = [
+    { command: 'python3', prefix: [] },
+    { command: 'python', prefix: [] },
+    { command: 'py', prefix: ['-3'] },
+  ];
+
+  for (const candidate of candidates) {
+    const result = spawnSync(candidate.command, [...candidate.prefix, '--version'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    });
+    if (result.status === 0) return candidate;
+  }
+
+  throw new Error('Python 3 is required to package the ChatGPT Skill');
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    cwd: ROOT,
+    encoding: 'utf8',
+    stdio: 'inherit',
+    windowsHide: true,
+    ...options,
+  });
+  if (result.error) throw result.error;
+  if (result.status !== 0) throw new Error(`${command} exited with status ${result.status}`);
+}
+
+function packageSkill(archivePath = DEFAULT_ARCHIVE) {
+  run(process.execPath, [path.join(ROOT, 'scripts', 'build-chatgpt-skill.js')]);
+
+  const output = path.resolve(archivePath);
+  fs.mkdirSync(path.dirname(output), { recursive: true });
+  fs.rmSync(output, { force: true });
+
+  const python = findPython();
+  run(
+    python.command,
+    [...python.prefix, '-m', 'zipfile', '-c', output, 'ponytail'],
+    { cwd: CHATGPT_DIR },
+  );
+
+  console.log('wrote', path.relative(ROOT, output).replace(/\\/g, '/'));
+  return output;
+}
+
+function outputArg(argv) {
+  const index = argv.indexOf('--output');
+  if (index === -1) return DEFAULT_ARCHIVE;
+  if (!argv[index + 1]) throw new Error('--output requires a path');
+  return path.resolve(argv[index + 1]);
+}
+
+module.exports = { CHATGPT_DIR, DEFAULT_ARCHIVE, findPython, outputArg, packageSkill };
+
+if (require.main === module) packageSkill(outputArg(process.argv.slice(2)));

--- a/tests/chatgpt-skill.test.js
+++ b/tests/chatgpt-skill.test.js
@@ -1,0 +1,56 @@
+#!/usr/bin/env node
+// The ChatGPT adapter is generated from the canonical skills/. These tests
+// catch stale copies and ensure an uploaded bundle exposes exactly one
+// SKILL.md entrypoint instead of six independent skills.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const {
+  ENTRYPOINT,
+  NAMES,
+  OPENAI_YAML,
+  OUT,
+  outPath,
+  renderFiles,
+  sourceBody,
+} = require('../scripts/build-chatgpt-skill');
+
+function walk(dir) {
+  return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(dir, entry.name);
+    return entry.isDirectory() ? walk(full) : [full];
+  });
+}
+
+test('committed ChatGPT adapter matches the generator', () => {
+  for (const [relativePath, expected] of renderFiles()) {
+    const actual = fs.readFileSync(outPath(relativePath), 'utf8').replace(/\r\n/g, '\n');
+    assert.equal(actual, expected, `stale — run: node scripts/build-chatgpt-skill.js (${relativePath})`);
+  }
+});
+
+test('ChatGPT bundle exposes exactly one SKILL.md', () => {
+  const skillFiles = walk(OUT).filter((file) => path.basename(file) === 'SKILL.md');
+  assert.deepEqual(skillFiles.map((file) => path.relative(OUT, file).replace(/\\/g, '/')), ['SKILL.md']);
+});
+
+test('root entrypoint uses ChatGPT-compatible frontmatter', () => {
+  const frontmatter = ENTRYPOINT.match(/^---\n([\s\S]*?)\n---/)[1];
+  const keys = frontmatter.split('\n').filter((line) => /^[a-z][a-z-]*:/.test(line)).map((line) => line.split(':')[0]);
+  assert.deepEqual(keys, ['name', 'description']);
+  assert.match(frontmatter, /^name: ponytail$/m);
+});
+
+test('OpenAI UI metadata is present', () => {
+  assert.match(OPENAI_YAML, /display_name: "Ponytail"/);
+  assert.match(OPENAI_YAML, /short_description:/);
+});
+
+for (const name of NAMES) {
+  test(`${name}: ChatGPT reference is the canonical skill body`, () => {
+    const reference = fs.readFileSync(outPath(`references/${name}.md`), 'utf8').replace(/\r\n/g, '\n');
+    assert.equal(reference, sourceBody(name));
+  });
+}

--- a/tests/chatgpt-skill.test.js
+++ b/tests/chatgpt-skill.test.js
@@ -1,13 +1,16 @@
 #!/usr/bin/env node
 // The ChatGPT adapter is generated from the canonical skills/. These tests
-// catch stale copies and ensure an uploaded bundle exposes exactly one
-// SKILL.md entrypoint instead of six independent skills.
+// catch stale copies, host-instruction leaks, package omissions, and archives
+// that expose more than one SKILL.md entrypoint.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { spawnSync } = require('child_process');
 const {
+  CHATGPT_HOST,
   ENTRYPOINT,
   NAMES,
   OPENAI_YAML,
@@ -16,6 +19,9 @@ const {
   renderFiles,
   sourceBody,
 } = require('../scripts/build-chatgpt-skill');
+const { findPython, packageSkill } = require('../scripts/package-chatgpt-skill');
+
+const ROOT = path.join(__dirname, '..');
 
 function walk(dir) {
   return fs.readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -27,7 +33,7 @@ function walk(dir) {
 test('committed ChatGPT adapter matches the generator', () => {
   for (const [relativePath, expected] of renderFiles()) {
     const actual = fs.readFileSync(outPath(relativePath), 'utf8').replace(/\r\n/g, '\n');
-    assert.equal(actual, expected, `stale — run: node scripts/build-chatgpt-skill.js (${relativePath})`);
+    assert.equal(actual, expected, `stale — run: npm run build:chatgpt (${relativePath})`);
   }
 });
 
@@ -46,6 +52,43 @@ test('root entrypoint uses ChatGPT-compatible frontmatter', () => {
 test('OpenAI UI metadata is present', () => {
   assert.match(OPENAI_YAML, /display_name: "Ponytail"/);
   assert.match(OPENAI_YAML, /short_description:/);
+});
+
+test('ChatGPT help overrides lifecycle-host behavior', () => {
+  assert.match(CHATGPT_HOST, /conversation/);
+  assert.match(CHATGPT_HOST, /Plugins → Skills/);
+  assert.match(CHATGPT_HOST, /not registered ChatGPT slash-menu commands/);
+  assert.match(ENTRYPOINT, /references\/chatgpt-host\.md/);
+  assert.match(ENTRYPOINT, /ignore its host-specific install, update, persistence, and configuration sections/);
+});
+
+test('npm package ships and exposes the ChatGPT adapter', () => {
+  const pkg = JSON.parse(fs.readFileSync(path.join(ROOT, 'package.json'), 'utf8'));
+  assert.ok(pkg.files.includes('.chatgpt/'));
+  assert.ok(pkg.files.includes('scripts/build-chatgpt-skill.js'));
+  assert.ok(pkg.files.includes('scripts/package-chatgpt-skill.js'));
+  assert.equal(pkg.scripts['build:chatgpt'], 'node scripts/build-chatgpt-skill.js');
+  assert.equal(pkg.scripts['pack:chatgpt'], 'node scripts/package-chatgpt-skill.js');
+});
+
+test('packaging creates one uploadable Skill ZIP', { timeout: 20_000 }, () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-chatgpt-'));
+  const archive = packageSkill(path.join(temp, 'skill.zip'));
+  const python = findPython();
+  const result = spawnSync(
+    python.command,
+    [...python.prefix, '-m', 'zipfile', '-l', archive],
+    { encoding: 'utf8', windowsHide: true },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const entries = result.stdout.split('\n').flatMap((line) => {
+    const match = line.match(/^(.*?)\s{2,}\d{4}-\d{2}-\d{2}/);
+    return match ? [match[1].trim()] : [];
+  });
+  assert.ok(entries.includes('ponytail/SKILL.md'));
+  assert.ok(entries.includes('ponytail/agents/openai.yaml'));
+  assert.ok(entries.includes('ponytail/references/chatgpt-host.md'));
+  assert.equal(entries.filter((entry) => path.basename(entry) === 'SKILL.md').length, 1);
 });
 
 for (const name of NAMES) {


### PR DESCRIPTION
## What changed

* add `.chatgpt/ponytail/`, a standard single-Skill ChatGPT adapter with one root `SKILL.md` and `agents/openai.yaml`
* route Ponytail's core, review, audit, debt, gain, and help behavior through that entrypoint
* generate the six reference files from the canonical `skills/` bodies so the adapter cannot drift
* add parity tests that check generated content, validate the frontmatter shape, and ensure the bundle contains exactly one `SKILL.md`

## Why

The repository's canonical distribution contains six independent `SKILL.md` entrypoints. That works for skill-capable agent hosts, but a ChatGPT upload intended to behave like one Ponytail plugin needs one entrypoint.

The adapter keeps the canonical skill bodies as generated references and handles mode changes in conversation instead of trying to run Claude Code, Codex, or Copilot lifecycle hooks that ChatGPT does not support.

## Usage

Regenerate the adapter after changing a canonical skill:

```bash
node scripts/build-chatgpt-skill.js
node --test tests/chatgpt-skill.test.js
```

Create an uploadable archive:

```bash
cd .chatgpt
python3 -m zipfile -c skill.zip ponytail
```

## Validation

* `node --test tests/chatgpt-skill.test.js` — 10 passing
* OpenAI Skill validator — valid
* ZIP integrity and single-entrypoint checks — passing

Built against upstream `main` at `16f29800fd2681bdf24f3eb4ccffe38be3baec6b`.
