### PR TITLE
ponytail-audit/review: no pass for over-defensive control flow or broad exception wrappers

### DIFF
--- a/.openclaw/skills/ponytail-audit/SKILL.md
+++ b/.openclaw/skills/ponytail-audit/SKILL.md
@@ -16,13 +16,19 @@ Same as ponytail-review:
 - `stdlib:` hand-rolled thing the standard library ships. Name the function.
 - `native:` dependency or code doing what the platform already does. Name the feature.
 - `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `defensive:` over-defensive control flow (redundant null checks, dead branches) or a blanket catch/except swallowing every error. Replacement: flatten to guard clauses, one handler at the real boundary.
 - `shrink:` same logic, fewer lines. Show the shorter form.
 
 ## Hunt
 
 Deps the stdlib or platform already ships, single-implementation interfaces,
 factories with one product, wrappers that only delegate, files exporting one
-thing, dead flags and config, hand-rolled stdlib.
+thing, dead flags and config, hand-rolled stdlib. Also flag over-defensive
+control flow: nested condition ladders and redundant guards for states the
+code can't reach, blanket catch/except wrappers swallowing every error.
+Flatten, don't delete: guard clauses and early exits for nested conditionals,
+one handler at the real boundary. Never simplify away error handling that
+prevents data loss.
 
 ## Output
 

--- a/.openclaw/skills/ponytail-review/SKILL.md
+++ b/.openclaw/skills/ponytail-review/SKILL.md
@@ -19,6 +19,7 @@ Tags:
 - `stdlib:` hand-rolled thing the standard library ships. Name the function.
 - `native:` dependency or code doing what the platform already does. Name the feature.
 - `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `defensive:` over-defensive control flow (redundant null checks, dead branches) or a blanket catch/except swallowing every error. Replacement: flatten to guard clauses, one handler at the real boundary.
 - `shrink:` same logic, fewer lines. Show the shorter form.
 
 ## Examples
@@ -35,6 +36,10 @@ considered whether all these validation rules are needed at this stage?"
 ✅ `L52-71: delete: retry wrapper around an idempotent local call. Nothing replaces it.`
 
 ✅ `L30-44: shrink: manual loop builds dict. dict(zip(keys, values)), 1 line.`
+
+✅ `L23-25: defensive: nullable value null-checked three times on the way to one use. Check it where it's read, drop the rest.`
+
+✅ `L44-50: defensive: catch (Exception) wraps the whole body. Let the one recoverable error through; anything else is a bug.`
 
 ## Scoring
 

--- a/skills/ponytail-audit/SKILL.md
+++ b/skills/ponytail-audit/SKILL.md
@@ -20,13 +20,19 @@ Same as ponytail-review:
 - `stdlib:` hand-rolled thing the standard library ships. Name the function.
 - `native:` dependency or code doing what the platform already does. Name the feature.
 - `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `defensive:` over-defensive control flow (redundant null checks, dead branches) or a blanket catch/except swallowing every error. Replacement: flatten to guard clauses, one handler at the real boundary.
 - `shrink:` same logic, fewer lines. Show the shorter form.
 
 ## Hunt
 
 Deps the stdlib or platform already ships, single-implementation interfaces,
 factories with one product, wrappers that only delegate, files exporting one
-thing, dead flags and config, hand-rolled stdlib.
+thing, dead flags and config, hand-rolled stdlib. Also flag over-defensive
+control flow: nested condition ladders and redundant guards for states the
+code can't reach, blanket catch/except wrappers swallowing every error.
+Flatten, don't delete: guard clauses and early exits for nested conditionals,
+one handler at the real boundary. Never simplify away error handling that
+prevents data loss.
 
 ## Output
 

--- a/skills/ponytail-review/SKILL.md
+++ b/skills/ponytail-review/SKILL.md
@@ -24,6 +24,7 @@ Tags:
 - `stdlib:` hand-rolled thing the standard library ships. Name the function.
 - `native:` dependency or code doing what the platform already does. Name the feature.
 - `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
+- `defensive:` over-defensive control flow (redundant null checks, dead branches) or a blanket catch/except swallowing every error. Replacement: flatten to guard clauses, one handler at the real boundary.
 - `shrink:` same logic, fewer lines. Show the shorter form.
 
 ## Examples
@@ -40,6 +41,10 @@ considered whether all these validation rules are needed at this stage?"
 ✅ `L52-71: delete: retry wrapper around an idempotent local call. Nothing replaces it.`
 
 ✅ `L30-44: shrink: manual loop builds dict. dict(zip(keys, values)), 1 line.`
+
+✅ `L23-25: defensive: nullable value null-checked three times on the way to one use. Check it where it's read, drop the rest.`
+
+✅ `L44-50: defensive: catch (Exception) wraps the whole body. Let the one recoverable error through; anything else is a bug.`
 
 ## Scoring
 


### PR DESCRIPTION
## Why

`ponytail-audit` and `ponytail-review` target structural slop you fix by deleting — speculative abstraction, reinvented stdlib, dead flexibility. But a common AI-shaped failure has nothing structurally redundant to cut: over-defensive control flow (deeply nested condition ladders, redundant guards) and blanket `try/except` / `catch` wrappers that swallow uncertainty.

## What

Add a `defensive:` tag to both skills' vocabulary (byte-identical in both files, keeping audit's "Same as ponytail-review" true):

- over-defensive control flow (redundant null checks, dead branches) or a blanket catch/except swallowing every error
- Replacement: flatten to guard clauses, one handler at the real boundary

Two review examples covering each symptom (redundant null-checking, broad `catch (Exception)`), plus an audit Hunt entry following the issue's *flatten, don't delete* principle — explicitly never simplifying away error handling that prevents data loss.

## Tests

- `node --test tests/openclaw-skills.test.js` → 18/18
- `node scripts/check-rule-copies.js` → exit 0
- `npm test` → all pass except the pre-existing `csv: correct pandas one-liner passes` failure (fails identically on base; no pandas installed locally) — unrelated to this change.

Fixes #682
