### PR TITLE
fix: silence hooks when Node is unavailable

### DIFF
--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" \"ponytail-activate.js\"",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
           }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" \"ponytail-subagent.js\"",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd\" \"ponytail-mode-tracker.js\"",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."
           }

--- a/hooks/run-hook.cmd
+++ b/hooks/run-hook.cmd
@@ -1,0 +1,10 @@
+: <<'CMDBLOCK'
+@echo off
+where node >nul 2>nul
+if errorlevel 1 exit /b 0
+node "%~dp0%~1"
+exit /b %ERRORLEVEL%
+CMDBLOCK
+
+command -v node >/dev/null 2>&1 || exit 0
+exec node "${0%/*}/$1"

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -1,9 +1,9 @@
 #!/usr/bin/env node
 // Regression test for issues #19 and #593: on Windows the lifecycle hooks run
 // via PowerShell, so the shared `command` field must be cross-platform (plain
-// `node`, no bash-only syntax). commandWindows is not part of the supported
+// polyglot launcher, no bash-only syntax). commandWindows is not part of the supported
 // hooks schema on the Claude.ai plugin marketplace validator, so it is omitted
-// — ${CLAUDE_PLUGIN_ROOT} expansion and `node` work everywhere.
+// — ${CLAUDE_PLUGIN_ROOT} expansion and the launcher work everywhere.
 //
 // The hook also has to point at a script that actually ships in hooks/.
 
@@ -11,7 +11,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
-const { spawn } = require('child_process');
+const { spawn, spawnSync } = require('child_process');
 
 const root = path.join(__dirname, '..');
 const HOOKS_JSON = 'hooks/claude-codex-hooks.json';
@@ -22,7 +22,7 @@ const HOST_PLUGIN_MANIFESTS = [
 // PowerShell 5.1 rejects these POSIX shell guards when a host runs `command`.
 const POSIX_GUARD_SYNTAX = /\bcommand\s+-v\b|&&|\|\||>\/dev\/null|2>&1/;
 // Pull the hooks/<script> a command launches, so we can check it exists.
-const HOOK_SCRIPT = /hooks[\\/]([\w.-]+\.(?:js|mjs|cjs|ps1|sh))/;
+const HOOK_SCRIPT = /hooks[\\/]([\w.-]+\.(?:js|mjs|cjs|cmd|ps1|sh))/;
 
 // Read inside each case so a missing/malformed file fails as a clean assertion,
 // not a load-time crash.
@@ -54,15 +54,26 @@ test('shared hook commands avoid POSIX-only guard syntax', () => {
   }
 });
 
+test('shared hooks exit quietly when node is unavailable (#708)', { skip: process.platform === 'win32' }, () => {
+  for (const hook of commandHooks()) {
+    const command = hook.command.replace('${CLAUDE_PLUGIN_ROOT}', root);
+    const result = spawnSync('/bin/sh', ['-c', command], {
+      env: { CLAUDE_PLUGIN_ROOT: root, PATH: '' },
+      encoding: 'utf8',
+    });
+    assert.equal(result.status, 0, `hook failed without node: ${result.stderr}`);
+    assert.equal(result.stderr, '', `hook reported an error without node: ${result.stderr}`);
+  }
+});
+
 // Issue #527 / #569: the shared `command` field must be shell-agnostic. `exec`
 // is a bash/zsh builtin with no PowerShell equivalent, but some hosts run
 // `command` through PowerShell on Windows regardless of the commandWindows
 // field — VS Code Copilot always does (it never reads commandWindows), and
 // native Claude Code launched from Git Bash was seen doing the same. `exec
 // node ...` then dies on its first token with CommandNotFoundException, so
