### PR TITLE
fix: scope the machine-global mode flag by project so concurrent sessions stop clobbering each other (#662)

### DIFF
--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -4,6 +4,9 @@ const os = require('os');
 const { getClaudeDir, getConfigDir } = require('./ponytail-config');
 
 const STATE_FILE = '.ponytail-active';
+// Sidecar recording which project wrote the (machine-global) flag, so a
+// concurrent session in another repo can tell the flag isn't theirs (#662).
+const OWNER_FILE = '.ponytail-active.owner';
 
 // ponytail: VS Code Copilot never sets COPILOT_PLUGIN_DATA — it only injects
 // CLAUDE_PLUGIN_ROOT, pointed at an install path under .vscode/agent-plugins/
@@ -29,14 +32,52 @@ if (isCopilot) stateDir = process.env.COPILOT_PLUGIN_DATA || getClaudeDir();
 if (isQoder) stateDir = path.join(os.homedir(), '.qoder');
 
 const statePath = path.join(stateDir, STATE_FILE);
+const ownerPath = path.join(stateDir, OWNER_FILE);
+
+// Claude Code sets CLAUDE_PROJECT_DIR per session, so it identifies which
+// concurrent session owns the shared flag (#662). Empty when unknown (non-Claude
+// hosts) — callers then fall back to the legacy unscoped behavior.
+function projectDir() {
+  return (process.env.CLAUDE_PROJECT_DIR || '').trim();
+}
+
+function readOwner() {
+  try {
+    return fs.readFileSync(ownerPath, 'utf8').trim() || null;
+  } catch (e) {
+    return null;
+  }
+}
+
+// True only when this session's project wrote the current flag. Used to WHITELIST
+// injection (an explicit /ponytail opt-in in an otherwise-off repo), never to
+// suppress — so two sessions sharing a configured mode never disable each other.
+function ownedByCurrentProject() {
+  const dir = projectDir();
+  return Boolean(dir) && readOwner() === dir;
+}
 
 function setMode(mode) {
   fs.mkdirSync(path.dirname(statePath), { recursive: true });
   fs.writeFileSync(statePath, mode);
+  // Attribute the flag to this project. Unknown project → drop any stale owner so
+  // the flag stays unscoped (legacy behavior) rather than falsely attributed.
+  const dir = projectDir();
+  try {
+    if (dir) fs.writeFileSync(ownerPath, dir);
+    else fs.unlinkSync(ownerPath);
+  } catch (e) {}
 }
 
 function clearMode() {
+  // Never delete a flag owned by another concurrent session's repo — that would
+  // yank ponytail out from under it mid-session (#662). Unknown project (or no
+  // recorded owner) falls back to the legacy unconditional clear.
+  const dir = projectDir();
+  const owner = readOwner();
+  if (owner && dir && owner !== dir) return;
   try { fs.unlinkSync(statePath); } catch (e) {}
+  try { fs.unlinkSync(ownerPath); } catch (e) {}
 }
 
 // Live mode written by activate/mode-tracker. Absent flag = ponytail off.
@@ -94,6 +135,7 @@ module.exports = {
   isCodex,
   isCopilot,
   isQoder,
+  ownedByCurrentProject,
   readMode,
   setMode,
   writeHookOutput,

--- a/hooks/ponytail-subagent.js
+++ b/hooks/ponytail-subagent.js
@@ -11,12 +11,24 @@
 // "^general$" is exact. Unset means inject into every subagent, as before.
 
 const { getPonytailInstructions } = require('./ponytail-instructions');
-const { readMode, writeHookOutput } = require('./ponytail-runtime');
+const { ownedByCurrentProject, readMode, writeHookOutput } = require('./ponytail-runtime');
+const { getDefaultMode } = require('./ponytail-config');
 
 const mode = readMode();
 
 // Absent flag or off → ponytail isn't active; inject nothing.
 if (!mode || mode === 'off') {
+  process.exit(0);
+}
+
+// The .ponytail-active flag is machine-global, so a concurrent session in another
+// repo may have written an active mode into it (#662). If THIS session is
+// configured off (PONYTAIL_DEFAULT_MODE=off for this repo) and didn't set the flag
+// itself, ignore the foreign flag rather than leaking the ruleset into a repo that
+// opted out. Ownership only whitelists — an explicit /ponytail opt-in in an
+// off-default repo owns the flag and still injects — so it never suppresses a
+// legitimately-active session.
+if (getDefaultMode() === 'off' && !ownedByCurrentProject()) {
   process.exit(0);
 }
 

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -37,6 +37,9 @@ delete process.env.COPILOT_PLUGIN_DATA;
 // A leaked subagent matcher would scope the inject-into-every-subagent assertions.
 delete process.env.PONYTAIL_SUBAGENT_MATCHER;
 delete process.env.QODER_SESSION_ID;
+// The #662 flag-ownership tests set CLAUDE_PROJECT_DIR explicitly; a value leaked
+// from the outer session would make the ownership branch nondeterministic.
+delete process.env.CLAUDE_PROJECT_DIR;
 
 const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-hooks-'));
 // Runs on normal exit and on assertion-throw exit; force makes it idempotent.
@@ -352,6 +355,59 @@ result = run('ponytail-subagent.js', scopeEnv, '');
 assert.equal(result.status, 0, result.stderr);
 output = JSON.parse(result.stdout);
 assert.match(output.hookSpecificOutput.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);
+
+// #662: the .ponytail-active flag is machine-global. A .ponytail-active.owner
+// sidecar records which project wrote it, so a concurrent session in another repo
+// neither reads a foreign active flag when it opted out, nor deletes a flag it
+// doesn't own. CLAUDE_PROJECT_DIR identifies the reading/writing project.
+const raceHome = path.join(temp, 'race-home');
+const raceDir = path.join(raceHome, '.claude');
+const raceFlag = path.join(raceDir, '.ponytail-active');
+const raceOwner = path.join(raceDir, '.ponytail-active.owner');
+fs.mkdirSync(raceDir, { recursive: true });
+
+// Repo B is configured off; repo A (owner) wrote 'full' to the shared flag.
+// B's subagent must ignore the foreign flag and stay silent.
+fs.writeFileSync(raceFlag, 'full');
+fs.writeFileSync(raceOwner, '/repo/A');
+result = run('ponytail-subagent.js', {
+  HOME: raceHome, USERPROFILE: raceHome,
+  CLAUDE_PROJECT_DIR: '/repo/B', PONYTAIL_DEFAULT_MODE: 'off',
+});
+assert.equal(result.status, 0, result.stderr);
+assert.equal(result.stdout, '', 'an off repo must ignore another repo\'s active flag (#662)');
+
+// But an explicit /ponytail opt-in in that off repo owns the flag → still injects.
+fs.writeFileSync(raceOwner, '/repo/B');
+result = run('ponytail-subagent.js', {
+  HOME: raceHome, USERPROFILE: raceHome,
+  CLAUDE_PROJECT_DIR: '/repo/B', PONYTAIL_DEFAULT_MODE: 'off',
+});
+assert.equal(result.status, 0, result.stderr);
+output = JSON.parse(result.stdout);
+assert.match(output.hookSpecificOutput.additionalContext, /PONYTAIL MODE ACTIVE — level: full/,
+  'a self-owned opt-in flag still injects even when the repo default is off (#662)');
+
+// Owner-aware clearMode: an off session in repo B must NOT delete repo A's flag.
+fs.writeFileSync(raceFlag, 'full');
+fs.writeFileSync(raceOwner, '/repo/A');
+result = run('ponytail-activate.js', {
+  HOME: raceHome, USERPROFILE: raceHome,
+  CLAUDE_PROJECT_DIR: '/repo/B', PONYTAIL_DEFAULT_MODE: 'off',
+});
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.readFileSync(raceFlag, 'utf8'), 'full',
+  'an off session must not clear another repo\'s owned flag (#662)');
+
+// A same-repo off session (owns the flag) still clears it.
+fs.writeFileSync(raceOwner, '/repo/B');
+result = run('ponytail-activate.js', {
+  HOME: raceHome, USERPROFILE: raceHome,
+  CLAUDE_PROJECT_DIR: '/repo/B', PONYTAIL_DEFAULT_MODE: 'off',
+});
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.existsSync(raceFlag), false,
+  'a same-repo off session still clears its own flag (#662)');
 
 // Qoder: no SessionStart event, so UserPromptSubmit does double duty —
 // it activates the default mode on first prompt (writes flag), then injects


