### PR TITLE
fix(hermes): stop filterSkillBodyForMode from swallowing rule bullets that start with a mode word

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -77,7 +77,7 @@ def _filter_skill_body_for_mode(body: str, mode: str) -> str:
             if label_mode and label_mode != effective:
                 continue
 
-        example_label = re.match(r"^-\s*([^:]+):\s*", line)
+        example_label = re.match(r"^-\s*([^:]+):\s*\"", line)
         if example_label:
             label_mode = _normalize_runtime_mode(example_label.group(1))
             if label_mode and label_mode != effective:


### PR DESCRIPTION
Hey team!,  I noticed a bug in how the Python port handles instructions for the Hermes adapter.

_filter_skill_body_for_mode was accidentally swallowing perfectly valid rule bullets. The regex it was using didn't check for a closing quote (:\s*"), so if a normal instruction bullet happened to start with a word that matched a mode (like - Full: always write documentation), it thought it was a mode-specific example and silently dropped it from the prompt.

I updated the regex to match the JavaScript implementation by requiring the quote (re.match(r"^-\s*([^:]+):\s*\"", line)).

What I tested:

Verified that normal instructions are preserved and only actual examples wrapped in quotes are mode-filtered.
Ran node tests/hermes-plugin.test.js locally and all tests are green.
