### PR TITLE
Selftest wipes PONYTAIL_PLUGIN_DIR before the run can use it

### DIFF
--- a/benchmarks/agentic/run.py
+++ b/benchmarks/agentic/run.py
@@ -207,11 +207,15 @@ def _selftest_plugin_dir():
     fails loudly (sys.exit) instead of silently passing a non-existent path to --plugin-dir."""
     fails = 0
     sentinel = "/tmp/ponytail-selftest-plugin-dir"
+    prior = os.environ.get("PONYTAIL_PLUGIN_DIR")
     os.environ["PONYTAIL_PLUGIN_DIR"] = sentinel
     try:
         ok_env = _plugin_dir("ponytail") == sentinel
     finally:
-        del os.environ["PONYTAIL_PLUGIN_DIR"]
+        if prior is None:
+            del os.environ["PONYTAIL_PLUGIN_DIR"]
+        else:
+            os.environ["PONYTAIL_PLUGIN_DIR"] = prior   # restore the caller's override
     print(f"{'ok ' if ok_env else 'XX '} plugin_dir   env  override honored")
     fails += 0 if ok_env else 1
     missing = "ponytail-does-not-exist-xyz"          # no env, no cache entry -> must sys.exit


### PR DESCRIPTION
I was re-running `benchmarks/agentic` to check the numbers in `results/2026-06-18-agentic.md` — different machine, plugin not installed there, so I set `PONYTAIL_PLUGIN_DIR` the way `benchmarks/agentic/README.md` suggests. Baseline cells ran fine, then the first ponytail cell died:

```
ponytail plugin dir not found under ~/.claude/plugins/cache/ponytail/ponytail; install the plugin or set PONYTAIL_PLUGIN_DIR
```

Which was confusing, because I had.

`_selftest_plugin_dir()` sets the var to a sentinel to prove the override is honored, then unconditionally `del`s it in the `finally`. The selftest runs ahead of every real run, so by the time `_plugin_dir()` is called for an actual cell the variable is gone and it falls through to the cache-dir branch.

Bit of an irony: the docstring on `_plugin_dir` says hardcoding one machine's path "made the ponytail/caveman arms unreproducible off that box" — and the env override that solves that is the thing getting cleared.

Fix saves the prior value and restores it. With `PONYTAIL_PLUGIN_DIR=/tmp/x`:

```
before: env after selftest = None
after:  env after selftest = '/tmp/x'
```

`python run.py --selftest` still reports all instruments valid, and the run I was after finishes now.

For what it's worth, the reproduction held up well — median `src_loc` on datepicker came out 401 baseline / 22.5 ponytail against your published 404 / 23, two months later on a different box.