### PR TITLE
feat: add OpenCode V2 adapter

### DIFF
--- a/.opencode/v2/ponytail.mjs
+++ b/.opencode/v2/ponytail.mjs
@@ -1,0 +1,44 @@
+// ponytail — OpenCode V2 plugin adapter.
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+
+const PLUGIN_ID = 'ponytail.v2';
+const CONTEXT_HOOK = 'context';
+const DISABLED_MODE = 'off';
+const CONFIG_DIRECTORY = 'opencode';
+const STATE_FILE = '.ponytail-active';
+const TEXT_ENCODING = 'utf8';
+const MISSING_FILE_ERROR_CODE = 'ENOENT';
+const STATE_READ_ERROR = 'ponytail: could not read mode state';
+
+const require = createRequire(import.meta.url);
+const { getPonytailInstructions } = require('../../hooks/ponytail-instructions');
+const { getDefaultMode, normalizePersistedMode } = require('../../hooks/ponytail-config');
+
+const statePath = path.join(
+  process.env.XDG_CONFIG_HOME || path.join(os.homedir(), '.config'),
+  CONFIG_DIRECTORY,
+  STATE_FILE,
+);
+
+function readMode() {
+  try {
+    return normalizePersistedMode(fs.readFileSync(statePath, TEXT_ENCODING).trim()) || getDefaultMode();
+  } catch (error) {
+    if (error?.code !== MISSING_FILE_ERROR_CODE) console.error(STATE_READ_ERROR, error);
+    return getDefaultMode();
+  }
+}
+
+export default {
+  id: PLUGIN_ID,
+  setup: async (ctx) => {
+    await ctx.session.hook(CONTEXT_HOOK, (event) => {
+      const mode = readMode();
+      if (mode !== DISABLED_MODE) event.system.push(getPonytailInstructions(mode));
+    });
+  },
+};

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "main": "./.opencode/plugins/ponytail.mjs",
   "exports": {
     ".": "./.opencode/plugins/ponytail.mjs",
-    "./plugin": "./.opencode/plugins/ponytail.mjs"
+    "./plugin": "./.opencode/plugins/ponytail.mjs",
+    "./v2": "./.opencode/v2/ponytail.mjs"
   },
   "files": [
     "AGENTS.md",

--- a/tests/opencode-v2-plugin.test.js
+++ b/tests/opencode-v2-plugin.test.js
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const TEMP_PREFIX = 'ponytail-opencode-v2-';
+const PLUGIN_ID = 'ponytail.v2';
+const CONTEXT_HOOK = 'context';
+const V2_EXPORT = './.opencode/v2/ponytail.mjs';
+const DEFAULT_MODE_PATTERN = /PONYTAIL MODE ACTIVE — level: full/;
+const ULTRA_MODE_PATTERN = /PONYTAIL MODE ACTIVE — level: ultra/;
+
+const tempConfigHome = fs.mkdtempSync(path.join(os.tmpdir(), TEMP_PREFIX));
+const statePath = path.join(tempConfigHome, 'opencode', '.ponytail-active');
+process.env.XDG_CONFIG_HOME = tempConfigHome;
+delete process.env.PONYTAIL_DEFAULT_MODE;
+
+let plugin;
+test.before(async () => {
+  const pluginPath = path.join(__dirname, '..', '.opencode', 'v2', 'ponytail.mjs');
+  plugin = (await import(pathToFileURL(pluginPath))).default;
+});
+
+async function setupPlugin() {
+  let contextHook;
+  await plugin.setup({
+    session: {
+      hook: async (name, callback) => {
+        assert.equal(name, CONTEXT_HOOK);
+        contextHook = callback;
+      },
+    },
+  });
+  return contextHook;
+}
+
+test('V2 adapter registers a unique plugin and injects the persisted mode', async () => {
+  const packageManifest = require('../package.json');
+  assert.equal(packageManifest.exports['./v2'], V2_EXPORT);
+  assert.equal(plugin.id, PLUGIN_ID);
+  const contextHook = await setupPlugin();
+
+  const defaultContext = { system: [] };
+  await contextHook(defaultContext);
+  assert.equal(defaultContext.system.length, 1);
+  assert.match(defaultContext.system[0], DEFAULT_MODE_PATTERN);
+
+  fs.mkdirSync(path.dirname(statePath), { recursive: true });
+  fs.writeFileSync(statePath, 'ultra');
+  const ultraContext = { system: ['Existing instructions'] };
+  await contextHook(ultraContext);
+  assert.equal(ultraContext.system.length, 2);
+  assert.match(ultraContext.system[1], ULTRA_MODE_PATTERN);
+
+  fs.writeFileSync(statePath, 'off');
+  const offContext = { system: [] };
+  await contextHook(offContext);
+  assert.deepEqual(offContext.system, []);
+});
+
+test.after(() => fs.rmSync(tempConfigHome, { recursive: true, force: true }));


### PR DESCRIPTION
Add a separate OpenCode V2 plugin export that injects the shared Ponytail instructions through the V2 session context hook. Preserve persisted mode handling and the existing V1 adapter.

## Test verification (RED → GREEN)

With the fix reverted, the new test fails (RED):

```
TAP version 13
# Subtest: V2 adapter registers a unique plugin and injects the persisted mode
not ok 1 - V2 adapter registers a unique plugin and injects the persisted mode
  ---
  duration_ms: 1.07946
  type: 'test'
  location: '/home/ousama/www/public/ousamabenyounes/ponytail/tests/opencode-v2-plugin.test.js:41:1'
  failureType: 'hookFailed'
  error: "Cannot find module '/home/ousama/www/public/ousamabenyounes/ponytail/.opencode/v2/ponytail.mjs' imported from /home/ousama/www/public/ousamabenyounes/ponytail/tests/opencode-v2-plugin.test.js"
  code: 'ERR_MODULE_NOT_FOUND'
  stack: |-
    finalizeResolution (node:internal/modules/esm/resolve:274:11)
    moduleResolve (node:internal/modules/esm/resolve:859:10)
    defaultResolve (node:internal/modules/esm/resolve:983:11)
    #cachedDefaultResolve (node:internal/modules/esm/loader:731:20)
    ModuleLoader.resolve (node:internal/modules/esm/loader:708:38)
    ModuleLoader.getModuleJobForImport (node:internal/modules/esm/loader:310:38)
    onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:664:36)
    TracingChannel.tracePromise (node:diagnostics_channel:350:14)
    ModuleLoader.import (node:internal/modules/esm/loader:663:21)
    defaultImportModuleDynamicallyForScript (node:internal/modules/esm/utils:235:31)
  ...
1..1
# tests 1
# suites 0
# pass 0
# fail 1
# cancelled 0
# skipped 0
# todo 0
# duration_ms 87.499084
```

With the fix applied, the test passes (GREEN):

```
GREEN attempt 1/2 (exit 0)
TAP version 13
# Subtest: V2 adapter registers a unique plugin and injects the persisted mode
ok 1 - V2 adapter registers a unique plugin and injects the persisted mode
  ---
  duration_ms: 11.759577
  type: 'test'
  ...
1..1
# tests 1
# suites 0
# pass 1
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 134.866061
```

## Full local suite

Command: `node scripts/check-rule-copies.js && node scripts/check-versions.js && npm test`

```
# tests 23
# suites 0
# pass 23
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 115.320577

> ponytail-mcp@4.9.0 test
> node --test ./test/*.test.js

TAP version 13
# Subtest: resolveMode keeps valid intensities
ok 1 - resolveMode keeps valid intensities
  ---
  duration_ms: 3.530473
  type: 'test'
  ...
# Subtest: resolveMode falls back to a runtime intensity for off/unknown/empty
ok 2 - resolveMode falls back to a runtime intensity for off/unknown/empty
  ---
  duration_ms: 1.174411
  type: 'test'
  ...
# Subtest: buildInstructions returns the ruleset tagged with the resolved mode
ok 3 - buildInstructions returns the ruleset tagged with the resolved mode
  ---
  duration_ms: 1.280801
  type: 'test'
  ...
1..3
# tests 3
# suites 0
# pass 3
# fail 0
# cancelled 0
# skipped 0
# todo 0
# duration_ms 111.474179
```

Fix #718