### PR DESCRIPTION
## Summary

Fix #662

Live ponytail mode lives in one machine-global `.ponytail-active` file, so two Claude Code sessions in different repos clobber each other:

1. Repo A configured `full` writes the flag; a concurrent repo B configured `off` then injects the ruleset into every subagent it spawns, despite being `off`.
2. Starting a session in repo B calls `clearMode()`, deleting the flag out from under repo A's still-running session — A's subagents silently stop receiving the ruleset.

**Fix — attribute the flag to its writer.** `setMode()` records the writing project in a `.ponytail-active.owner` sidecar keyed by `CLAUDE_PROJECT_DIR` (which Claude Code sets per session). Two changes use it:

- `clearMode()` refuses to delete a flag owned by a *different* project — fixes consequence 2.
- The `SubagentStart` hook ignores the flag only when this repo defaults `off` *and* doesn't own it — fixes consequence 1.

Ownership only **whitelists**: an explicit `/ponytail` opt-in in an otherwise-off repo owns the flag and still injects, so a legitimately-active session is never suppressed. Unknown project (non-Claude hosts, which use their own per-host state dir anyway) falls back to the legacy unscoped behavior, and runtime `/ponytail` toggles keep driving subagents unchanged.

## Test verification (RED → GREEN)

New assertions in `tests/hooks.test.js` cover: an off repo ignores a foreign flag, a self-owned opt-in still injects, `clearMode` won't delete a foreign flag, and a same-repo off session still clears its own.

RED — both hooks at unmodified `main`, new tests applied:

```
# AssertionError [ERR_ASSERTION]: an off repo must ignore another repo's active flag (#662)
#     at tests/hooks.test.js:378
# pass 0
# fail 1
```

GREEN — full suite with the fix:

```
# tests 107
# pass 106
# fail 1   (pre-existing: "csv: correct pandas one-liner" needs `pip install pandas`, which CI installs)
```

`node scripts/check-rule-copies.js` and `node scripts/check-versions.js` both pass.

## Files changed

| File | Change |
|------|--------|
| `hooks/ponytail-runtime.js` | `.ponytail-active.owner` sidecar; owner-aware `clearMode`; `ownedByCurrentProject` |
| `hooks/ponytail-subagent.js` | ignore a foreign flag when this repo defaults off and doesn't own it |
| `tests/hooks.test.js` | 4 ownership scenarios for concurrent cross-repo sessions |
