### PR TITLE
feat(hooks): honor hideStatus for the Claude Code statusline badge (#659)

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -8,12 +8,13 @@
 
 const fs = require('fs');
 const path = require('path');
-const { getDefaultMode, getClaudeDir, isShellSafe } = require('./ponytail-config');
+const { getDefaultMode, getClaudeDir, getHideStatus, isShellSafe } = require('./ponytail-config');
 const { getPonytailInstructions } = require('./ponytail-instructions');
 const {
   clearMode,
   isCodex,
   isCopilot,
+  setHidden,
   setMode,
   writeHookOutput,
 } = require('./ponytail-runtime');
@@ -36,6 +37,15 @@ try {
   setMode(mode);
 } catch (e) {
   // Silent fail -- flag is best-effort, don't block the hook
+}
+
+// 1b. Reflect hideStatus into a marker the statusline scripts can stat (#659).
+// getHideStatus() reads PONYTAIL_HIDE_STATUS or config.hideStatus; the marker is
+// rewritten every session start so toggling the setting takes effect next session.
+try {
+  setHidden(getHideStatus());
+} catch (e) {
+  // Silent fail — the badge is cosmetic, never block session start over it.
 }
 
 // 2. Emit the ponytail ruleset, filtered to the active intensity level.

--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -4,6 +4,7 @@ const os = require('os');
 const { getClaudeDir, getConfigDir } = require('./ponytail-config');
 
 const STATE_FILE = '.ponytail-active';
+const HIDDEN_FILE = '.ponytail-hidden';
 
 // ponytail: VS Code Copilot never sets COPILOT_PLUGIN_DATA — it only injects
 // CLAUDE_PLUGIN_ROOT, pointed at an install path under .vscode/agent-plugins/
@@ -29,10 +30,30 @@ if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA || getClaudeDir();
 if (isQoder) stateDir = path.join(os.homedir(), '.qoder');
 
 const statePath = path.join(stateDir, STATE_FILE);
+const hiddenPath = path.join(stateDir, HIDDEN_FILE);
 
 function setMode(mode) {
   fs.mkdirSync(path.dirname(statePath), { recursive: true });
   fs.writeFileSync(statePath, mode);
+}
+
+// Hide the statusline badge without deactivating ponytail (#659). The statusline
+// scripts are shell/PowerShell that only stat a file, so instead of teaching them
+// to parse config, activate resolves getHideStatus() once and drops (or clears)
+// this marker next to the mode flag. Rewritten every session start, so unsetting
+// PONYTAIL_HIDE_STATUS brings the badge back on its own.
+function setHidden(hidden) {
+  try {
+    if (hidden) {
+      fs.mkdirSync(path.dirname(hiddenPath), { recursive: true });
+      fs.writeFileSync(hiddenPath, '');
+    } else {
+      fs.unlinkSync(hiddenPath);
+    }
+  } catch (e) {
+    // best-effort: ENOENT on clear is fine, and the badge is cosmetic — never
+    // block the hook over it.
+  }
 }
 
 function clearMode() {
@@ -95,6 +116,7 @@ module.exports = {
   isCopilot,
   isQoder,
   readMode,
+  setHidden,
   setMode,
   writeHookOutput,
 };

--- a/hooks/ponytail-statusline.ps1
+++ b/hooks/ponytail-statusline.ps1
@@ -4,6 +4,10 @@ $Flag = Join-Path $ClaudeDir ".ponytail-active"
 if (-not (Test-Path $Flag)) {
     exit 0
 }
+# hideStatus: activate drops this marker when the badge is silenced (#659)
+if (Test-Path (Join-Path $ClaudeDir ".ponytail-hidden")) {
+    exit 0
+}
 
 $Mode = ""
 try {

--- a/hooks/ponytail-statusline.sh
+++ b/hooks/ponytail-statusline.sh
@@ -1,7 +1,10 @@
 #!/usr/bin/env bash
 # CLAUDE_CONFIG_DIR overrides ~/.claude, matching where the hooks write the flag (issue #34)
-flag="${CLAUDE_CONFIG_DIR:-$HOME/.claude}/.ponytail-active"
+dir="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+flag="$dir/.ponytail-active"
 [ -f "$flag" ] || exit 0
+# hideStatus: activate drops this marker when the badge is silenced (#659)
+[ -f "$dir/.ponytail-hidden" ] && exit 0
 
 mode=$(head -n1 "$flag" | tr -d '[:space:]')
 

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -21,6 +21,7 @@ function removeIfExists(filePath, label) {
 }
 
 removeIfExists(path.join(getClaudeDir(), '.ponytail-active'), 'mode flag');
+removeIfExists(path.join(getClaudeDir(), '.ponytail-hidden'), 'hidden-badge marker');
 removeIfExists(getConfigPath(), 'config file');
 
 const settingsPath = path.join(getClaudeDir(), 'settings.json');

--- a/tests/statusline-hide.test.js
+++ b/tests/statusline-hide.test.js
@@ -1,0 +1,82 @@
+#!/usr/bin/env node
+// #659 — hideStatus parity for the Claude Code statusline badge.
+//
+// getHideStatus() lived in the shared hooks/ponytail-config.js but only
+// pi-extension read it; the native Claude/Codex statusline scripts ignored it.
+// The fix: ponytail-activate.js drops a `.ponytail-hidden` marker next to the
+// mode flag when hideStatus resolves truthy, and the statusline scripts bail
+// when they see it. This test proves the whole round-trip via the real hook.
+
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const root = path.join(__dirname, '..');
+
+// The statusline script under test is bash; skip on hosts without it rather
+// than fail (Windows has its own ponytail-statusline.ps1, unit-tested elsewhere).
+const bashOk = spawnSync('bash', ['-c', 'true'], { encoding: 'utf8' }).status === 0;
+
+function activate(env) {
+  return spawnSync(process.execPath, [path.join(root, 'hooks', 'ponytail-activate.js')], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+}
+function statusline(env) {
+  return spawnSync('bash', [path.join(root, 'hooks', 'ponytail-statusline.sh')], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  });
+}
+
+// Keep the base env clean so activate takes the native-Claude branch.
+for (const k of ['CLAUDE_CONFIG_DIR', 'PLUGIN_DATA', 'COPILOT_PLUGIN_DATA',
+  'QODER_SESSION_ID', 'PONYTAIL_HIDE_STATUS', 'PONYTAIL_DEFAULT_MODE']) {
+  delete process.env[k];
+}
+
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-hide-'));
+process.on('exit', () => fs.rmSync(temp, { recursive: true, force: true }));
+
+const home = path.join(temp, 'home');
+fs.mkdirSync(path.join(home, '.claude'), { recursive: true });
+const hiddenMarker = path.join(home, '.claude', '.ponytail-hidden');
+const base = { HOME: home, USERPROFILE: home };
+
+// 1. Default: no hideStatus → no marker → badge shows.
+let r = activate(base);
+assert.equal(r.status, 0, r.stderr);
+assert.equal(fs.existsSync(hiddenMarker), false, 'no marker when hideStatus is off');
+if (bashOk) {
+  assert.match(statusline(base).stdout, /PONYTAIL/, 'badge must show by default');
+}
+
+// 2. PONYTAIL_HIDE_STATUS=1 → activate writes the marker → statusline prints nothing.
+r = activate({ ...base, PONYTAIL_HIDE_STATUS: '1' });
+assert.equal(r.status, 0, r.stderr);
+assert.equal(fs.existsSync(hiddenMarker), true, 'marker written when hideStatus is on');
+if (bashOk) {
+  assert.equal(statusline(base).stdout, '', 'badge must be hidden when marker is present');
+}
+
+// 3. config.hideStatus (no env var) is honored too — proves the shared resolver
+//    is used, not just the env shortcut.
+fs.mkdirSync(path.join(temp, 'cfg', 'ponytail'), { recursive: true });
+fs.writeFileSync(path.join(temp, 'cfg', 'ponytail', 'config.json'),
+  JSON.stringify({ hideStatus: true }));
+r = activate({ ...base, XDG_CONFIG_HOME: path.join(temp, 'cfg') });
+assert.equal(r.status, 0, r.stderr);
+assert.equal(fs.existsSync(hiddenMarker), true, 'config.hideStatus must write the marker');
+
+// 4. Toggling it back off rewrites state: marker cleared, badge returns.
+r = activate(base);
+assert.equal(r.status, 0, r.stderr);
+assert.equal(fs.existsSync(hiddenMarker), false, 'marker cleared when hideStatus is unset');
+if (bashOk) {
+  assert.match(statusline(base).stdout, /PONYTAIL/, 'badge returns after unsetting hideStatus');
+}
+
+console.log('statusline-hide.test.js: OK' + (bashOk ? '' : ' (bash-dependent asserts skipped)'));

--- a/tests/uninstall.test.js
+++ b/tests/uninstall.test.js
@@ -27,6 +27,10 @@ fs.mkdirSync(claudeDir, { recursive: true });
 const flagPath = path.join(claudeDir, '.ponytail-active');
 fs.writeFileSync(flagPath, 'full');
 
+// #659: uninstall must also clear the hide-badge marker activate may have written.
+const hiddenPath = path.join(claudeDir, '.ponytail-hidden');
+fs.writeFileSync(hiddenPath, '');
+
 const configDir = path.join(temp, 'config-home', 'ponytail');
 fs.mkdirSync(configDir, { recursive: true });
 const configPath = path.join(configDir, 'config.json');
@@ -46,6 +50,7 @@ const env = {
 let result = runUninstall(env);
 assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.existsSync(flagPath), false, 'mode flag must be removed');
+assert.equal(fs.existsSync(hiddenPath), false, 'hide-badge marker must be removed (#659)');
 assert.equal(fs.existsSync(configPath), false, 'config file must be removed');
 
 const settingsAfter = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));


### PR DESCRIPTION
## Summary

Fix #659

`getHideStatus()` (reading `PONYTAIL_HIDE_STATUS` / `config.hideStatus`) lives in the shared `hooks/ponytail-config.js`, but only `pi-extension` reads it. On native Claude Code / Codex the statusline scripts ignore it and always draw the `[PONYTAIL]` badge — the reporter set the variable and nothing happened.

The statusline scripts are shell / PowerShell that only `stat` `.ponytail-active`, so teaching them to parse config would be the wrong layer. Instead, following the reporter's suggestion:

- `ponytail-activate.js` already reads the config at SessionStart. It now resolves `getHideStatus()` once and drops (or clears) a sibling `.ponytail-hidden` marker via a new best-effort `setHidden()` in `ponytail-runtime.js` (written next to the mode flag, so `CLAUDE_CONFIG_DIR` stays consistent).
- `ponytail-statusline.sh` and `ponytail-statusline.ps1` bail out (`exit 0`, no output) when the marker is present.
- The marker is rewritten every session start, so unsetting the value brings the badge back on its own next session.
- `scripts/uninstall.js` removes the marker too.

No config parsing added to the per-render shell scripts (they still just `stat` files), no new dependency.

## Test verification (RED → GREEN)

New `tests/statusline-hide.test.js` drives the real hook: `activate` then `statusline.sh`, covering env var, `config.hideStatus`, and toggle-back-on. `tests/uninstall.test.js` gains an assertion that the marker is removed.

RED — prod reverted, new tests present:
```
not ok 1 - tests/statusline-hide.test.js
not ok 2 - tests/uninstall.test.js
# pass 0
# fail 2
```

GREEN — with the fix:
```
# tests 2
# pass 2
# fail 0
```

Full suite (`node --test tests/*.test.js pi-extension/test/*.test.js`), iso-or-better vs `main`:
```
main : # pass 106  # fail 1   (csv: correct pandas one-liner — pre-existing, pandas not installed)
fix  : # pass 107  # fail 1   (same pre-existing failure; +1 new passing test)
```
`node scripts/check-rule-copies.js` stays green.

## Files changed

| File | Change |
|------|--------|
| `hooks/ponytail-runtime.js` | add `.ponytail-hidden` marker + best-effort `setHidden()` |
| `hooks/ponytail-activate.js` | write/clear the marker from `getHideStatus()` at SessionStart |
| `hooks/ponytail-statusline.sh` | bail when the marker is present |
| `hooks/ponytail-statusline.ps1` | bail when the marker is present |
| `scripts/uninstall.js` | remove the marker on uninstall |
| `tests/statusline-hide.test.js` | new round-trip test |
| `tests/uninstall.test.js` | assert marker removed |