-// every hook fails on Windows. Plain `node ...` runs natively in both bash and
-// PowerShell. The wrapper-process pileup that #461 originally used `exec` to
-// avoid is handled separately by each hook's stdin self-exit guard (#443/#477).
+// every hook fails on Windows. The polyglot launcher runs natively in both
+// POSIX shells and cmd.exe, and quietly skips optional hooks without Node.
 test('shared hook commands are shell-agnostic (no bash-only exec prefix)', () => {
   const commands = commandHooks()
     .map((h) => h.command)
@@ -70,7 +81,7 @@ test('shared hook commands are shell-agnostic (no bash-only exec prefix)', () =>
   assert.ok(commands.length > 0, 'expected at least one shared command entry');
   for (const cmd of commands) {
     assert.doesNotMatch(cmd, /(^|\s)exec\s/, `command must not use the bash-only 'exec' builtin (breaks under PowerShell): ${cmd}`);
-    assert.match(cmd, /^node\s+/, `command must invoke node directly so it runs in both bash and PowerShell: ${cmd}`);
+    assert.match(cmd, /run-hook\.cmd/, `command must use the cross-platform launcher: ${cmd}`);
     assert.doesNotMatch(cmd, /;\s*exit 0$/, `command must not leave a shell wrapper waiting on node: ${cmd}`);
   }
 });


### PR DESCRIPTION
Route Claude and Codex lifecycle hooks through a cross-platform launcher that exits quietly when Node is unavailable while preserving normal hook behavior.

## Test verification (RED → GREEN)

With the fix reverted, the new test fails (RED):

```
TAP version 13
# Subtest: shared hooks exit quietly when node is unavailable (\#708)
not ok 1 - shared hooks exit quietly when node is unavailable (\#708)
  ---
  duration_ms: 6.557026
  type: 'test'
  location: '/home/ousama/www/public/ousamabenyounes/ponytail/tests/hooks-windows.test.js:57:1'
  failureType: 'testCodeFailure'
  error: |-
    hook failed without node: /bin/sh: 1: node: not found
    
    
    127 !== 0
    
  code: 'ERR_ASSERTION'
  name: 'AssertionError'
  expected: 0
  actual: 127
  operator: 'strictEqual'
  stack: |-
    TestContext.<anonymous> (/home/ousama/www/public/ousamabenyounes/ponytail/tests/hooks-windows.test.js:64:12)
    Test.runInAsyncScope (node:async_hooks:214:14)
    Test.run (node:internal/test_runner/test:1047:25)
    Test.start (node:internal/test_runner/test:944:17)
    startSubtestAfterBootstrap (node:internal/test_runner/harness:296:17)
  ...
1..1
# tests 1
# suites 0
# pass 0
# fail 1
# cancelled 0
# skipped 0
# todo 0
# duration_ms 96.191256
```

With the fix applied, the test passes (GREEN):

```
TAP version 13
# Subtest: shared hooks exit quietly when node is unavailable (\#708)
ok 1 - shared hooks exit quietly when node is unavailable (\#708)
  ---
  duration_ms: 16.748734
  type: 'test'
  ...
1..1
# tests 1
# suites 0
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 115.226943
```

## Full local suite

Command: `node scripts/check-rule-copies.js && node scripts/check-versions.js && npm test`

```
# tests 23
# suites 0
# pass 23
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 130.213113

> ponytail-mcp@4.9.0 test
> node --test ./test/*.test.js

TAP version 13
# Subtest: resolveMode keeps valid intensities
ok 1 - resolveMode keeps valid intensities
  ---
  duration_ms: 2.766971
  type: 'test'
  ...
# Subtest: resolveMode falls back to a runtime intensity for off/unknown/empty
ok 2 - resolveMode falls back to a runtime intensity for off/unknown/empty
  ---
  duration_ms: 1.007104
  type: 'test'
  ...
# Subtest: buildInstructions returns the ruleset tagged with the resolved mode
ok 3 - buildInstructions returns the ruleset tagged with the resolved mode
  ---
  duration_ms: 0.933625
  type: 'test'
  ...
1..3
# tests 3
# suites 0
# pass 3
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 89.781739
```

Fix #708
