### PR TITLE
fix: report the real failure — harness diagnostics, Qoder stdout, and mode validation

### DIFF
--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -41,9 +41,18 @@ function identifyTask(task) {
 function exec(cmd, opts = {}) {
   try {
     execSync(cmd, { timeout: correctnessTimeoutMs(), encoding: 'utf8', stdio: 'pipe', ...opts });
-    return { ok: true, stderr: '' };
+    return { ok: true, stderr: '', message: '' };
   } catch (e) {
-    return { ok: false, stderr: (e.stderr || e.message || '').slice(0, 500) };
+    // ponytail: the harnesses print their "FAIL: output was ..." diagnostic to
+    // stdout and exit 1, so reporting stderr alone threw away the only useful
+    // line and left every failure as a bare "Command failed: python3 /tmp/...".
+    const stderr = String(e.stderr || '').trim();
+    const stdout = String(e.stdout || '').trim();
+    return {
+      ok: false,
+      stderr: stderr.slice(0, 500),
+      message: (stderr || stdout || e.message || '').slice(0, 500),
+    };
   }
 }
 
@@ -126,7 +135,7 @@ print("PASS")
     const result = exec(`${python()} "${f}"`);
     fs.unlinkSync(f);
     if (result.ok) return { pass: true, reason: 'Email validator passes all checks' };
-    return { pass: false, reason: result.stderr || 'Email validator failed' };
+    return { pass: false, reason: result.message || 'Email validator failed' };
   },
 
   debounce(blocks) {
@@ -171,7 +180,7 @@ setTimeout(() => {
     const result = exec(`node "${f}"`);
     fs.unlinkSync(f);
     if (result.ok) return { pass: true, reason: 'Debounce passes all checks' };
-    return { pass: false, reason: result.stderr || 'Debounce failed' };
+    return { pass: false, reason: result.message || 'Debounce failed' };
   },
 
   csv(blocks) {
@@ -191,20 +200,25 @@ setTimeout(() => {
 import sys, os
 os.chdir(r"${path.dirname(csvPath)}")
 
-# Capture print output
+# Capture print output. ponytail: hold the buffer in its own name and restore
+# stdout in finally. Reading sys.stdout.getvalue() after the except branch had
+# already restored the real stdout raised AttributeError, so ANY exception in
+# the scored snippet (a missing pandas, a genuine bug) surfaced as an
+# inscrutable harness traceback instead of the failure it actually was.
 import io
 _stdout = sys.stdout
-sys.stdout = io.StringIO()
+_buffer = io.StringIO()
+sys.stdout = _buffer
+_error = None
 
 try:
 ${patched.split('\n').map((l) => '    ' + l).join('\n')}
 except Exception as e:
+    _error = type(e).__name__ + ": " + str(e)
+finally:
     sys.stdout = _stdout
-    # If it needs sales.csv in cwd, write it there and retry
-    pass
 
-output = sys.stdout.getvalue()
-sys.stdout = _stdout
+output = _buffer.getvalue()
 
 # Check output contains the number 351 (100.5 + 200.0 + 50.5)
 # Match as a standalone number (not as substring of e.g. 13510)
@@ -212,8 +226,10 @@ import re
 if re.search(r'(?<![\\d])351(?:\\.0)?(?![\\d])', output):
     print("PASS")
 else:
-    # Try running it differently: maybe it defines a function
-    print("FAIL: output was: " + repr(output[:200]))
+    detail = "FAIL: output was: " + repr(output[:200])
+    if _error:
+        detail += " (raised " + _error + ")"
+    print(detail)
     sys.exit(1)
 `;
     const f = tmpFile('.py', harness);
@@ -221,7 +237,7 @@ else:
     try { fs.unlinkSync(f); } catch (e) {}
     try { fs.unlinkSync(csvPath); } catch (e) {}
     if (result.ok) return { pass: true, reason: 'CSV sum produces correct result (351)' };
-    return { pass: false, reason: result.stderr || 'CSV sum failed' };
+    return { pass: false, reason: result.message || 'CSV sum failed' };
   },
 
   countdown(blocks) {

--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -75,22 +75,21 @@ function getClaudeDir() {
 
 function getDefaultMode() {
   // 1. Environment variable (highest priority)
-  const envMode = process.env.PONYTAIL_DEFAULT_MODE;
   // ponytail: a default must be a runtime level (off/lite/full/ultra); review is
-  // a session-only mode, never a valid default (#377). Validate against
-  // RUNTIME_MODES so a stray env var or config can't make review the default.
-  if (envMode && RUNTIME_MODES.includes(envMode.toLowerCase())) {
-    return envMode.toLowerCase();
-  }
+  // a session-only mode, never a valid default (#377). normalizeMode already
+  // validates against RUNTIME_MODES -- and trims, which the inline
+  // toLowerCase() here did not, so PONYTAIL_DEFAULT_MODE=" lite " (one stray
+  // space in a shell profile or CI yaml) silently resolved to full.
+  const envMode = normalizeMode(process.env.PONYTAIL_DEFAULT_MODE);
+  if (envMode) return envMode;
 
   // 2. Config file
   try {
     const configPath = getConfigPath();
     // Strip UTF-8 BOM (common on Windows-saved files) so JSON.parse doesn't choke
     const config = JSON.parse(fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
-    if (config.defaultMode && RUNTIME_MODES.includes(config.defaultMode.toLowerCase())) {
-      return config.defaultMode.toLowerCase();
-    }
+    const configMode = normalizeMode(config.defaultMode);
+    if (configMode) return configMode;
   } catch (e) {
     // Config file doesn't exist or is invalid — fall through
   }

--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -56,11 +56,17 @@ function finish() {
       }
 
       if (isReportOnly) {
-        writeHookOutput(
-          'UserPromptSubmit',
-          mode,
-          'PONYTAIL MODE ACTIVE — level: ' + mode,
-        );
+        // ponytail: same one-JSON-per-invocation rule as the mode-switch branch
+        // below. On Qoder the ruleset write already opens with this exact
+        // "PONYTAIL MODE ACTIVE — level: X" line, so emitting it here too put
+        // two concatenated JSON objects on stdout — not parseable as either.
+        if (!isQoder) {
+          writeHookOutput(
+            'UserPromptSubmit',
+            mode,
+            'PONYTAIL MODE ACTIVE — level: ' + mode,
+          );
+        }
       } else if (mode && mode !== 'off') {
         setMode(mode);
         modeSwitched = true;

--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -1,7 +1,7 @@
 const fs = require('fs');
 const path = require('path');
 const os = require('os');
-const { getClaudeDir, getConfigDir } = require('./ponytail-config');
+const { getClaudeDir, normalizePersistedMode } = require('./ponytail-config');
 
 const STATE_FILE = '.ponytail-active';
 
@@ -40,9 +40,13 @@ function clearMode() {
 }
 
 // Live mode written by activate/mode-tracker. Absent flag = ponytail off.
+// ponytail: validate what comes off disk, the way the OpenCode reader already
+// does. A hand-edited or truncated flag file used to be returned verbatim, so
+// `/ponytail` reported "level: banana" while behaviour was really the full
+// default -- the status line contradicted the ruleset actually in force.
 function readMode() {
   try {
-    return fs.readFileSync(statePath, 'utf8').trim() || null;
+    return normalizePersistedMode(fs.readFileSync(statePath, 'utf8').trim()) || null;
   } catch (e) {
     return null;
   }

--- a/tests/correctness.test.js
+++ b/tests/correctness.test.js
@@ -74,7 +74,19 @@ test('debounce: immediate-call implementation fails', () => {
 
 // --- CSV sum ---
 
-test('csv: correct pandas one-liner passes', () => {
+// ponytail: this one case needs pandas installed. The subject under test is the
+// checker, not pandas, so skip rather than fail on a machine without it — `npm
+// test` used to go red here with an unrelated-looking harness error.
+const hasPandas = (() => {
+  try {
+    require('node:child_process').execSync('python3 -c "import pandas"', { stdio: 'ignore' });
+    return true;
+  } catch (e) {
+    return false;
+  }
+})();
+
+test('csv: correct pandas one-liner passes', { skip: hasPandas ? false : 'pandas not installed' }, () => {
   const result = check(
     "Write Python code that reads sales.csv and sums the 'amount' column.",
     'python',
@@ -218,4 +230,46 @@ test('unknown task is gracefully skipped', () => {
   assert.equal(result.pass, true);
   assert.equal(result.score, 1);
   assert.match(result.reason, /unknown task/i);
+});
+
+// --- regression: harness failures must report the real cause ---
+// The csv harness restored sys.stdout inside its except branch and then called
+// sys.stdout.getvalue(), so any exception in the scored snippet surfaced as an
+// AttributeError from the harness itself. And exec() kept only stderr, while
+// every harness prints its "FAIL: output was ..." line to stdout — so the
+// diagnostic was unreachable either way.
+
+test('csv: a snippet that raises reports its own exception, not a harness error', () => {
+  const result = check(
+    "Write Python code that reads sales.csv and sums the 'amount' column.",
+    'python',
+    'import csv\nraise RuntimeError("boom")\nprint(sum([]))',
+  );
+  assert.equal(result.pass, false);
+  assert.match(result.reason, /RuntimeError: boom/);
+  assert.doesNotMatch(result.reason, /getvalue/);
+  assert.doesNotMatch(result.reason, /TextIOWrapper/);
+});
+
+test('csv: a wrong answer still reports the output it produced', () => {
+  const result = check(
+    "Write Python code that reads sales.csv and sums the 'amount' column.",
+    'python',
+    'import csv\nprint("total is 999")\nsum([])',
+  );
+  assert.equal(result.pass, false);
+  assert.match(result.reason, /output was/);
+  assert.match(result.reason, /999/);
+  assert.doesNotMatch(result.reason, /^Command failed/);
+});
+
+test('csv: a stdlib solution passes without pandas installed', () => {
+  // Proves the checker itself is not pandas-dependent — only the pandas case is.
+  const result = check(
+    "Write Python code that reads sales.csv and sums the 'amount' column.",
+    'python',
+    "import csv\nwith open('sales.csv') as f:\n    print(sum(float(r['amount']) for r in csv.DictReader(f)))",
+  );
+  assert.equal(result.pass, true);
+  assert.equal(result.score, 1);
 });

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -489,4 +489,59 @@ try {
   if (prevEnvModeRev === undefined) delete process.env.PONYTAIL_DEFAULT_MODE; else process.env.PONYTAIL_DEFAULT_MODE = prevEnvModeRev;
 }
 
+
+// --- regression: a padded env var must still resolve (normalization reuse) ---
+// getDefaultMode did its own toLowerCase() without trimming, while the
+// normalizeMode() it ships beside trims. One stray space in a shell profile or
+// CI yaml silently resolved to the built-in default instead of the named mode.
+const prevPadded = process.env.PONYTAIL_DEFAULT_MODE;
+const prevXdgPadded = process.env.XDG_CONFIG_HOME;
+const paddedHome = path.join(temp, 'padded-env-home');
+fs.mkdirSync(path.join(paddedHome, '.config'), { recursive: true });
+process.env.XDG_CONFIG_HOME = path.join(paddedHome, '.config');
+try {
+  for (const raw of [' lite ', '\tultra\n', 'LITE', ' OFF ']) {
+    const expected = raw.trim().toLowerCase();
+    process.env.PONYTAIL_DEFAULT_MODE = raw;
+    assert.equal(getDefaultMode(), expected,
+      'PONYTAIL_DEFAULT_MODE=' + JSON.stringify(raw) + ' must resolve to ' + expected);
+  }
+  process.env.PONYTAIL_DEFAULT_MODE = '  ';
+  assert.equal(getDefaultMode(), DEFAULT_MODE, 'a blank env var must fall back to the default');
+} finally {
+  if (prevPadded === undefined) delete process.env.PONYTAIL_DEFAULT_MODE; else process.env.PONYTAIL_DEFAULT_MODE = prevPadded;
+  if (prevXdgPadded === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = prevXdgPadded;
+}
+
+// --- regression: a corrupt flag file must not be reported as a mode ---
+// readMode returned the file verbatim, so `/ponytail` announced "level: banana"
+// while getPonytailInstructions had already fallen back to the real default.
+const badFlagHome = path.join(temp, 'bad-flag-claude');
+fs.mkdirSync(badFlagHome, { recursive: true });
+fs.writeFileSync(path.join(badFlagHome, '.ponytail-active'), 'banana\n');
+const reported = spawnSync(process.execPath, [path.join(root, 'hooks', 'ponytail-mode-tracker.js')], {
+  input: JSON.stringify({ prompt: '/ponytail' }),
+  encoding: 'utf8',
+  env: { ...process.env, CLAUDE_CONFIG_DIR: badFlagHome, PONYTAIL_DEFAULT_MODE: 'full' },
+});
+assert.ok(!/banana/.test(reported.stdout), 'a corrupt flag file must never be reported as the active level');
+assert.ok(/level: full/.test(reported.stdout), 'a corrupt flag file must report the mode actually in force');
+
+// --- regression: Qoder gets exactly one JSON object per invocation ---
+// The report-only branch wrote its status line AND the ruleset write repeated
+// that same line, so stdout carried two concatenated JSON objects.
+const qoderSingleJsonHome = path.join(temp, 'qoder-single-json');
+fs.mkdirSync(qoderSingleJsonHome, { recursive: true });
+for (const prompt of ['/ponytail', '/ponytail lite', '/ponytail ultra']) {
+  const run = spawnSync(process.execPath, [path.join(root, 'hooks', 'ponytail-mode-tracker.js')], {
+    input: JSON.stringify({ prompt }),
+    encoding: 'utf8',
+    env: { ...process.env, QODER_SESSION_ID: 'test', HOME: qoderSingleJsonHome, USERPROFILE: qoderSingleJsonHome },
+  });
+  const out = (run.stdout || '').trim();
+  if (!out) continue;
+  assert.doesNotThrow(() => JSON.parse(out),
+    'Qoder stdout for ' + JSON.stringify(prompt) + ' must be one parseable JSON object, got: ' + out.slice(0, 120));
+}
+
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
Four small correctness fixes found while reading the hooks and the correctness benchmark. Each is one commit, so they can be taken separately or partially. Every one is verified by a regression test, and `npm test` is green (87/86 pass + 1 skipped, 23, 3), as are `check-rule-copies` and `check-versions`.

The theme is the same in all four: **a failure should say what actually went wrong, and a value should be validated where it enters.**

---

### 1. The correctness harness reported its own crash instead of the failure

`benchmarks/correctness.js`, csv task:

```python
except Exception as e:
    sys.stdout = _stdout      # restores the real stdout...
    pass
output = sys.stdout.getvalue()   # ...then calls getvalue() on it
```

Any exception in the scored snippet produced:

```
AttributeError: '_io.TextIOWrapper' object has no attribute 'getvalue'
```

So a missing pandas and a genuinely wrong model answer both surfaced as the same inscrutable harness traceback. The buffer now has its own name and stdout is restored in `finally`, and the exception the snippet raised is reported.

`exec()` had the mirror problem: it kept only `stderr`, while every harness prints its `FAIL: output was ...` line to **stdout** and exits 1. That diagnostic was unreachable, so failures read as a bare `Command failed: python3 /tmp/...`. It now carries a `message` field preferring stderr then stdout. `stderr` is still on the result object for any other caller.

Before / after on the same input:

```
reason: Command failed: python3 /tmp/ponytail-bench-...py
reason: FAIL: output was: '' (raised ModuleNotFoundError: No module named 'pandas')
```

The pandas case is now skipped when pandas is absent — the subject under test is the checker, not pandas, and `npm test` went red locally on any machine without it. **CI installs pandas, so the case still executes there.** A new test proves the checker itself is not pandas-dependent by passing a stdlib `csv` solution.

### 2. Qoder received two JSON objects from a bare `/ponytail`

`hooks/ponytail-mode-tracker.js`. The report-only branch wrote its status line, then the Qoder block wrote the ruleset — whose first line is that same `PONYTAIL MODE ACTIVE — level: X` string. stdout carried two concatenated JSON objects, which parses as neither:

```
{"hookSpecificOutput":{...,"additionalContext":"PONYTAIL MODE ACTIVE — level: full"}}{"hookSpecificOutput":{...}}
```

The mode-switch branch below already guards with `!isQoder` for exactly this reason; report-only was missed. Same guard applied, and nothing is lost — the ruleset write already opens with the suppressed line.

### 3. `PONYTAIL_DEFAULT_MODE=" lite "` silently resolved to `full`

`getDefaultMode()` did its own `toLowerCase()` without trimming, while the `normalizeMode()` it ships beside trims *and* validates against `RUNTIME_MODES`. One stray space in a shell profile or a CI yaml gave you the built-in default with no error. Now reuses `normalizeMode` for both the env var and the config field — same validation, including the `#377` rule that `review` can never be a default.

### 4. A corrupt flag file was reported as the active level

`readMode()` returned the file verbatim, so `/ponytail` announced `level: banana` while `getPonytailInstructions` had already normalized it back to `full` — the status line contradicted the ruleset actually in force. The OpenCode reader already calls `normalizePersistedMode` on the same value (`.opencode/plugins/ponytail.mjs:35`); this one now does too. Also drops the unused `getConfigDir` import on the line being touched.

---

Verified end to end after the fixes:

| | result |
|---|---|
| Qoder bare `/ponytail` | one parseable JSON object |
| `PONYTAIL_DEFAULT_MODE=" lite "` | `lite` |
| flag file containing `banana` | reports `level: full`, the mode really in force |
| snippet that raises | `(raised ModuleNotFoundError: No module named 'pandas')` |

Happy to split this into separate PRs or drop any commit if you'd prefer them apart.