### PR TITLE
feat: support external policy and skill paths

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -20,7 +20,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 // The shared instruction builder is CommonJS; bridge to it from this ES module.
 const require = createRequire(import.meta.url);
 const { getPonytailInstructions } = require('../../hooks/ponytail-instructions');
-const { getDefaultMode, normalizePersistedMode } = require('../../hooks/ponytail-config');
+const { getDefaultMode, getSafeSkillPaths, normalizePersistedMode } = require('../../hooks/ponytail-config');
 const { parseCommandFile } = require('./ponytail-frontmatter.cjs');
 
 // OpenCode has no flag-file convention of its own; keep mode beside its config.
@@ -67,6 +67,9 @@ export default async ({ client } = {}) => {
       config.skills.paths = config.skills.paths || [];
       if (!config.skills.paths.includes(ponytailSkillsDir)) {
         config.skills.paths.push(ponytailSkillsDir);
+      }
+      for (const skillPath of getSafeSkillPaths()) {
+        if (!config.skills.paths.includes(skillPath)) config.skills.paths.push(skillPath);
       }
     },
 

--- a/README.md
+++ b/README.md
@@ -179,6 +179,29 @@ Injects the ruleset every turn at the active level; adds the `/ponytail` command
 
 The `./` path resolves against your project's `opencode.json`; to share one checkout across projects, point it at the absolute path of the `.mjs` instead (it finds its `hooks/` and `skills/` relative to its own file).
 
+### Custom policy and skills
+
+Ponytail can append an external Markdown policy to every active instruction injection and register additional skills without changing the bundled rules. Environment variables take precedence over the config file:
+
+```bash
+export PONYTAIL_POLICY_FILE="$HOME/.config/ponytail/team-policy.md"
+export PONYTAIL_SKILL_PATHS="$HOME/.config/ponytail/skills:/work/shared/ponytail-skills"
+```
+
+Equivalent `~/.config/ponytail/config.json` (or `$XDG_CONFIG_HOME/ponytail/config.json`):
+
+```json
+{
+  "policyFile": "/Users/me/.config/ponytail/team-policy.md",
+  "skillPaths": [
+    "/Users/me/.config/ponytail/skills",
+    "/work/shared/ponytail-skills"
+  ]
+}
+```
+
+Each skill path must exist and contain directories with `SKILL.md` files. Missing or invalid paths are ignored. Names matching Ponytail's built-in skills are ignored rather than overwritten. This feature is prompt and skill injection only; it does **not** enforce workspace execution blocking, sandboxing, or any other tool/runtime policy.
+
 ### Gemini CLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -188,6 +188,10 @@ export PONYTAIL_POLICY_FILE="$HOME/.config/ponytail/team-policy.md"
 export PONYTAIL_SKILL_PATHS="$HOME/.config/ponytail/skills:/work/shared/ponytail-skills"
 ```
 
+`POLICY.md` is trusted configuration: its contents are inserted into the
+agent's instructions on every active injection. Review it with the same care
+as any other instruction source.
+
 Equivalent `~/.config/ponytail/config.json` (or `$XDG_CONFIG_HOME/ponytail/config.json`):
 
 ```json

