### PR TITLE
fix(benchmark-local): handle Ollama connection/response errors gracefully

### DIFF
--- a/benchmarks/benchmark-local.py
+++ b/benchmarks/benchmark-local.py
@@ -16,7 +16,9 @@ import re
 import time
 import urllib.request
 import urllib.parse
+import urllib.error
 from pathlib import Path
+
 
 ROOT = Path(__file__).parent.parent
 
@@ -73,10 +75,23 @@ def call_ollama(model, system_prompt, user_prompt, ollama_url):
         method="POST",
     )
     t0 = time.time()
-    with urllib.request.urlopen(req, timeout=180) as resp:
-        data = json.loads(resp.read())
+    try:
+        with urllib.request.urlopen(req, timeout=180) as resp:
+            data = json.loads(resp.read())
+    except urllib.error.URLError as e:
+        raise RuntimeError(
+            f"Could not reach Ollama at {ollama_url} (model '{model}'): {e}. "
+            "Is Ollama running and is the model pulled?"
+        ) from e
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Ollama returned invalid JSON for model '{model}': {e}") from e
     elapsed = time.time() - t0
-    return data["message"]["content"], round(elapsed, 1)
+    try:
+        return data["message"]["content"], round(elapsed, 1)
+    except KeyError as e:
+        raise RuntimeError(
+            f"Unexpected response shape from Ollama for model '{model}': {data}"
+        ) from e
 
 
 def run(model, repeat, ollama_url):

--- a/benchmarks/benchmark-local.py
+++ b/benchmarks/benchmark-local.py
@@ -78,6 +78,12 @@ def call_ollama(model, system_prompt, user_prompt, ollama_url):
     try:
         with urllib.request.urlopen(req, timeout=180) as resp:
             data = json.loads(resp.read())
+    except urllib.error.HTTPError as e:
+        body = e.read().decode(errors="replace")
+        raise RuntimeError(
+            f"Ollama returned HTTP {e.code} for model '{model}': {body}. "
+            "Check that the model name is correct and has been pulled."
+        ) from e
     except urllib.error.URLError as e:
         raise RuntimeError(
             f"Could not reach Ollama at {ollama_url} (model '{model}'): {e}. "


### PR DESCRIPTION
## What

`call_ollama()` in `benchmarks/benchmark-local.py` had no error handling around the HTTP request to Ollama or around parsing its response. Any failure there (Ollama not running, wrong model name, unexpected response shape) crashed the whole benchmark run with a raw Python traceback.

This PR wraps those two points in try/except and raises a clear `RuntimeError` instead:

- `urllib.error.URLError` → Ollama unreachable (not running / wrong URL)
- `json.JSONDecodeError` → Ollama responded with non-JSON
- `KeyError` → response JSON didn't have the expected `message.content` shape (e.g. an error payload)

## Why

This script is meant to be run locally against Ollama (`benchmarks/benchmark-local.py --model llama3.2 --repeat 3`), and "Ollama isn't running yet" or "wrong model name" are common, expected mistakes — not exceptional edge cases. Right now those mistakes produce a confusing stack trace instead of telling the user what to check.

## Before / after

Before (Ollama not reachable):

\`\`\`
Traceback (most recent call last):
  File "benchmark-local.py", line 76, in call_ollama
    with urllib.request.urlopen(req, timeout=180) as resp:
  ...
urllib.error.URLError: <urlopen error [Errno 111] Connection refused>
\`\`\`

After:

\`\`\`
RuntimeError: Could not reach Ollama at http://localhost:11434/ (model 'llama3.2'): <urlopen error [Errno 111] Connection refused>. Is Ollama running and is the model pulled?
\`\`\`

## Testing

- `python -m py_compile benchmarks/benchmark-local.py` — passes
- Manually verified both new error paths raise the expected `RuntimeError` with a clear message:
  - unreachable host → clear connection-refused message
  - malformed response shape (mocked) → clear "unexpected response shape" message

## Scope

Small, self-contained fix — only touches `call_ollama()` and one import line. No behavior changes for the success path.