### PR TITLE
fix: resolve PONYTAIL_DIR placeholder in qoder-hooks.json for plugin auto-loading

### DIFF
--- a/hooks/qoder-hooks.json
+++ b/hooks/qoder-hooks.json
@@ -1,12 +1,13 @@
 {
-  "_comment": "Reference template — copy the 'hooks' object into your .qoder/settings.json or ~/.qoder/settings.json. Replace PONYTAIL_DIR with the path to your ponytail checkout (e.g. ~/.qoder/plugins/ponytail or the npm global install path).",
   "hooks": {
     "UserPromptSubmit": [
       {
         "hooks": [
           {
             "type": "command",
-            "command": "node PONYTAIL_DIR/hooks/ponytail-mode-tracker.js"
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js"],
+            "timeout": 5
           }
         ]
       }
@@ -17,7 +18,9 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node PONYTAIL_DIR/hooks/ponytail-subagent.js"
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js"],
+            "timeout": 5
           }
         ]
       }


### PR DESCRIPTION
## Summary

- `plugin.json` declares `"hooks": "./hooks/qoder-hooks.json"`, so qodercli loads this file directly as plugin hooks at runtime
- The `PONYTAIL_DIR` placeholder is never substituted by the plugin system, causing `Cannot find module` (CJS loader) errors on every `UserPromptSubmit` and `PreToolUse` event
- Replace with `${CLAUDE_PLUGIN_ROOT}` (resolved by the qodercli plugin runtime, same pattern as other plugins like i-have-adhd) and use the `command` + `args` format

## Reproduction

Install ponytail as a qodercli plugin (`qoder plugins install /path/to/ponytail`). Every prompt submit triggers:

```
UserPromptSubmit hook error
Failed with non-blocking status code: node:internal/modules/cjs/loader:1520
```

## Test plan

- [x] `qoder plugins validate` passes with hooks (2) loaded
- [x] Both hooks execute with exit 0 when tested with `${CLAUDE_PLUGIN_ROOT}` resolved to the install path
- [ ] Install from this branch and confirm no hook errors on session start