--- a/README.md
+++ b/README.md
@@ -202,6 +202,22 @@ Equivalent `~/.config/ponytail/config.json` (or `$XDG_CONFIG_HOME/ponytail/confi
 
 Each skill path must exist and contain directories with `SKILL.md` files. Missing or invalid paths are ignored. Names matching Ponytail's built-in skills are ignored rather than overwritten. This feature is prompt and skill injection only; it does **not** enforce workspace execution blocking, sandboxing, or any other tool/runtime policy.
 
+For hosts that only read project instructions (AGENTS.md, Cursor, Windsurf,
+Cline, Copilot editor, Kiro, Junie, Amp, Jules, Zed, CodeWhale, and
+Gemini/Antigravity), materialize the same opt-in policy explicitly:
+
+```bash
+npm run sync-policy -- --project /path/to/project
+```
+
+This preserves the surrounding files and writes a managed block to the static
+adapter files plus existing generated OpenClaw skills. Run the command again
+after every `POLICY.md` change; static adapters do not refresh automatically.
+It is a no-op without a readable configured policy, and `off` removes only the
+managed block. These hosts do not gain native skills or hooks from this command:
+use the documented plugin surfaces for Claude, Codex, Hermes, MCP, pi, OpenCode,
+Qoder, or Copilot CLI where available.
+
 ### Gemini CLI
 
 ```bash

--- a/__init__.py
+++ b/__init__.py
@@ -23,6 +23,7 @@ ROOT = Path(__file__).resolve().parent
 SKILLS_DIR = ROOT / "skills"
 PONYTAIL_SKILL = SKILLS_DIR / "ponytail" / "SKILL.md"
 REVIEW_SKILL = SKILLS_DIR / "ponytail-review" / "SKILL.md"
+BUILTIN_SKILL_NAMES = {"ponytail", *SKILL_COMMANDS}
 
 _current_mode = None
 
@@ -49,13 +50,43 @@ def _config_dir() -> Path:
     return Path.home() / ".config" / "ponytail"
 
 
+def _config() -> dict[str, Any]:
+    try:
+        data = json.loads((_config_dir() / "config.json").read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _custom_skill_files() -> list[tuple[str, Path]]:
+    configured = os.environ.get("PONYTAIL_SKILL_PATHS")
+    values = configured.split(os.pathsep) if configured is not None else _config().get("skillPaths", [])
+    if not isinstance(values, list):
+        return []
+    result: list[tuple[str, Path]] = []
+    for raw in values:
+        if not isinstance(raw, str) or not raw.strip():
+            continue
+        root = Path(raw).expanduser().resolve()
+        if not root.is_dir():
+            continue
+        candidates = [root] if (root / "SKILL.md").is_file() else [child for child in root.iterdir() if child.is_dir()]
+        for directory in candidates:
+            name = directory.name
+            skill_file = directory / "SKILL.md"
+            if name in BUILTIN_SKILL_NAMES or not skill_file.is_file():
+                continue
+            if not any(existing == name for existing, _ in result):
+                result.append((name, skill_file))
+    return result
+
+
 def _default_mode() -> str:
     env_mode = _normalize_config_mode(os.environ.get("PONYTAIL_DEFAULT_MODE"))
     if env_mode:
         return env_mode
     try:
-        data = json.loads((_config_dir() / "config.json").read_text(encoding="utf-8"))
-        file_mode = _normalize_config_mode(data.get("defaultMode"))
+        file_mode = _normalize_config_mode(_config().get("defaultMode"))
         if file_mode:
             return file_mode
     except Exception:
@@ -110,16 +141,29 @@ def build_injected_context(mode: str | None = None) -> str:
     if configured == "review":
         try:
             body = REVIEW_SKILL.read_text(encoding="utf-8")
-            return f"PONYTAIL MODE ACTIVE — level: review\n\n{_strip_frontmatter(body)}"
+            context = f"PONYTAIL MODE ACTIVE — level: review\n\n{_strip_frontmatter(body)}"
+            return _append_policy(context)
         except OSError:
-            return "PONYTAIL MODE ACTIVE — level: review. Review diffs for unnecessary complexity."
+            return _append_policy("PONYTAIL MODE ACTIVE — level: review. Review diffs for unnecessary complexity.")
 
     effective = _normalize_runtime_mode(configured) or DEFAULT_MODE
     try:
         body = PONYTAIL_SKILL.read_text(encoding="utf-8")
-        return f"PONYTAIL MODE ACTIVE — level: {effective}\n\n{_filter_skill_body_for_mode(body, effective)}"
+        return _append_policy(f"PONYTAIL MODE ACTIVE — level: {effective}\n\n{_filter_skill_body_for_mode(body, effective)}")
     except OSError:
-        return _fallback_instructions(effective)
+        return _append_policy(_fallback_instructions(effective))
+
+
+def _append_policy(context: str) -> str:
+    configured = os.environ.get("PONYTAIL_POLICY_FILE") or _config().get("policyFile")
+    if not isinstance(configured, str) or not configured.strip():
+        return context
+    policy = Path(configured).expanduser().resolve()
+    try:
+        text = policy.read_text(encoding="utf-8").strip()
+    except OSError:
+        return context
+    return f"{context}\n\n## External policy\n\n{text}" if text else context
 
 
 def _pre_llm_call(session_id: str = "", **_: Any) -> dict[str, str] | None:
@@ -198,6 +242,8 @@ def register(ctx: Any) -> None:
         skill_md = child / "SKILL.md"
         if child.is_dir() and skill_md.exists():
             ctx.register_skill(child.name, skill_md)
+    for name, skill_md in _custom_skill_files():
+        ctx.register_skill(name, skill_md)
 
     ctx.register_hook("pre_llm_call", _pre_llm_call)
     ctx.register_hook("pre_gateway_dispatch", rewrite_gateway_command)

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -31,6 +31,39 @@ to load in a given agent.
 | Zed | `AGENTS.md` | Auto-includes `AGENTS.md` from the worktree root as one of its default rule files for the Agent Panel. Instruction-tier. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 
+## External POLICY.md support
+
+`PONYTAIL_POLICY_FILE` (or `config.policyFile`) is opt-in. Claude/Codex hooks,
+OpenCode, pi, MCP, and Hermes read the configured Markdown at injection time;
+Qoder and Copilot CLI plugin paths retain their hook/plugin behavior and use the
+same shared policy resolver. Missing, empty, or unreadable policy files are
+ignored, and `off` emits no policy. Built-in skills cannot be replaced by custom
+skill paths.
+
+Instruction-only adapters have no host-native runtime registration surface, so
+they cannot consume a policy dynamically. Materialize the policy explicitly:
+
+```bash
+npm run sync-policy -- --project /path/to/project
+```
+
+The command writes a managed, replaceable block to `AGENTS.md`, Cursor,
+Windsurf, Cline, Copilot editor, Kiro, Junie, Qoder, Gemini/Antigravity
+(`.agents/rules`), and generated OpenClaw `SKILL.md` files. It preserves the
+surrounding instruction text and is safe to rerun. Run it again after every
+policy change; static adapters do not update automatically. With `off`, it
+removes only Ponytail's managed block and leaves built-in rules intact. With no
+readable policy configured, it is a no-op.
+
+Amp, Jules, Zed, and CodeWhale are covered through their shared `AGENTS.md`
+project-instruction surface. They have no supported host-native Ponytail skill
+registration here. Junie's `AGENTS.md`/guidelines-path behavior likewise remains
+instruction-tier only. OpenClaw is covered only through its existing generated
+skill-copy mechanism; Ponytail does not claim an OpenClaw host hook.
+
+See the complete adapter matrix below for the distinction between runtime
+plugin/hook support and static instruction support.
+
 ## Adapter Rule
 
 Keep adapters thin. When a host supports skills or hooks, point it at the

--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -64,8 +64,75 @@ function getConfigDir() {
   return path.join(os.homedir(), '.config', 'ponytail');
 }
 
+function readConfig() {
+  try {
+    const config = JSON.parse(fs.readFileSync(getConfigPath(), 'utf8').replace(/^\uFEFF/, ''));
+    return config && typeof config === 'object' && !Array.isArray(config) ? config : {};
+  } catch (_) {
+    return {};
+  }
+}
+
 function getConfigPath() {
   return path.join(getConfigDir(), 'config.json');
+}
+
+function getPolicyFile() {
+  const configured = process.env.PONYTAIL_POLICY_FILE || readConfig().policyFile;
+  if (typeof configured !== 'string' || !configured.trim()) return null;
+  const candidate = path.resolve(configured.trim());
+  try {
+    return fs.statSync(candidate).isFile() ? candidate : null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function getSkillPaths() {
+  const configured = process.env.PONYTAIL_SKILL_PATHS !== undefined
+    ? process.env.PONYTAIL_SKILL_PATHS.split(path.delimiter)
+    : readConfig().skillPaths;
+  if (!Array.isArray(configured)) return [];
+  return configured
+    .filter((value) => typeof value === 'string' && value.trim())
+    .map((value) => path.resolve(value.trim()))
+    .filter((value, index, values) => values.indexOf(value) === index)
+    .filter((value) => {
+      try { return fs.statSync(value).isDirectory(); } catch (_) { return false; }
+    });
+}
+
+const BUILTIN_SKILL_NAMES = new Set(['ponytail', 'ponytail-review', 'ponytail-audit', 'ponytail-debt', 'ponytail-gain', 'ponytail-help']);
+
+function getCustomSkillFiles() {
+  const files = [];
+  for (const root of getSkillPaths()) {
+    const direct = path.join(root, 'SKILL.md');
+    const candidates = fs.existsSync(direct) ? [root] : fs.readdirSync(root, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => path.join(root, entry.name));
+    for (const directory of candidates) {
+      const name = path.basename(directory);
+      const skillFile = path.join(directory, 'SKILL.md');
+      if (BUILTIN_SKILL_NAMES.has(name)) continue;
+      try {
+        if (fs.statSync(skillFile).isFile()) files.push({ name, path: skillFile });
+      } catch (_) {}
+    }
+  }
+  return files.filter((entry, index, values) => values.findIndex((item) => item.name === entry.name) === index);
+}
+
+function getSafeSkillPaths() {
+  return getSkillPaths().filter((root) => {
+    if (fs.existsSync(path.join(root, 'SKILL.md'))) return !BUILTIN_SKILL_NAMES.has(path.basename(root));
+    try {
+      return !fs.readdirSync(root, { withFileTypes: true })
+        .some((entry) => entry.isDirectory() && BUILTIN_SKILL_NAMES.has(entry.name));
+    } catch (_) {
+      return false;
+    }
+  });
 }
 
 function getClaudeDir() {
@@ -157,7 +224,11 @@ module.exports = {
   getDefaultMode,
   getConfigDir,
   getConfigPath,
+  getCustomSkillFiles,
   getClaudeDir,
+  getPolicyFile,
+  getSkillPaths,
+  getSafeSkillPaths,
   getHideStatus,
   getQuietStartup,
   isShellSafe,

--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -124,15 +124,21 @@ function getCustomSkillFiles() {
 }
 
 function getSafeSkillPaths() {
-  return getSkillPaths().filter((root) => {
-    if (fs.existsSync(path.join(root, 'SKILL.md'))) return !BUILTIN_SKILL_NAMES.has(path.basename(root));
-    try {
-      return !fs.readdirSync(root, { withFileTypes: true })
-        .some((entry) => entry.isDirectory() && BUILTIN_SKILL_NAMES.has(entry.name));
-    } catch (_) {
-      return false;
+  const paths = [];
+  for (const root of getSkillPaths()) {
+    if (fs.existsSync(path.join(root, 'SKILL.md'))) {
+      if (!BUILTIN_SKILL_NAMES.has(path.basename(root))) paths.push(root);
+      continue;
     }
-  });
+    try {
+      for (const entry of fs.readdirSync(root, { withFileTypes: true })) {
+        if (!entry.isDirectory() || BUILTIN_SKILL_NAMES.has(entry.name)) continue;
+        const directory = path.join(root, entry.name);
+        if (fs.statSync(path.join(directory, 'SKILL.md')).isFile()) paths.push(directory);
+      }
+    } catch (_) {}
+  }
+  return paths;
 }
 
 function getClaudeDir() {

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -3,7 +3,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { DEFAULT_MODE, normalizeMode, normalizePersistedMode } = require('./ponytail-config');
+const { DEFAULT_MODE, getPolicyFile, normalizeMode, normalizePersistedMode } = require('./ponytail-config');
 
 const INDEPENDENT_MODES = new Set(['review']);
 const SKILL_PATH = path.join(__dirname, '..', 'skills', 'ponytail', 'SKILL.md');
@@ -78,16 +78,27 @@ function getPonytailInstructions(mode) {
   const configuredMode = normalizePersistedMode(mode) || DEFAULT_MODE;
 
   if (INDEPENDENT_MODES.has(configuredMode)) {
-    return 'PONYTAIL MODE ACTIVE — level: ' + configuredMode + '. Behavior defined by /ponytail-' + configuredMode + ' skill.';
+    return appendPolicy('PONYTAIL MODE ACTIVE — level: ' + configuredMode + '. Behavior defined by /ponytail-' + configuredMode + ' skill.');
   }
 
   const effectiveMode = normalizeMode(configuredMode) || DEFAULT_MODE;
 
   try {
-    return 'PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' +
-      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode);
+    return appendPolicy('PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' +
+      filterSkillBodyForMode(fs.readFileSync(SKILL_PATH, 'utf8'), effectiveMode));
   } catch (e) {
-    return getFallbackInstructions(effectiveMode);
+    return appendPolicy(getFallbackInstructions(effectiveMode));
+  }
+}
+
+function appendPolicy(instructions) {
+  const policyFile = getPolicyFile();
+  if (!policyFile) return instructions;
+  try {
+    const policy = fs.readFileSync(policyFile, 'utf8').trim();
+    return policy ? instructions + '\n\n## External policy\n\n' + policy : instructions;
+  } catch (_) {
+    return instructions;
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "files": [
     "AGENTS.md",
     "hooks/",
+    "scripts/sync-policy.js",
     "skills/",
     ".opencode/",
     ".qoder/",
@@ -34,7 +35,8 @@
     "LICENSE"
   ],
   "scripts": {
-    "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix ponytail-mcp"
+    "test": "node --test tests/*.test.js && npm test --prefix pi-extension && npm test --prefix ponytail-mcp",
+    "sync-policy": "node scripts/sync-policy.js"
   },
   "pi": {
     "extensions": ["./pi-extension/index.js"],

--- a/scripts/sync-policy.js
+++ b/scripts/sync-policy.js
@@ -81,7 +81,7 @@ function hasSymlinkComponent(root, destination) {
 }
 
 function isPathLike(value) {
-  return path.isAbsolute(value) || value.startsWith('~/') || value.startsWith('./') || value.startsWith('../') || value.includes('/') || value.includes('\\') || value.endsWith('.md');
+  return path.isAbsolute(value) || value.startsWith('~/') || value.startsWith('./') || value.startsWith('../') || value.endsWith('.md');
 }
 
 function normalizeExplicitPolicy(policy) {

--- a/scripts/sync-policy.js
+++ b/scripts/sync-policy.js
@@ -1,0 +1,121 @@
+#!/usr/bin/env node
+// Materialize the configured external policy into instruction-only adapters.
+// Runtime hook/plugin consumers read the policy on every turn; static adapters
+// need this explicit sync after a policy change.
+
+const fs = require('fs');
+const path = require('path');
+const {
+  getDefaultMode,
+  getPolicyFile,
+  normalizeMode,
+} = require('../hooks/ponytail-config');
+
+const START = '<!-- ponytail:external-policy:start -->';
+const END = '<!-- ponytail:external-policy:end -->';
+
+// Hosts with native skill/hook registration are intentionally absent: their
+// runtime adapters already consume POLICY.md. These are instruction-only or
+// generated/copy surfaces.
+const STATIC_ADAPTERS = [
+  ['AGENTS.md', 'AGENTS.md'],
+  ['.cursor/rules/ponytail.mdc', '.cursor/rules/ponytail.mdc'],
+  ['.windsurf/rules/ponytail.md', '.windsurf/rules/ponytail.md'],
+  ['.clinerules/ponytail.md', '.clinerules/ponytail.md'],
+  ['.github/copilot-instructions.md', '.github/copilot-instructions.md'],
+  ['.kiro/steering/ponytail.md', '.kiro/steering/ponytail.md'],
+  ['.junie/guidelines.md', 'AGENTS.md'],
+  ['.agents/rules/ponytail.md', '.agents/rules/ponytail.md'],
+  ['.qoder/rules/ponytail.md', '.qoder/rules/ponytail.md'],
+];
+
+function readPolicy() {
+  const file = getPolicyFile();
+  if (!file) return null;
+  try {
+    const text = fs.readFileSync(file, 'utf8').trim();
+    return text || null;
+  } catch (_) {
+    return null;
+  }
+}
+
+function removeManagedPolicy(text) {
+  const escapedStart = START.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  const escapedEnd = END.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  return text.replace(new RegExp(`\\n?${escapedStart}[\\s\\S]*?${escapedEnd}\\n?`, 'g'), '').replace(/\n{3,}/g, '\n\n');
+}
+
+function addManagedPolicy(text, policy) {
+  const base = removeManagedPolicy(String(text || '').replace(/\r\n/g, '\n')).trimEnd();
+  if (!policy) return base + (base ? '\n' : '');
+  return `${base}\n\n${START}\n## External policy\n\n${policy}\n${END}\n`;
+}
+
+function sourceFor(root, source) {
+  const file = path.join(__dirname, '..', source);
+  return fs.readFileSync(file, 'utf8');
+}
+
+function syncPolicy({ project = process.cwd(), policy = readPolicy(), mode = getDefaultMode() } = {}) {
+  const root = path.resolve(project);
+  const configuredPolicy = typeof policy === 'string' && fs.existsSync(policy)
+    ? fs.readFileSync(policy, 'utf8').trim()
+    : policy;
+  const policyText = typeof configuredPolicy === 'string' ? configuredPolicy.trim() : null;
+  const effectiveMode = normalizeMode(mode) || 'full';
+  const results = [];
+  // Missing policy is a no-op. This keeps the feature opt-in and avoids
+  // materializing adapter files merely because a user ran the command.
+  if (!policyText && effectiveMode !== 'off') return { policy: false, mode: effectiveMode, files: results };
+  for (const [target, source] of STATIC_ADAPTERS) {
+    const destination = path.join(root, target);
+    const exists = fs.existsSync(destination);
+    if (!exists && effectiveMode === 'off') continue;
+    let original;
+    try { original = fs.readFileSync(destination, 'utf8'); } catch (_) { original = sourceFor(root, source); }
+    const rendered = addManagedPolicy(original, effectiveMode === 'off' ? null : policyText);
+    if (rendered !== original.replace(/\r\n/g, '\n')) {
+      fs.mkdirSync(path.dirname(destination), { recursive: true });
+      fs.writeFileSync(destination, rendered, 'utf8');
+      results.push(target);
+    }
+  }
+
+  // OpenClaw's existing generator produces one SKILL.md per skill. Keep those
+  // generated files usable by appending the same managed block, without
+  // altering canonical skills/ or pretending OpenClaw has a host hook API.
+  const openclaw = path.join(root, '.openclaw', 'skills');
+  if (fs.existsSync(openclaw)) {
+    for (const entry of fs.readdirSync(openclaw, { withFileTypes: true })) {
+      if (!entry.isDirectory()) continue;
+      const destination = path.join(openclaw, entry.name, 'SKILL.md');
+      if (!fs.existsSync(destination)) continue;
+      const original = fs.readFileSync(destination, 'utf8');
+      const rendered = addManagedPolicy(original, effectiveMode === 'off' ? null : policyText);
+      if (rendered !== original.replace(/\r\n/g, '\n')) {
+        fs.writeFileSync(destination, rendered, 'utf8');
+        results.push(path.relative(root, destination).replace(/\\/g, '/'));
+      }
+    }
+  }
+  return { policy: Boolean(policy), mode: effectiveMode, files: results };
+}
+
+module.exports = { END, START, STATIC_ADAPTERS, addManagedPolicy, removeManagedPolicy, readPolicy, syncPolicy };
+
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  const projectIndex = args.indexOf('--project');
+  const project = projectIndex >= 0 ? args[projectIndex + 1] : process.cwd();
+  if (projectIndex >= 0 && (!project || project.startsWith('--'))) {
+    console.error('Usage: npm run sync-policy -- [--project PATH]');
+    process.exit(2);
+  }
+  const result = syncPolicy({ project });
+  if (!result.policy && result.mode !== 'off') {
+    console.error('No readable policy configured; nothing changed. Set PONYTAIL_POLICY_FILE or config.policyFile.');
+    process.exit(1);
+  }
+  console.log(`${result.mode === 'off' ? 'Removed' : 'Synced'} external policy in ${result.files.length} static adapter file(s).`);
+}

--- a/scripts/sync-policy.js
+++ b/scripts/sync-policy.js
@@ -49,7 +49,10 @@ function removeManagedPolicy(text) {
 function addManagedPolicy(text, policy) {
   const base = removeManagedPolicy(String(text || '').replace(/\r\n/g, '\n')).trimEnd();
   if (!policy) return base + (base ? '\n' : '');
-  return `${base}\n\n${START}\n## External policy\n\n${policy}\n${END}\n`;
+  const safePolicy = String(policy)
+    .split(START).join(`${START}&#45;&#45;>`)
+    .split(END).join(`${END.slice(0, -3)}&#45;&#45;>`);
+  return `${base}\n\n${START}\n## External policy\n\n${safePolicy}\n${END}\n`;
 }
 
 function sourceFor(root, source) {
@@ -57,11 +60,41 @@ function sourceFor(root, source) {
   return fs.readFileSync(file, 'utf8');
 }
 
+function hasSymlinkComponent(root, destination) {
+  let current = root;
+  try {
+    if (fs.lstatSync(current).isSymbolicLink()) return true;
+  } catch (_) {
+    return true;
+  }
+  const relative = path.relative(root, path.dirname(destination));
+  for (const component of relative ? relative.split(path.sep) : []) {
+    current = path.join(current, component);
+    try {
+      if (fs.lstatSync(current).isSymbolicLink()) return true;
+    } catch (error) {
+      if (error.code !== 'ENOENT') return true;
+      break;
+    }
+  }
+  try { return fs.lstatSync(destination).isSymbolicLink(); } catch (error) { return error.code !== 'ENOENT'; }
+}
+
+function isPathLike(value) {
+  return path.isAbsolute(value) || value.startsWith('~/') || value.startsWith('./') || value.startsWith('../') || value.includes('/') || value.includes('\\') || value.endsWith('.md');
+}
+
+function normalizeExplicitPolicy(policy) {
+  if (typeof policy !== 'string') return policy;
+  if (fs.existsSync(policy)) {
+    try { return fs.readFileSync(policy, 'utf8').trim(); } catch (_) { return null; }
+  }
+  return isPathLike(policy) ? null : policy;
+}
+
 function syncPolicy({ project = process.cwd(), policy = readPolicy(), mode = getDefaultMode() } = {}) {
   const root = path.resolve(project);
-  const configuredPolicy = typeof policy === 'string' && fs.existsSync(policy)
-    ? fs.readFileSync(policy, 'utf8').trim()
-    : policy;
+  const configuredPolicy = normalizeExplicitPolicy(policy);
   const policyText = typeof configuredPolicy === 'string' ? configuredPolicy.trim() : null;
   const effectiveMode = normalizeMode(mode) || 'full';
   const results = [];
@@ -72,11 +105,13 @@ function syncPolicy({ project = process.cwd(), policy = readPolicy(), mode = get
     const destination = path.join(root, target);
     const exists = fs.existsSync(destination);
     if (!exists && effectiveMode === 'off') continue;
+    if (hasSymlinkComponent(root, destination)) continue;
     let original;
     try { original = fs.readFileSync(destination, 'utf8'); } catch (_) { original = sourceFor(root, source); }
     const rendered = addManagedPolicy(original, effectiveMode === 'off' ? null : policyText);
     if (rendered !== original.replace(/\r\n/g, '\n')) {
       fs.mkdirSync(path.dirname(destination), { recursive: true });
+      if (hasSymlinkComponent(root, destination)) continue;
       fs.writeFileSync(destination, rendered, 'utf8');
       results.push(target);
     }
@@ -91,9 +126,11 @@ function syncPolicy({ project = process.cwd(), policy = readPolicy(), mode = get
       if (!entry.isDirectory()) continue;
       const destination = path.join(openclaw, entry.name, 'SKILL.md');
       if (!fs.existsSync(destination)) continue;
+      if (hasSymlinkComponent(root, destination)) continue;
       const original = fs.readFileSync(destination, 'utf8');
       const rendered = addManagedPolicy(original, effectiveMode === 'off' ? null : policyText);
       if (rendered !== original.replace(/\r\n/g, '\n')) {
+        if (hasSymlinkComponent(root, destination)) continue;
         fs.writeFileSync(destination, rendered, 'utf8');
         results.push(path.relative(root, destination).replace(/\\/g, '/'));
       }

--- a/tests/custom-policy-skills.test.js
+++ b/tests/custom-policy-skills.test.js
@@ -1,0 +1,74 @@
+#!/usr/bin/env node
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const config = require('../hooks/ponytail-config');
+const { getPonytailInstructions } = require('../hooks/ponytail-instructions');
+
+function withEnv(values, fn) {
+  const previous = {};
+  for (const [key, value] of Object.entries(values)) {
+    previous[key] = process.env[key];
+    if (value === undefined) delete process.env[key];
+    else process.env[key] = value;
+  }
+  try { return fn(); } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
+
+test('external policy is appended from env and config fallback', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-policy-'));
+  const policy = path.join(tmp, 'policy.md');
+  fs.writeFileSync(policy, '# Team policy\nUse the existing logger.\n');
+  fs.mkdirSync(path.join(tmp, 'ponytail'));
+  fs.writeFileSync(path.join(tmp, 'ponytail', 'config.json'), JSON.stringify({ policyFile: policy }));
+
+  withEnv({ XDG_CONFIG_HOME: tmp, PONYTAIL_POLICY_FILE: undefined }, () => {
+    assert.match(getPonytailInstructions('full'), /# Team policy/);
+  });
+  withEnv({ XDG_CONFIG_HOME: tmp, PONYTAIL_POLICY_FILE: policy }, () => {
+    assert.match(getPonytailInstructions('full'), /Use the existing logger/);
+  });
+});
+
+test('missing, invalid, and non-markdown policy paths are ignored', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-policy-'));
+  withEnv({ XDG_CONFIG_HOME: tmp, PONYTAIL_POLICY_FILE: path.join(tmp, 'missing.md') }, () => {
+    const context = getPonytailInstructions('full');
+    assert.doesNotMatch(context, /Team policy/);
+  });
+  fs.mkdirSync(path.join(tmp, 'ponytail'));
+  fs.writeFileSync(path.join(tmp, 'ponytail', 'config.json'), '{invalid');
+  withEnv({ XDG_CONFIG_HOME: tmp, PONYTAIL_POLICY_FILE: undefined }, () => {
+    assert.doesNotMatch(getPonytailInstructions('full'), /Team policy/);
+  });
+});
+
+test('skill paths only return existing directories and exclude built-in names', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-skills-'));
+  const custom = path.join(tmp, 'custom');
+  fs.mkdirSync(path.join(custom, 'team-review'), { recursive: true });
+  fs.writeFileSync(path.join(custom, 'team-review', 'SKILL.md'), '# Team review');
+  fs.mkdirSync(path.join(custom, 'ponytail'), { recursive: true });
+  fs.writeFileSync(path.join(custom, 'ponytail', 'SKILL.md'), '# Should not replace built-in');
+
+  withEnv({ PONYTAIL_SKILL_PATHS: [custom, path.join(tmp, 'missing')].join(path.delimiter), XDG_CONFIG_HOME: tmp }, () => {
+    assert.deepEqual(config.getCustomSkillFiles().map(({ name }) => name), ['team-review']);
+  });
+});
+
+test('custom policy is present on every non-off injection', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-policy-'));
+  const policy = path.join(tmp, 'policy.md');
+  fs.writeFileSync(policy, 'POLICY-EVERY-TURN');
+  withEnv({ PONYTAIL_POLICY_FILE: policy }, () => {
+    assert.match(getPonytailInstructions('review'), /POLICY-EVERY-TURN/);
+  });
+});

--- a/tests/hermes-plugin.test.js
+++ b/tests/hermes-plugin.test.js
@@ -190,6 +190,32 @@ print(json.dumps({'message': message, 'context': injected['context']}))
   assert.match(data.context, /PONYTAIL MODE ACTIVE — level: ultra/);
 });
 
+test('Hermes registers custom skills and injects configured policy', () => {
+  const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-custom-'));
+  const skillDir = path.join(tmp, 'team-review');
+  const policyFile = path.join(tmp, 'policy.md');
+  fs.mkdirSync(skillDir);
+  fs.writeFileSync(path.join(skillDir, 'SKILL.md'), '# Team review');
+  fs.writeFileSync(policyFile, 'TEAM-POLICY');
+  const output = python(String.raw`
+import importlib.util, json
+spec = importlib.util.spec_from_file_location('ponytail_hermes_plugin', '__init__.py')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+class Ctx:
+    def __init__(self): self.skills = []
+    def register_skill(self, name, path): self.skills.append(name)
+    def register_hook(self, name, handler): pass
+    def register_command(self, name, handler, description='', args_hint=''): pass
+ctx = Ctx()
+mod.register(ctx)
+print(json.dumps({'skills': ctx.skills, 'context': mod.build_injected_context('full')}))
+`, { PONYTAIL_SKILL_PATHS: tmp, PONYTAIL_POLICY_FILE: policyFile });
+  const data = JSON.parse(output);
+  assert.ok(data.skills.includes('team-review'));
+  assert.match(data.context, /TEAM-POLICY/);
+});
+
 test('Hermes gateway rewrite respects slash access denial', () => {
   const output = python(String.raw`
 import importlib.util, json

--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -101,4 +101,21 @@ test('parseCommandFile returns null when there is no frontmatter', () => {
   assert.equal(parseCommandFile(bare), null);
 });
 
+test('config registers valid custom skills beside a built-in skill', async () => {
+  const root = path.join(tmp, 'custom-skills');
+  fs.mkdirSync(path.join(root, 'ponytail'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'ponytail', 'SKILL.md'), '# Built-in name');
+  fs.mkdirSync(path.join(root, 'team-review'), { recursive: true });
+  fs.writeFileSync(path.join(root, 'team-review', 'SKILL.md'), '# Custom skill');
+  process.env.PONYTAIL_SKILL_PATHS = root;
+
+  const hooks = await loadPlugin({});
+  const config = { skills: { paths: [] } };
+  await hooks.config(config);
+
+  assert.ok(config.skills.paths.includes(path.join(root, 'team-review')));
+  assert.ok(!config.skills.paths.includes(root));
+  delete process.env.PONYTAIL_SKILL_PATHS;
+});
+
 test.after(() => fs.rmSync(tmp, { recursive: true, force: true }));

--- a/tests/sync-policy.test.js
+++ b/tests/sync-policy.test.js
@@ -52,3 +52,38 @@ test('off mode removes managed policy but preserves built-in instructions', () =
   assert.match(after, /lazy senior developer/i);
   assert.doesNotMatch(after, new RegExp(START));
 });
+
+test('does not follow an existing symlink destination', () => {
+  const project = temp();
+  const outside = path.join(temp(), 'outside.md');
+  fs.writeFileSync(outside, 'outside instructions\n');
+  fs.symlinkSync(outside, path.join(project, 'AGENTS.md'));
+
+  const result = syncPolicy({ project, policy: 'Do not modify outside.' });
+
+  assert.equal(result.files.includes('AGENTS.md'), false);
+  assert.equal(fs.readFileSync(outside, 'utf8'), 'outside instructions\n');
+  assert.equal(fs.readlinkSync(path.join(project, 'AGENTS.md')), outside);
+});
+
+test('policy containing the end marker remains idempotent', () => {
+  const project = temp();
+  const policy = `Keep this text ${END} exactly in the policy.`;
+
+  syncPolicy({ project, policy });
+  const before = new Map(STATIC_ADAPTERS.map(([target]) => [target, fs.readFileSync(path.join(project, target), 'utf8')]));
+  const second = syncPolicy({ project, policy });
+
+  assert.deepEqual(second.files, []);
+  for (const [target, text] of before) assert.equal(fs.readFileSync(path.join(project, target), 'utf8'), text);
+});
+
+test('missing path-like explicit policy is treated as unreadable', () => {
+  const project = temp();
+
+  const result = syncPolicy({ project, policy: '/missing/path/POLICY.md' });
+
+  assert.equal(result.policy, false);
+  assert.deepEqual(result.files, []);
+  assert.equal(fs.existsSync(path.join(project, 'AGENTS.md')), false);
+});

--- a/tests/sync-policy.test.js
+++ b/tests/sync-policy.test.js
@@ -1,0 +1,54 @@
+#!/usr/bin/env node
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const { STATIC_ADAPTERS, START, END, syncPolicy } = require('../scripts/sync-policy');
+
+function temp() { return fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-sync-')); }
+
+test('syncs configured policy to every static adapter and generated OpenClaw skill', () => {
+  const project = temp();
+  const policy = path.join(project, 'POLICY.md');
+  fs.writeFileSync(policy, '# Team policy\nUse the existing logger.\n');
+  const openclaw = path.join(project, '.openclaw', 'skills', 'ponytail');
+  fs.mkdirSync(openclaw, { recursive: true });
+  fs.writeFileSync(path.join(openclaw, 'SKILL.md'), '---\nname: ponytail\n---\n\nRules.\n');
+
+  const result = syncPolicy({ project, policy });
+  assert.equal(result.files.length, STATIC_ADAPTERS.length + 1);
+  for (const [target] of STATIC_ADAPTERS) {
+    const text = fs.readFileSync(path.join(project, target), 'utf8');
+    assert.match(text, /Use the existing logger/);
+    assert.equal((text.match(new RegExp(START, 'g')) || []).length, 1);
+    assert.equal((text.match(new RegExp(END, 'g')) || []).length, 1);
+  }
+  assert.match(fs.readFileSync(path.join(openclaw, 'SKILL.md'), 'utf8'), /# Team policy/);
+
+  const second = syncPolicy({ project, policy });
+  assert.deepEqual(second.files, []);
+});
+
+test('missing policy is a no-op and does not create static adapter files', () => {
+  const project = temp();
+  const result = syncPolicy({ project, policy: null });
+  assert.deepEqual(result.files, []);
+  assert.equal(fs.existsSync(path.join(project, 'AGENTS.md')), false);
+});
+
+test('off mode removes managed policy but preserves built-in instructions', () => {
+  const project = temp();
+  const policy = path.join(project, 'POLICY.md');
+  fs.writeFileSync(policy, 'Do not change the API.');
+  syncPolicy({ project, policy });
+  const before = fs.readFileSync(path.join(project, 'AGENTS.md'), 'utf8');
+  assert.match(before, /Do not change the API/);
+  const result = syncPolicy({ project, policy: null, mode: 'off' });
+  assert.ok(result.files.length > 0);
+  const after = fs.readFileSync(path.join(project, 'AGENTS.md'), 'utf8');
+  assert.doesNotMatch(after, /Do not change the API/);
+  assert.match(after, /lazy senior developer/i);
+  assert.doesNotMatch(after, new RegExp(START));
+});

--- a/tests/sync-policy.test.js
+++ b/tests/sync-policy.test.js
@@ -87,3 +87,13 @@ test('missing path-like explicit policy is treated as unreadable', () => {
   assert.deepEqual(result.files, []);
   assert.equal(fs.existsSync(path.join(project, 'AGENTS.md')), false);
 });
+
+test('explicit policy text containing a workspace path is preserved', () => {
+  const project = temp();
+  const policy = '모든 작업은 /Users/cinos81/works 아래에서 수행한다.';
+
+  const result = syncPolicy({ project, policy });
+
+  assert.ok(result.files.length > 0);
+  assert.match(fs.readFileSync(path.join(project, 'AGENTS.md'), 'utf8'), /\/Users\/cinos81\/works/);
+});


### PR DESCRIPTION
## Summary

- Add optional external `POLICY.md` loading via `PONYTAIL_POLICY_FILE` or `config.json`.
- Add optional custom skill paths via `PONYTAIL_SKILL_PATHS` or `config.json`, while protecting built-in skill names.
- Apply the policy through shared runtime adapters, Hermes, OpenCode, and the existing host-specific paths.
- Add `npm run sync-policy -- --project PATH` for instruction-only/static adapters; rerun it after policy changes.
- Preserve existing behavior when no external policy or skill paths are configured.

## Scope and trust boundary

This PR extends prompt/context and skill injection only. It does not provide a filesystem sandbox, terminal-command blocker, or deterministic execution policy.

`POLICY.md` is trusted configuration. Its contents are inserted into agent instructions and can influence agent behavior; users should only configure files they trust.

Static adapters require an explicit synchronization run after policy changes. Hosts without a native skill registration surface do not receive native custom-skill registration; their documented instruction-file behavior remains unchanged.

## Verification

Passed:

- Focused policy, adapter, Hermes, OpenCode, and synchronizer tests: **29/29**
- JavaScript syntax checks
- Python compilation check for `__init__.py`
- Rule-copy consistency check
- `git diff --check`
- OpenCode 1.18.15 E2E with `openai/gpt-5.6-luna`: actual response ended with `야옹`
- Independent security and logic review: passed

Full suite:

- `npm test`: **94 passed, 1 failed**
- The only failure is the pre-existing unrelated `csv: correct pandas one-liner passes` case in `tests/correctness.test.js`; it reproduces independently and is outside the changed paths.

No secrets or credentials are included.
