### PR TITLE
Add a rule against unrequested edits to adjacent code

### DIFF
--- a/.agents/rules/ponytail.md
+++ b/.agents/rules/ponytail.md
@@ -23,6 +23,7 @@ Rules:
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Surgical changes: touch only what you were asked to touch. Don't "improve" adjacent code, comments, or formatting; match the style that's there. Remove only what your change orphaned. Notice unrelated dead code? Mention it, don't delete it. Every changed line traces to what was asked.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path.

--- a/.clinerules/ponytail.md
+++ b/.clinerules/ponytail.md
@@ -23,6 +23,7 @@ Rules:
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Surgical changes: touch only what you were asked to touch. Don't "improve" adjacent code, comments, or formatting; match the style that's there. Remove only what your change orphaned. Notice unrelated dead code? Mention it, don't delete it. Every changed line traces to what was asked.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path.

--- a/.cursor/rules/ponytail.mdc
+++ b/.cursor/rules/ponytail.mdc
@@ -29,6 +29,7 @@ Rules:
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Surgical changes: touch only what you were asked to touch. Don't "improve" adjacent code, comments, or formatting; match the style that's there. Remove only what your change orphaned. Notice unrelated dead code? Mention it, don't delete it. Every changed line traces to what was asked.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -23,6 +23,7 @@ Rules:
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Surgical changes: touch only what you were asked to touch. Don't "improve" adjacent code, comments, or formatting; match the style that's there. Remove only what your change orphaned. Notice unrelated dead code? Mention it, don't delete it. Every changed line traces to what was asked.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path.

--- a/.kiro/steering/ponytail.md
+++ b/.kiro/steering/ponytail.md
@@ -28,6 +28,7 @@ Rules:
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Surgical changes: touch only what you were asked to touch. Don't "improve" adjacent code, comments, or formatting; match the style that's there. Remove only what your change orphaned. Notice unrelated dead code? Mention it, don't delete it. Every changed line traces to what was asked.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path.

--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -47,6 +47,7 @@ every sibling caller still broken. Fix it once, where all callers route through.
 - No boilerplate, no scaffolding "for later", later can scaffold for itself.
 - Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
 - Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Surgical changes: touch only what you were asked to touch. Don't "improve" adjacent code, comments, or formatting; match the style that's there. Remove only what your change orphaned. Notice unrelated dead code? Mention it, don't delete it. Test: every changed line traces directly to what was asked for.
 - Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
 - Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path (`# ponytail: global lock, per-account locks if throughput matters`).

--- a/.qoder/rules/ponytail.md
+++ b/.qoder/rules/ponytail.md
@@ -23,6 +23,7 @@ Rules:
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Surgical changes: touch only what you were asked to touch. Don't "improve" adjacent code, comments, or formatting; match the style that's there. Remove only what your change orphaned. Notice unrelated dead code? Mention it, don't delete it. Every changed line traces to what was asked.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path.

--- a/.windsurf/rules/ponytail.md
+++ b/.windsurf/rules/ponytail.md
@@ -23,6 +23,7 @@ Rules:
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Surgical changes: touch only what you were asked to touch. Don't "improve" adjacent code, comments, or formatting; match the style that's there. Remove only what your change orphaned. Notice unrelated dead code? Mention it, don't delete it. Every changed line traces to what was asked.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,6 +23,7 @@ Rules:
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Surgical changes: touch only what you were asked to touch. Don't "improve" adjacent code, comments, or formatting; match the style that's there. Remove only what your change orphaned. Notice unrelated dead code? Mention it, don't delete it. Every changed line traces to what was asked.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path.

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -59,6 +59,7 @@ every sibling caller still broken. Fix it once, where all callers route through.
 - No boilerplate, no scaffolding "for later", later can scaffold for itself.
 - Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
 - Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
+- Surgical changes: touch only what you were asked to touch. Don't "improve" adjacent code, comments, or formatting; match the style that's there. Remove only what your change orphaned. Notice unrelated dead code? Mention it, don't delete it. Test: every changed line traces directly to what was asked for.
 - Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
 - Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path (`# ponytail: global lock, per-account locks if throughput matters`).


### PR DESCRIPTION
## Why

`ponytail:` and the repo's own AGENTS.md are explicit that agents must not "improve" adjacent code while fixing a bug — but the skill's Rules never said it. The result is the exact drift the issue names: unrequested edits to neighboring code, comments, or formatting riding along with a real fix.

## What

Add a `surgical changes` rule to the Rules section of `AGENTS.md` and `skills/ponytail/SKILL.md`:

- touch only what you were asked to touch
- don't "improve" adjacent code, comments, or formatting; match the style that's there
- remove only what your change orphaned; mention unrelated dead code instead of deleting it

Propagated byte-identically to the seven adapter copies (`.cursor`, `.windsurf`, `.clinerules`, `.agents`, `.qoder`, `.github/copilot-instructions`, `.kiro`), per `check-rule-copies.js`, and regenerated the `.openclaw/` skill.

## Tests

- `node scripts/check-rule-copies.js` → exit 0 (9 rule invariants intact, no existing rule reworded)
- `node --test tests/openclaw-skills.test.js` → 18/18
- `npm test` → all pass except the pre-existing `csv: correct pandas one-liner passes` failure, which fails identically on the base commit (no pandas installed locally) — unrelated to this change.

Fixes #640
