### PR TITLE
feat: add Cursor plugin adapter

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,14 @@
+{
+  "name": "ponytail",
+  "owner": {
+    "name": "Dietrich Gebert"
+  },
+  "plugins": [
+    {
+      "name": "ponytail",
+      "description": "Forces the laziest solution that works. YAGNI, stdlib first, one line over fifty.",
+      "source": "./",
+      "category": "productivity"
+    }
+  ]
+}

--- a/.cursor-plugin/plugin.json
+++ b/.cursor-plugin/plugin.json
@@ -1,0 +1,14 @@
+{
+  "name": "ponytail",
+  "version": "4.9.0",
+  "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
+  "author": { "name": "Dietrich Gebert" },
+  "homepage": "https://github.com/DietrichGebert/ponytail",
+  "repository": "https://github.com/DietrichGebert/ponytail",
+  "license": "MIT",
+  "keywords": ["yagni", "minimalism", "code-review", "productivity"],
+  "logo": "assets/logo.png",
+  "skills": "./skills/",
+  "rules": "./.cursor/rules/",
+  "commands": "./.opencode/command/"
+}

--- a/README.es.md
+++ b/README.es.md
@@ -237,7 +237,7 @@ Activo en cada sesión, con un puñado de comandos (ver [Comandos](#comandos)). 
 
 Configura el nivel para cada nueva sesión con la variable de entorno `PONYTAIL_DEFAULT_MODE` (`lite`/`full`/`ultra`/`off`), o con un campo `defaultMode` en `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` en Windows). El default es `full`.
 
-Cursor, Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro: copia el archivo de reglas correspondiente de este repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
+Cursor: copia la raíz del repo a `~/.cursor/plugins/local/ponytail` y recarga la ventana (**Developer: Reload Window**). Equipos: Dashboard → Plugins → Import from GitHub `DietrichGebert/ponytail`. El fallback sigue siendo copiar [`.cursor/rules/ponytail.mdc`](.cursor/rules/ponytail.mdc) al proyecto. Windsurf, Cline, GitHub Copilot (editor), Aider, Kiro: copia el archivo de reglas correspondiente de este repo ([`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
 
 Kiro: copia `.kiro/steering/ponytail.md` a `~/.kiro/steering/` (global) o `.kiro/steering/` en tu proyecto.
 
@@ -257,7 +257,7 @@ Qué archivos corresponden a qué agente: [Portabilidad de agentes](docs/agent-p
 | `/ponytail-debt` | Recolecta los atajos marcados con `ponytail:` que dejaste pendientes en un registro, para que "después" no se convierta en "nunca". |
 | `/ponytail-help` | Referencia rápida de los comandos anteriores. |
 
-Los comandos requieren un host compatible con skills (Claude Code, Codex, Devin CLI, OpenCode, Gemini, pi, Swival). En Codex son skills; se invocan con `@` (`@ponytail-review`). Los adaptadores de solo instrucciones (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) cargan el ruleset permanente sin los comandos.
+Los comandos requieren un host compatible con skills (Claude Code, Codex, Cursor, Devin CLI, OpenCode, Gemini, pi, Swival). En Codex son skills; se invocan con `@` (`@ponytail-review`). Los adaptadores de solo instrucciones (Windsurf, Cline, Copilot, Kiro, Antigravity) cargan el ruleset permanente sin los comandos.
 
 ## Desarrollo
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -256,7 +256,7 @@ enabled = ["ponytail"]
 
 새 세션마다 적용할 레벨은 `PONYTAIL_DEFAULT_MODE` 환경 변수(`lite`/`full`/`ultra`/`off`)로, 또는 `~/.config/ponytail/config.json`의 `defaultMode` 필드(Windows에선 `%APPDATA%\ponytail\config.json`)로 정한다. 기본값은 `full`이다.
 
-Cursor, Windsurf, Cline, GitHub Copilot(에디터), Aider, Kiro, Zed, CodeWhale: 이 저장소에서 맞는 규칙 파일을 복사하면 된다([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
+Cursor: 저장소 루트를 `~/.cursor/plugins/local/ponytail`에 복사한 다음 **Developer: Reload Window**. 팀: Dashboard → Plugins → Import from GitHub `DietrichGebert/ponytail`. 폴백은 그대로 [`.cursor/rules/ponytail.mdc`](.cursor/rules/ponytail.mdc)를 프로젝트에 복사. Windsurf, Cline, GitHub Copilot(에디터), Aider, Kiro, Zed, CodeWhale: 이 저장소에서 맞는 규칙 파일을 복사하면 된다([`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/)).
 
 Kiro: `.kiro/steering/ponytail.md`를 `~/.kiro/steering/`(전역)이나 프로젝트의 `.kiro/steering/`에 복사한다.
 
@@ -277,7 +277,7 @@ Codex 확장을 쓰는 VS Code는 이 저장소가 함께 싣는 `AGENTS.md`를 
 | `/ponytail-gain` | 벤치마크로 잰 효과 스코어보드(코드 절감, 비용 절감, 속도 향상)를 보여 준다. |
 | `/ponytail-help` | 위 명령들의 빠른 참조. |
 
-명령들은 스킬을 지원하는 호스트가 있어야 돈다(Claude Code, Codex, Devin CLI, OpenCode, Gemini, pi, Swival). Codex에선 스킬이라 `@`로 부른다(`@ponytail-review`). 지시문 전용 어댑터(Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity)는 명령 없이 늘 켜진 룰셋만 불러온다.
+명령들은 스킬을 지원하는 호스트가 있어야 돈다(Claude Code, Codex, Cursor, Devin CLI, OpenCode, Gemini, pi, Swival). Codex에선 스킬이라 `@`로 부른다(`@ponytail-review`). 지시문 전용 어댑터(Windsurf, Cline, Copilot, Kiro, Antigravity)는 명령 없이 늘 켜진 룰셋만 불러온다.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -155,6 +155,18 @@ Copilot CLI namespaces plugin commands by plugin name. For example:
 /ponytail:ponytail-review
 ```
 
+### Cursor
+
+Clone or copy the **repo root** to `~/.cursor/plugins/local/ponytail`, then **Developer: Reload Window**. The plugin folder must contain the manifest plus `skills/` and `.cursor/rules/` together; current Cursor builds reject a symlink whose target sits outside `~/.cursor/plugins/local`.
+
+Teams: Dashboard → Plugins → Import from GitHub `DietrichGebert/ponytail`.
+
+Skills, the always-on [`.cursor/rules/ponytail.mdc`](.cursor/rules/ponytail.mdc) rule, and the `/ponytail` commands (reused from [`.opencode/command/`](.opencode/command/)) all load from that copy. Intensity (`lite`/`full`/`ultra`/`off`) is honor-system: `/ponytail` tells the agent to switch; Cursor cannot inject per turn.
+
+Official marketplace listing is later — submit `https://github.com/DietrichGebert/ponytail` at [cursor.com/marketplace/publish](https://cursor.com/marketplace/publish). Until then the local copy and the team GitHub import are the install paths.
+
+Zero-setup fallback, unchanged: copy [`.cursor/rules/ponytail.mdc`](.cursor/rules/ponytail.mdc) into a project.
+
 ### Pi agent harness
 
 ```
@@ -271,7 +283,7 @@ Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`l
 
 While active, the ruleset is also injected into every subagent spawned via the Agent tool. To scope that to specific agent types (say, keep it off read-only search agents), set the `PONYTAIL_SUBAGENT_MATCHER` env var to a regex tested against the subagent's `agent_type`. It is unanchored and case-insensitive: `explore|general` matches either, `^general$` is exact, and plugin agent types look like `plugin:name`. Unset means inject into every subagent (the default); an invalid regex, or a subagent whose type the platform doesn't report, also falls back to injecting.
 
-Cursor, Windsurf, Cline, GitHub Copilot Chat (the VS Code, JetBrains, and Visual Studio editor extension, not the standalone Copilot CLI covered under [Install](#install)), Aider, Kiro, Zed, CodeWhale, Swival, Qoder: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/), [`.qoder/rules/`](.qoder/rules/)).
+Windsurf, Cline, GitHub Copilot Chat (the VS Code, JetBrains, and Visual Studio editor extension, not the standalone Copilot CLI covered under [Install](#install)), Aider, Kiro, Zed, CodeWhale, Swival, Qoder: copy the matching rules file from this repo ([`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/), [`.qoder/rules/`](.qoder/rules/)).
 
 Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kiro/steering/` in your project.
 
@@ -296,7 +308,8 @@ Which files map to which agent: [Agent portability](docs/agent-portability.md).
 | Devin CLI | `devin plugins remove ponytail` |
 | Grok Build | `grok plugin uninstall ponytail` |
 | Pi agent | `pi uninstall ponytail` |
-| Cursor / Windsurf / Cline / Qoder / etc. | Delete the copied rule file |
+| Cursor | Delete `~/.cursor/plugins/local/ponytail` (or remove the GitHub import in Dashboard → Plugins), then **Developer: Reload Window**. If you used the fallback, delete the copied `.mdc`. |
+| Windsurf / Cline / Qoder / etc. | Delete the copied rule file |
 
 These remove the plugin's own files. They leave behind a small amount of state ponytail writes outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` to clean those up too. **Run it before the host remove command above** — the script is itself a plugin file, so removing the plugin first deletes it (or run it from a separate clone of this repo). It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched.
 
@@ -311,7 +324,7 @@ These remove the plugin's own files. They leave behind a small amount of state p
 | `/ponytail-gain` | Show the measured impact scoreboard (less code, less cost, more speed) from the benchmark. |
 | `/ponytail-help` | Quick reference for the commands above. |
 
-Commands need a skill-capable host (Claude Code, Codex, Devin CLI, OpenCode, Gemini, pi, Swival, Hermes Agent, Qoder, Grok Build). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
+Commands need a skill-capable host (Claude Code, Codex, Cursor, Devin CLI, OpenCode, Gemini, pi, Swival, Hermes Agent, Qoder, Grok Build). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
 
 ## Development
 

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -15,7 +15,7 @@ to load in a given agent.
 | pi | `pi-extension/`, `skills/`, `hooks/` | Package extension: injects the ruleset each turn through the shared instruction builder and registers the `/ponytail` commands. |
 | Hermes Agent | `plugin.yaml`, `__init__.py`, `skills/` | Native Hermes plugin: injects active mode through `pre_llm_call`, rewrites gateway `/ponytail-*` skill commands into agent prompts, registers `/ponytail` mode switching, and exposes bundled skills as `ponytail:<skill>`. |
 | Gemini CLI | `gemini-extension.json`, `AGENTS.md`, `commands/`, `skills/` | Extension manifest points `contextFileName` at `AGENTS.md` for always-on rules, and reuses the existing `commands/*.toml` and `skills/`, which Gemini CLI auto-discovers. The Claude/Codex hook map is not placed at Gemini's auto-discovered `hooks/hooks.json` path. |
-| Cursor | `.cursor/rules/ponytail.mdc` | Always-on project rule. |
+| Cursor | `.cursor-plugin/plugin.json`, `.cursor-plugin/marketplace.json`, `skills/`, `.cursor/rules/`, `.opencode/command/` | Cursor Plugin: copy the repo root to `~/.cursor/plugins/local/ponytail` then Developer: Reload Window (no symlink outside that folder). Teams import `DietrichGebert/ponytail` from GitHub. Skills, always-on `.mdc` rule, and OpenCode markdown slash commands. Intensity is honor-system. Fallback: copy `.cursor/rules/ponytail.mdc` into a project. |
 | Windsurf | `.windsurf/rules/ponytail.md` | Project rule. |
 | Cline | `.clinerules/ponytail.md` | Project rule. |
 | GitHub Copilot | `.github/copilot-instructions.md` | Repository instruction file. |

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -21,6 +21,7 @@ const PINNED_SEMVER = /^\d+\.\d+\.\d+$/;
 const VERSION_FILES = [
   '.claude-plugin/plugin.json',  // Claude Code plugin — what users install
   '.codex-plugin/plugin.json',   // Codex plugin
+  '.cursor-plugin/plugin.json',  // Cursor plugin
   '.devin-plugin/plugin.json',   // Devin CLI plugin
   '.github/plugin/plugin.json',  // Copilot plugin
   '.qoder-plugin/plugin.json',   // Qoder plugin

--- a/tests/cursor-plugin.test.js
+++ b/tests/cursor-plugin.test.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+// Smoke test for the Cursor plugin adapter: verify manifest, rules, skills,
+// and OpenCode command wiring are present and consistent.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const SKILL_DIRS = [
+  'ponytail',
+  'ponytail-review',
+  'ponytail-audit',
+  'ponytail-debt',
+  'ponytail-gain',
+  'ponytail-help',
+];
+const COMMAND_FILES = [
+  'ponytail.md',
+  'ponytail-review.md',
+  'ponytail-audit.md',
+  'ponytail-debt.md',
+  'ponytail-gain.md',
+  'ponytail-help.md',
+];
+
+function readJSON(relPath) {
+  return JSON.parse(fs.readFileSync(path.join(root, relPath), 'utf8'));
+}
+
+test('cursor plugin manifest exists and has required fields', () => {
+  const manifest = readJSON('.cursor-plugin/plugin.json');
+  assert.equal(manifest.name, 'ponytail');
+  assert.ok(manifest.version, 'manifest must declare a version');
+  assert.ok(manifest.description, 'manifest must declare a description');
+  assert.ok(manifest.author, 'manifest must declare an author');
+  assert.equal(manifest.author.name, 'Dietrich Gebert');
+  assert.equal(manifest.author.url, undefined, 'Cursor schema forbids author.url');
+  assert.equal(manifest.displayName, undefined, 'Cursor schema forbids displayName');
+  assert.equal(manifest.license, 'MIT');
+  assert.equal(manifest.skills, './skills/');
+  assert.equal(manifest.rules, './.cursor/rules/');
+  assert.equal(manifest.commands, './.opencode/command/');
+  assert.equal(manifest.hooks, undefined);
+  assert.equal(manifest.logo, 'assets/logo.png');
+});
+
+test('cursor marketplace.json indexes this plugin at repo root', () => {
+  const marketplace = readJSON('.cursor-plugin/marketplace.json');
+  assert.equal(marketplace.name, 'ponytail');
+  assert.ok(marketplace.owner, 'marketplace must declare an owner');
+  assert.ok(Array.isArray(marketplace.plugins), 'marketplace must list plugins');
+  assert.equal(marketplace.plugins.length, 1);
+  assert.equal(marketplace.plugins[0].name, 'ponytail');
+  assert.equal(marketplace.plugins[0].source, './');
+});
+
+test('cursor rules file exists and is non-empty', () => {
+  const rulesPath = path.join(root, '.cursor', 'rules', 'ponytail.mdc');
+  assert.ok(fs.existsSync(rulesPath), '.cursor/rules/ponytail.mdc must exist');
+  const content = fs.readFileSync(rulesPath, 'utf8').trim();
+  assert.ok(content.length > 0, '.cursor/rules/ponytail.mdc must not be empty');
+  assert.ok(content.includes('lazy senior developer'), 'rules must contain the ponytail identity');
+});
+
+test('cursor manifest points at skills that actually ship', () => {
+  const manifest = readJSON('.cursor-plugin/plugin.json');
+  const skillsDir = path.join(root, manifest.skills);
+  assert.ok(fs.existsSync(skillsDir), 'skills/ directory must exist');
+
+  for (const skill of SKILL_DIRS) {
+    const skillFile = path.join(skillsDir, skill, 'SKILL.md');
+    assert.ok(
+      fs.existsSync(skillFile),
+      `missing skill: skills/${skill}/SKILL.md`,
+    );
+  }
+});
+
+test('cursor commands dir has the six markdown command files', () => {
+  const manifest = readJSON('.cursor-plugin/plugin.json');
+  const commandsDir = path.join(root, manifest.commands);
+  assert.ok(fs.existsSync(commandsDir), '.opencode/command/ must exist');
+
+  for (const file of COMMAND_FILES) {
+    assert.ok(
+      fs.existsSync(path.join(commandsDir, file)),
+      `missing command file: ${manifest.commands}${file}`,
+    );
+  }
+});
+
+test('cursor rules match AGENTS.md canonical body', () => {
+  // Reuse the same logic as check-rule-copies.js: the .mdc copy must be
+  // byte-identical to AGENTS.md minus frontmatter and the repo-self-application paragraph.
+  const agents = fs.readFileSync(path.join(root, 'AGENTS.md'), 'utf8')
+    .replace(/\r\n/g, '\n').trim();
+  const canonical = agents.replace(/\n\n\(Yes, this file also applies[\s\S]*?\)$/, '').trim();
+  const cursorCopy = fs.readFileSync(path.join(root, '.cursor', 'rules', 'ponytail.mdc'), 'utf8')
+    .replace(/\r\n/g, '\n')
+    .replace(/^---\n[\s\S]*?\n---\n*/, '')
+    .trim();
+  assert.equal(cursorCopy, canonical, '.cursor/rules/ponytail.mdc drifted from AGENTS.md');
+});


### PR DESCRIPTION
## Summary

Thin **Cursor Plugin** adapter, same packaging pattern as the Grok Build adapter in #661: host-specific `.cursor-plugin/` files that point at existing Ponytail content instead of copying it.

- `.cursor-plugin/plugin.json` and `.cursor-plugin/marketplace.json` (`source: "./"`) so Teams can **Import from GitHub** and install `ponytail`.
- Reuses `skills/`, the existing always-on `.cursor/rules/ponytail.mdc`, and the OpenCode markdown commands in `.opencode/command/`.
- Local install: copy the repo root to `~/.cursor/plugins/local/ponytail`, then Developer: Reload Window. Copying the `.mdc` into a project remains the zero-setup fallback.

## Important behavior note

Cursor's `beforeSubmitPrompt` can only allow/block a prompt, and `subagentStart` can only allow/deny a subagent. Neither injects `additional_context`. `sessionStart` can inject, but it is fire-and-forget and deferred on cloud agents. So this adapter does **not** register lifecycle hooks — same call as Grok in #661, where passive hook stdout could not deliver the ruleset.

Intensity (`lite`/`full`/`ultra`/`off`) is honor-system in Cursor: `/ponytail` tells the agent to switch. The always-on `.mdc` rule is what actually sticks every session.

No Cursor MCP server and no custom agents. Grok's root `plugin.json` is untouched.

## Packaging

- `.cursor-plugin/plugin.json` uses documented Cursor fields only (`additionalProperties: false` — no `author.url` / `displayName`).
- `.cursor-plugin/marketplace.json` indexes one plugin at repo root for team GitHub import.
- Version is pinned at `4.9.0` and added to `scripts/check-versions.js`.
- English, Spanish, Korean, and `docs/agent-portability.md` describe the supported install paths. Official Cursor Marketplace listing is a later human submit at cursor.com/marketplace/publish.

## Test plan

- [x] `node --test tests/cursor-plugin.test.js` (6/6)
- [x] `node scripts/check-rule-copies.js`
- [x] `node scripts/check-versions.js` (9 files at 4.9.0)
- [ ] After merge: Customize → + Add Marketplace → Import from GitHub `DietrichGebert/ponytail` → install `ponytail`
- [ ] Or copy repo root to `~/.cursor/plugins/local/ponytail` and Developer: Reload Window; confirm skills, the always-on rule, and `/ponytail` commands load


Made with [Cursor](https://cursor.com)