### PR TITLE
ponytail-audit: no pass to flag AI-shaped test brittleness (fixture-name branches in prod, snapshot/mock-only assertions, 1:1 method-mirror tests)

### DIFF
--- a/.openclaw/skills/ponytail-audit/SKILL.md
+++ b/.openclaw/skills/ponytail-audit/SKILL.md
@@ -17,12 +17,16 @@ Same as ponytail-review:
 - `native:` dependency or code doing what the platform already does. Name the feature.
 - `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
 - `shrink:` same logic, fewer lines. Show the shorter form.
+- `test:` AI-shaped test brittleness: method mirrored 1:1, snapshot-only or mock-call-only assertions, fixture branches in prod code. Replacement: assert observable behavior.
 
 ## Hunt
 
 Deps the stdlib or platform already ships, single-implementation interfaces,
 factories with one product, wrappers that only delegate, files exporting one
-thing, dead flags and config, hand-rolled stdlib.
+thing, dead flags and config, hand-rolled stdlib. Also flag AI-shaped test
+brittleness: tests that mirror a method 1:1, snapshot-only or mock-call-only
+assertions, and — worst — fixture-name, id, or timestamp branches leaking into
+production code to make a test pass. Test behaviors, not methods.
 
 ## Output
 
@@ -33,5 +37,6 @@ End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. S
 
 Scope: over-engineering and complexity only. Correctness bugs, security holes,
 and performance are explicitly out of scope. Route them to a normal review
-pass. Lists findings, applies nothing. One-shot.
+pass. Test brittleness is dead weight to cut, not a correctness fix to keep.
+Lists findings, applies nothing. One-shot.
 "stop ponytail-audit" or "normal mode" to revert.

--- a/skills/ponytail-audit/SKILL.md
+++ b/skills/ponytail-audit/SKILL.md
@@ -21,12 +21,16 @@ Same as ponytail-review:
 - `native:` dependency or code doing what the platform already does. Name the feature.
 - `yagni:` abstraction with one implementation, config nobody sets, layer with one caller.
 - `shrink:` same logic, fewer lines. Show the shorter form.
+- `test:` AI-shaped test brittleness: method mirrored 1:1, snapshot-only or mock-call-only assertions, fixture branches in prod code. Replacement: assert observable behavior.
 
 ## Hunt
 
 Deps the stdlib or platform already ships, single-implementation interfaces,
 factories with one product, wrappers that only delegate, files exporting one
-thing, dead flags and config, hand-rolled stdlib.
+thing, dead flags and config, hand-rolled stdlib. Also flag AI-shaped test
+brittleness: tests that mirror a method 1:1, snapshot-only or mock-call-only
+assertions, and — worst — fixture-name, id, or timestamp branches leaking into
+production code to make a test pass. Test behaviors, not methods.
 
 ## Output
 
@@ -37,5 +41,6 @@ End with `net: -<N> lines, -<M> deps possible.` Nothing to cut: `Lean already. S
 
 Scope: over-engineering and complexity only. Correctness bugs, security holes,
 and performance are explicitly out of scope. Route them to a normal review
-pass. Lists findings, applies nothing. One-shot.
+pass. Test brittleness is dead weight to cut, not a correctness fix to keep.
+Lists findings, applies nothing. One-shot.
 "stop ponytail-audit" or "normal mode" to revert.


### PR DESCRIPTION
## Why

ponytail's test stance is "non-trivial logic leaves one runnable check," but `ponytail-audit` — scanning existing code — has no pass for AI-shaped *test* slop. Distinct from #602 (which constrains the agent while writing tests), this is about detecting brittleness in tests that already exist.

## What

Add a `test:` tag and a Hunt entry flagging three failure modes:

- tests that mirror a method 1:1 (break on any refactor; they assert structure, not behavior)
- snapshot-only or mock-call-only assertions (they pin the AI's own output, not observable behavior)
- worst: fixture-name / id / timestamp branches leaking into production code to make a test pass

Plus a Boundaries clarification that test brittleness is dead weight to cut, not a correctness fix — keeping audit's "correctness out of scope" stance intact.

## Tests

- `node --test tests/openclaw-skills.test.js` → 18/18
- `node scripts/check-rule-copies.js` → exit 0
- `npm test` → all pass except the pre-existing `csv: correct pandas one-liner passes` failure (fails identically on base; no pandas installed locally) — unrelated to this change.

Fixes #683
