### PR TITLE
feat: add a native spend firewall (#721)

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,34 @@ The ladder runs *after* it understands the problem, not instead of it: it reads 
 
 Lazy, not negligent: trust-boundary validation, data-loss handling, security, and accessibility are never on the chopping block.
 
+## Spend firewall
+
+Writing less code is one way not to burn money. Not looping forty times on a
+failing build is the other.
+
+Ponytail can hold a per-session budget, metered from the token usage in the
+agent's own transcript — the numbers you were actually billed for, not an
+estimate. It warns at 75% and stops the session at the limit:
+
+```
+/ponytail spend limit 5
+```
+
+```
+PONYTAIL SPEND WARNING — this session has spent $3.81 of its $5.00 budget (76%).
+$1.19 left. Wrap up the current task, or raise the limit with `/ponytail spend limit <usd>`.
+```
+
+It checks at two points: before a turn starts, and before each tool call. The
+second one is the point — a runaway loop spends its money inside a single turn,
+long before the next prompt boundary.
+
+`/ponytail spend` reports where you stand at any time, with or without a limit
+set. **Off unless you set a limit** — nothing changes on upgrade.
+
+No account, no network call, no third party: the budget is a number in your own
+config file. Full reference in [docs/spend-firewall.md](docs/spend-firewall.md).
+
 ## Install
 
 The most effort ponytail will ever ask of you:
@@ -305,13 +333,14 @@ These remove the plugin's own files. They leave behind a small amount of state p
 | Command | What it does |
 |---------|--------------|
 | `/ponytail [lite \| full \| ultra \| off]` | Set the intensity, or turn it off. No argument reports the current level. |
+| `/ponytail spend [limit <usd> \| reset \| warn \| block \| off]` | Session spend: report it, cap it, or clear the counter. See [Spend firewall](#spend-firewall). |
 | `/ponytail-review` | Review the current diff for over-engineering, hands back a delete-list. |
 | `/ponytail-audit` | Audit the whole repo for over-engineering, not just the diff. |
 | `/ponytail-debt` | Harvest the `ponytail:` shortcuts you've deferred into a ledger, so "later" doesn't become "never". |
 | `/ponytail-gain` | Show the measured impact scoreboard (less code, less cost, more speed) from the benchmark. |
 | `/ponytail-help` | Quick reference for the commands above. |
 
-Commands need a skill-capable host (Claude Code, Codex, Devin CLI, OpenCode, Gemini, pi, Swival, Hermes Agent, Qoder, Grok Build). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands.
+Commands need a skill-capable host (Claude Code, Codex, Devin CLI, OpenCode, Gemini, pi, Swival, Hermes Agent, Qoder, Grok Build). In Codex they're skills, invoke with `@` (`@ponytail-review`). The instruction-only adapters (Cursor, Windsurf, Cline, Copilot, Kiro, Antigravity) load the always-on ruleset without the commands. `/ponytail` and `/ponytail spend` are the exceptions: they are handled by hooks rather than skills, so they work on any host that runs ponytail's hooks.
 
 ## Development
 
@@ -332,7 +361,7 @@ The correctness benchmark spawns Python for email and CSV checks; `python3` is t
 Yes, and you should. Caveman shrinks what the agent says; ponytail shrinks what it builds. Different halves, no overlap: caveman leaves code byte-for-byte exact, ponytail stays out of the prose. Terse talk about minimal code.
 
 **Does it need a config file?**
-No. An optional `~/.config/ponytail/config.json` or `PONYTAIL_DEFAULT_MODE` env var can set the default level, but nothing is required.
+No. An optional `~/.config/ponytail/config.json` or `PONYTAIL_DEFAULT_MODE` env var can set the default level, and the same file holds the optional [spend budget](docs/spend-firewall.md), but nothing is required.
 
 **What if I really need the 120-line cache class?**
 You don't. Insist anyway and he'll build it. Slowly. Correctly. While looking at you.

--- a/docs/spend-firewall.md
+++ b/docs/spend-firewall.md
@@ -1,0 +1,166 @@
+# Spend firewall
+
+Ponytail's job is to stop an agent over-building. The spend firewall is the
+same instinct pointed at the bill: a per-session budget, metered from real token
+usage, that warns before you hit it and stops the session at it.
+
+It exists because the expensive failure isn't a long session — it's a loop. An
+agent that retries a failing build forty times spends forty times the money
+without ever telling you, and the first you hear of it is the invoice.
+
+**It is off unless you set a limit.** Nothing changes on upgrade.
+
+## Turn it on
+
+```
+/ponytail spend limit 5
+```
+
+Five dollars per session. You get a warning at 75%, and the session stops at
+$5.00.
+
+Or without the command:
+
+```bash
+export PONYTAIL_SPEND_LIMIT=5
+```
+
+## Commands
+
+| Command | What it does |
+|---------|--------------|
+| `/ponytail spend` | Report: spent, budget, percentage, tokens. Works with no limit set — just the meter. |
+| `/ponytail spend limit <usd>` | Set the per-session budget. Saved to config, so it applies to new sessions too. |
+| `/ponytail spend reset` | Zero this session's counter. The way out of a block when the work is legitimately worth more. |
+| `/ponytail spend warn` | Warn at the threshold and past the limit, never block. |
+| `/ponytail spend block` | Warn at the threshold, block at the limit. The default. |
+| `/ponytail spend off` | Stop warning and blocking. Metering continues, so `/ponytail spend` still reports. |
+
+These stay reachable from inside a blocked session — otherwise the only way out
+of a bad limit would be restarting the agent.
+
+## The two checkpoints
+
+The firewall runs at two points, because a runaway burns money at two rates:
+
+| Event | Catches | Effect |
+|-------|---------|--------|
+| `UserPromptSubmit` | A new turn starting on a session that is already over | The turn never runs — the cheapest possible stop |
+| `PreToolUse` | The loop running away *inside* one turn | The next tool call is denied |
+
+`PreToolUse` is the one that matters. A single turn can make hundreds of tool
+calls; checking only at the prompt boundary means the budget is enforced once
+per turn, long after the damage.
+
+## Configuration
+
+`~/.config/ponytail/config.json` (or `%APPDATA%\ponytail\config.json`):
+
+```json
+{
+  "spend": {
+    "limit": 5,
+    "warnAt": 0.75,
+    "mode": "block"
+  }
+}
+```
+
+| Key | Env var | Default | Meaning |
+|-----|---------|---------|---------|
+| `limit` | `PONYTAIL_SPEND_LIMIT` | none — feature off | Per-session budget in USD |
+| `warnAt` | `PONYTAIL_SPEND_WARN` | `0.75` | Warning threshold; `0.75` or `"75%"` |
+| `mode` | `PONYTAIL_SPEND_MODE` | `block` | `off`, `warn`, or `block` |
+| `prices` | — | built-in table | Per-model rate overrides |
+
+Env wins over the config file, matching how `PONYTAIL_DEFAULT_MODE` works.
+
+### Price overrides
+
+The built-in table carries Anthropic list prices. If you are on a negotiated
+rate, a partner platform with its own pricing (Bedrock, Vertex), or a model the
+table doesn't know, override it — USD per 1M tokens:
+
+```json
+{
+  "spend": {
+    "limit": 5,
+    "prices": {
+      "claude-opus-5": { "input": 4, "output": 20 },
+      "my-local-model": { "input": 0, "output": 0 }
+    }
+  }
+}
+```
+
+## How the number is arrived at
+
+The agent already writes a JSONL transcript of the session, and every assistant
+message in it carries the `usage` block the API returned. The firewall reads
+that. No API calls, no estimation, no tokenizer — the counts are the ones you
+were billed for.
+
+Three things about that file shape the implementation:
+
+**One message spans several lines.** The transcript writes one line per content
+block, and every line repeats the same `usage`. Summing lines roughly doubles
+the total — a measured session had 61 lines carrying 29 real messages. Messages
+are deduped by `message.id`.
+
+**It only grows.** Re-reading the whole file on every tool call is work
+proportional to session length, inside a 5-second hook timeout. Only the bytes
+appended since the last check are read, and the byte offset lives in the ledger.
+
+**It is written while you read it.** The last line is often half-flushed, so
+reading stops at the final newline and picks the rest up next time.
+
+Cache tokens are priced at their own multipliers off the input rate — 1.25× for
+a 5-minute cache write, 2× for a 1-hour write, 0.1× for a read. Cache reads are
+cheap, not free, and a loop that re-reads a 200k-token prefix every turn is
+exactly the runaway this catches.
+
+A model no table knows is counted in tokens but not in dollars, and
+`/ponytail spend` says so rather than quietly reading low.
+
+## State
+
+One JSON file per session under `~/.config/ponytail/spend/`. Per-session files
+rather than one shared one because sessions run concurrently and would clobber
+each other. Written temp-then-rename, so a hook killed by its timeout can't
+leave a truncated ledger that reads as "$0 spent". Files older than seven days
+are swept on the first read of a new session.
+
+## Host support
+
+| Host | Meter | Warn | Block |
+|------|-------|------|-------|
+| Claude Code | ✅ | ✅ | ✅ both checkpoints |
+| Codex, Qoder | ✅ | ✅ | advisory only |
+
+Hard denial needs the host to honour a hook's deny decision, which only native
+Claude Code is known to do on both events. Elsewhere the same message is
+injected as context — the agent is told to stop, it just isn't forced to.
+
+Copilot is deliberately not wired: it ignores hook output on every event except
+session start, so the firewall could meter there but never report or stop
+anything. The adapters that use a JS plugin API rather than hook manifests —
+OpenCode, pi, Hermes, Gemini — are not wired yet either.
+
+## When it fails
+
+Every failure path allows the work through. An unreadable transcript, a corrupt
+ledger, malformed hook input, a bug in the guard itself — all of them mean
+"don't block". A firewall that wedges a session over its own bug costs more
+than the bill it was preventing.
+
+The one deliberate inaccuracy is in the same direction: a cold read of a
+transcript larger than 32 MB starts from the tail rather than stalling the hook,
+so very long pre-existing sessions can under-count.
+
+## What this is not
+
+It is not billing, metering-as-a-service, or a payment integration. There is no
+account, no network call, and no third party — the budget is a number in your
+own config file, and the meter reads a file already on your disk. If you need to
+charge *your* users for *their* agent usage, that is a different problem and
+belongs in your application, not in a plugin that makes agents write less code.

--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -33,6 +33,24 @@
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."
+          },
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-spend.js\"",
+            "timeout": 5,
+            "statusMessage": "Checking ponytail spend budget..."
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-spend.js\"",
+            "timeout": 5,
+            "statusMessage": "Checking ponytail spend budget..."
           }
         ]
       }

--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -133,11 +133,10 @@ function getHideStatus() {
   }
 }
 
-function writeDefaultMode(mode) {
-  // ponytail: only a runtime level can be a default; review is session-only (#377).
-  const normalized = normalizeMode(mode);
-  if (!normalized) return null;
-
+// Merge top-level keys into config.json, leaving every other key alone. Both
+// the mode default and the spend budget persist through here, so writing one
+// can never drop the other.
+function updateConfig(patch) {
   const configPath = getConfigPath();
   fs.mkdirSync(path.dirname(configPath), { recursive: true });
   let config = {};
@@ -145,8 +144,16 @@ function writeDefaultMode(mode) {
     config = JSON.parse(fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
     if (!config || typeof config !== 'object' || Array.isArray(config)) config = {};
   } catch (_) {}
-  config.defaultMode = normalized;
+  Object.assign(config, patch);
   fs.writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
+  return config;
+}
+
+function writeDefaultMode(mode) {
+  // ponytail: only a runtime level can be a default; review is session-only (#377).
+  const normalized = normalizeMode(mode);
+  if (!normalized) return null;
+  updateConfig({ defaultMode: normalized });
   return normalized;
 }
 
@@ -165,5 +172,6 @@ module.exports = {
   normalizeConfigMode,
   normalizePersistedMode,
   isDeactivationCommand,
+  updateConfig,
   writeDefaultMode,
 };

--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -43,6 +43,11 @@ function finish() {
           }
           return; // don't fall through to the session-mode switch
         }
+        // `/ponytail spend ...` belongs to the spend firewall, which answers
+        // on this same event from ponytail-spend.js. It names a budget, not an
+        // intensity level, so the tracker must leave the session mode alone —
+        // otherwise asking about the budget silently resets the mode.
+        if (arg === 'spend') return;
         if (arg === 'lite') mode = 'lite';
         else if (arg === 'full') mode = 'full';
         else if (arg === 'ultra') mode = 'ultra';

--- a/hooks/ponytail-spend.js
+++ b/hooks/ponytail-spend.js
@@ -1,0 +1,115 @@
+#!/usr/bin/env node
+// ponytail — spend firewall hook (UserPromptSubmit + PreToolUse)
+//
+// Meters what the session has actually spent, from the transcript the agent is
+// already writing, and stops it at a budget the user set. Two checkpoints,
+// because a runaway burns money at two different rates:
+//
+//   UserPromptSubmit — cheapest possible stop: the turn never starts.
+//   PreToolUse       — catches the loop that runs away *inside* one turn, which
+//                      is the case that actually empties a budget.
+//
+// Off unless a limit is configured, and fail-open everywhere: a guard that
+// wedges a session over its own bug is worse than the bill it prevents.
+//
+// PreToolUse runs before every tool call, so the disabled path is the hot path.
+// Nothing is required at module load — the no-limit case reads one small config
+// file and exits, which keeps it within a few ms of bare `node -e 0`.
+
+const TIER_RANK = { ok: 0, warn: 1, block: 2 };
+
+let input = '';
+let done = false;
+
+// Advisory output, in whatever shape the host reads. The mode argument only
+// feeds Codex's status line, so it carries the session's real ponytail level —
+// passing something like 'spend' there would overwrite the level indicator.
+function emit(event, text) {
+  const { readMode, writeHookOutput } = require('./ponytail-runtime');
+  writeHookOutput(event, readMode() || 'off', text);
+}
+
+// Only native Claude Code is known to honour a hook's deny decision on both of
+// these events. Elsewhere the same message still goes out as advisory context —
+// the agent is told to stop, it just isn't forced to.
+function deny(event, reason) {
+  const { isCodex, isCopilot, isQoder } = require('./ponytail-runtime');
+  if (isCodex || isCopilot || isQoder) return emit(event, reason);
+
+  if (event === 'PreToolUse') {
+    return process.stdout.write(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: reason,
+      },
+    }));
+  }
+  process.stdout.write(JSON.stringify({ decision: 'deny', reason, systemMessage: reason }));
+}
+
+// A warning is worth saying once per tier, not once per tool call. The ledger
+// remembers how far the user has already been told.
+function notifyOnce(ledger, sessionId, tier, event, message) {
+  if (TIER_RANK[tier] <= TIER_RANK[ledger.notifiedTier || 'ok']) return;
+  ledger.notifiedTier = tier;
+  require('./spend/ledger').save(sessionId, ledger);
+  emit(event, message);
+}
+
+function handleCommand(command, sessionId, transcriptPath, config) {
+  const { applySpendCommand } = require('./spend/commands');
+  if (command.action !== 'status') {
+    return emit('UserPromptSubmit', applySpendCommand(command, sessionId));
+  }
+  // Status is the one command that needs a fresh read: it is what someone types
+  // to find out where they stand, so a stale number defeats the point.
+  const { evaluate, renderStatus } = require('./spend/policy');
+  const ledger = require('./spend/meter').meter(sessionId, transcriptPath, config);
+  emit('UserPromptSubmit', renderStatus(ledger, config, evaluate(ledger.costUsd, config)));
+}
+
+function finish() {
+  if (done) return;
+  done = true;
+  try {
+    const data = JSON.parse(input.replace(/^\uFEFF/, ''));
+    const event = data.hook_event_name === 'PreToolUse' ? 'PreToolUse' : 'UserPromptSubmit';
+    const sessionId = data.session_id;
+    const transcriptPath = data.transcript_path;
+
+    const policy = require('./spend/policy');
+    const config = policy.getSpendConfig();
+
+    // Commands are answered before the budget gate, on purpose: raising the
+    // limit or clearing the counter has to stay reachable from inside a blocked
+    // session, or the only way out is to restart the agent.
+    if (event === 'UserPromptSubmit') {
+      const command = require('./spend/commands').parseSpendCommand(data.prompt);
+      if (command) return handleCommand(command, sessionId, transcriptPath, config);
+    }
+
+    // No budget, nothing to enforce — and no transcript read on the hot path
+    // for the users who never asked for this.
+    if (!config.enabled) return;
+
+    const ledger = require('./spend/meter').meter(sessionId, transcriptPath, config);
+    const decision = policy.evaluate(ledger.costUsd, config);
+
+    if (decision.tier === 'block') return deny(event, policy.renderBlock(ledger, config, decision));
+    if (decision.tier === 'warn') {
+      notifyOnce(ledger, sessionId, 'warn', event, policy.renderWarning(ledger, config, decision));
+    }
+  } catch (e) {
+    // Fail open. A hook that can't parse its own input must not be the reason a
+    // session stops working.
+  }
+}
+
+process.stdin.on('data', (chunk) => { input += chunk; });
+process.stdin.on('end', finish);
+
+// Same never-hang contract the other lifecycle hooks follow: on Windows the
+// PowerShell wrapper can swallow the piped JSON so 'end' never fires (#443).
+process.stdin.on('error', () => { finish(); process.exit(0); });
+setTimeout(() => { finish(); process.exit(0); }, 1000).unref();

--- a/hooks/qoder-hooks.json
+++ b/hooks/qoder-hooks.json
@@ -7,6 +7,10 @@
           {
             "type": "command",
             "command": "node PONYTAIL_DIR/hooks/ponytail-mode-tracker.js"
+          },
+          {
+            "type": "command",
+            "command": "node PONYTAIL_DIR/hooks/ponytail-spend.js"
           }
         ]
       }
@@ -18,6 +22,14 @@
           {
             "type": "command",
             "command": "node PONYTAIL_DIR/hooks/ponytail-subagent.js"
+          }
+        ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node PONYTAIL_DIR/hooks/ponytail-spend.js"
           }
         ]
       }

--- a/hooks/spend/commands.js
+++ b/hooks/spend/commands.js
@@ -1,0 +1,81 @@
+// ponytail — spend firewall: the `/ponytail spend ...` command surface.
+//
+// Parsing lives apart from the hook that runs it so the grammar can be tested
+// without a process, a transcript, or a config file.
+
+const fs = require('fs');
+const { getConfigPath, updateConfig } = require('../ponytail-config');
+const { MODES, parseMode, parseUsd } = require('./policy');
+const { reset } = require('./ledger');
+
+// Matches the same prefixes the mode tracker accepts: `/ponytail`, `@ponytail`
+// (Codex), `$ponytail`, and the `/ponytail:ponytail` plugin-namespaced form.
+const INVOCATION = /^[/@$]ponytail(?::ponytail)?\s+spend\b/i;
+
+// Returns null when the prompt is not a spend command, so the caller can fall
+// straight through to metering.
+function parseSpendCommand(prompt) {
+  const text = String(prompt || '').trim();
+  if (!INVOCATION.test(text)) return null;
+
+  const args = text.split(/\s+/).slice(2);
+  const verb = (args[0] || '').toLowerCase().replace(/[.!?]+$/, '');
+
+  if (!verb || verb === 'status') return { action: 'status' };
+  if (verb === 'reset' || verb === 'clear') return { action: 'reset' };
+  if (verb === 'limit' || verb === 'budget') {
+    const amount = parseUsd(args[1]);
+    return amount
+      ? { action: 'limit', amount }
+      : { action: 'invalid', detail: 'limit needs a dollar amount, e.g. `/ponytail spend limit 5`' };
+  }
+  if (parseMode(verb)) return { action: 'mode', mode: parseMode(verb) };
+
+  return { action: 'invalid', detail: 'unknown option "' + verb + '"' };
+}
+
+// The stored spend section, so a partial update keeps the keys it isn't
+// touching. Resolved config can't be reused here: it has env overrides and
+// defaults folded in, and writing those back would persist them by accident.
+function readSpendSection() {
+  try {
+    const config = JSON.parse(fs.readFileSync(getConfigPath(), 'utf8').replace(/^\uFEFF/, ''));
+    const spend = config && config.spend;
+    return spend && typeof spend === 'object' && !Array.isArray(spend) ? spend : {};
+  } catch (e) {
+    return {};
+  }
+}
+
+// Applies a parsed command and returns the line to show the user. `status` is
+// handled by the caller, which has the metered ledger this module doesn't.
+function applySpendCommand(command, sessionId) {
+  const spend = readSpendSection();
+
+  if (command.action === 'reset') {
+    reset(sessionId);
+    return "PONYTAIL SPEND RESET — this session's counter is back to $0.00.";
+  }
+
+  if (command.action === 'limit') {
+    updateConfig({ spend: { ...spend, limit: command.amount } });
+    return 'PONYTAIL SPEND LIMIT SET — $' + command.amount.toFixed(2) +
+      ' per session, saved to config. Mode: ' + (parseMode(spend.mode) || 'block') + '.';
+  }
+
+  if (command.action === 'mode') {
+    updateConfig({ spend: { ...spend, mode: command.mode } });
+    const explain = {
+      off: 'metering continues, nothing is warned or blocked',
+      warn: 'warns at the threshold and over the limit, never blocks',
+      block: 'warns at the threshold, blocks at the limit',
+    }[command.mode];
+    return 'PONYTAIL SPEND MODE — ' + command.mode + ': ' + explain + '.';
+  }
+
+  return 'PONYTAIL SPEND — ' + (command.detail || 'unrecognized command') + '. Try: `/ponytail spend`, ' +
+    '`/ponytail spend limit <usd>`, `/ponytail spend reset`, or `/ponytail spend ' +
+    MODES.join('|') + '`.';
+}
+
+module.exports = { INVOCATION, applySpendCommand, parseSpendCommand };

--- a/hooks/spend/ledger.js
+++ b/hooks/spend/ledger.js
@@ -1,0 +1,102 @@
+// ponytail — spend firewall: the per-session ledger on disk.
+//
+// One JSON file per session under the ponytail config dir. Per-session files
+// rather than one shared file because sessions run concurrently: two agents
+// writing one document lose each other's writes, two agents writing their own
+// files don't.
+
+const fs = require('fs');
+const path = require('path');
+const { getConfigDir } = require('../ponytail-config');
+
+const LEDGER_VERSION = 1;
+const PRUNE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+
+function ledgerDir() {
+  return path.join(getConfigDir(), 'spend');
+}
+
+// Session ids come from the host agent, so they reach the filesystem untrusted.
+// An allowlist keeps "../../.bashrc" from becoming a path.
+function safeName(sessionId) {
+  const cleaned = String(sessionId || '').replace(/[^A-Za-z0-9._-]/g, '_').slice(0, 64);
+  return cleaned && cleaned !== '.' && cleaned !== '..' ? cleaned : 'default';
+}
+
+function ledgerPath(sessionId) {
+  return path.join(ledgerDir(), safeName(sessionId) + '.json');
+}
+
+function emptyLedger(sessionId) {
+  return {
+    version: LEDGER_VERSION,
+    sessionId: sessionId || null,
+    startedAt: new Date().toISOString(),
+    offset: 0,
+    seen: [],
+    tokens: 0,
+    costUsd: 0,
+    unpricedTokens: 0,
+    unpricedModels: [],
+    // Highest tier the user has already been told about, so a warning is shown
+    // once at the threshold instead of on every prompt after it.
+    notifiedTier: 'ok',
+  };
+}
+
+function load(sessionId) {
+  try {
+    const raw = fs.readFileSync(ledgerPath(sessionId), 'utf8').replace(/^\uFEFF/, '');
+    const state = JSON.parse(raw);
+    if (!state || typeof state !== 'object' || state.version !== LEDGER_VERSION) {
+      return emptyLedger(sessionId);
+    }
+    return { ...emptyLedger(sessionId), ...state };
+  } catch (e) {
+    return emptyLedger(sessionId);
+  }
+}
+
+// Write to a temp file and rename: a hook killed by its timeout mid-write
+// leaves the previous ledger intact instead of a truncated one that reads as
+// "$0 spent so far".
+function save(sessionId, state) {
+  try {
+    const target = ledgerPath(sessionId);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    const temp = target + '.' + process.pid + '.tmp';
+    fs.writeFileSync(temp, JSON.stringify({ ...state, updatedAt: new Date().toISOString() }), 'utf8');
+    fs.renameSync(temp, target);
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function reset(sessionId) {
+  const fresh = emptyLedger(sessionId);
+  save(sessionId, fresh);
+  return fresh;
+}
+
+// Sessions end without telling us, so old ledgers are swept on write rather
+// than cleaned up on exit.
+function prune(maxAgeMs = PRUNE_AFTER_MS) {
+  let removed = 0;
+  try {
+    const dir = ledgerDir();
+    const cutoff = Date.now() - maxAgeMs;
+    for (const name of fs.readdirSync(dir)) {
+      const file = path.join(dir, name);
+      try {
+        if (fs.statSync(file).mtimeMs < cutoff) {
+          fs.unlinkSync(file);
+          removed++;
+        }
+      } catch (e) { /* raced with another hook — fine */ }
+    }
+  } catch (e) { /* no ledger dir yet */ }
+  return removed;
+}
+
+module.exports = { LEDGER_VERSION, PRUNE_AFTER_MS, emptyLedger, ledgerDir, ledgerPath, load, prune, reset, safeName, save };

--- a/hooks/spend/meter.js
+++ b/hooks/spend/meter.js
@@ -1,0 +1,45 @@
+// ponytail — spend firewall: turns new transcript bytes into a running total.
+// The one place transcript reading, pricing, and the ledger meet.
+
+const { costOf, resolveRate, tokensOf } = require('./pricing');
+const { load, prune, save } = require('./ledger');
+const { readUsageSince } = require('./transcript');
+
+// Reads whatever the agent has appended since the last call, prices it, and
+// persists the new total. Returns the ledger either way, so a caller can report
+// a session's spend without caring whether anything moved.
+function meter(sessionId, transcriptPath, config = {}) {
+  const ledger = load(sessionId);
+  const firstRead = ledger.offset === 0;
+  const { offset, seen, records } = readUsageSince(transcriptPath, ledger);
+
+  if (!records.length && offset === ledger.offset) return ledger;
+
+  const unpriced = new Set(ledger.unpricedModels);
+  for (const record of records) {
+    const tokens = tokensOf(record.usage);
+    ledger.tokens += tokens;
+
+    const rate = resolveRate(record.model, config.prices);
+    if (rate) {
+      ledger.costUsd += costOf(record.usage, rate);
+    } else {
+      // A model no table knows — a local or self-hosted one. Its tokens are
+      // still counted and surfaced, so the total never silently reads low.
+      ledger.unpricedTokens += tokens;
+      if (record.model) unpriced.add(String(record.model));
+    }
+  }
+
+  ledger.offset = offset;
+  ledger.seen = seen;
+  ledger.unpricedModels = [...unpriced].slice(0, 8);
+  save(sessionId, ledger);
+
+  // Sessions never announce their end, so old ledgers are swept once per
+  // session instead of on exit.
+  if (firstRead) prune();
+  return ledger;
+}
+
+module.exports = { meter };

--- a/hooks/spend/policy.js
+++ b/hooks/spend/policy.js
@@ -1,0 +1,161 @@
+// ponytail — spend firewall: what the budget is, and what to do about it.
+//
+// Two tiers, which is the whole design: a warning while there is still room to
+// change course, and a hard stop at the limit. One tier is either a nag you
+// learn to ignore or a wall you hit with no notice.
+
+const fs = require('fs');
+const { getConfigPath } = require('../ponytail-config');
+
+const DEFAULT_WARN_AT = 0.75;
+const DEFAULT_MODE = 'block';
+const MODES = ['off', 'warn', 'block'];
+
+function readConfigFile() {
+  try {
+    const raw = fs.readFileSync(getConfigPath(), 'utf8').replace(/^\uFEFF/, '');
+    const config = JSON.parse(raw);
+    return config && typeof config === 'object' ? config : {};
+  } catch (e) {
+    return {};
+  }
+}
+
+function parseUsd(value) {
+  const amount = typeof value === 'string' ? Number(value.trim().replace(/^\$/, '')) : Number(value);
+  return isFinite(amount) && amount > 0 ? amount : null;
+}
+
+// Accepts 0.75 and "75%" — people write thresholds both ways.
+function parseFraction(value) {
+  if (typeof value === 'string' && value.trim().endsWith('%')) {
+    const percent = Number(value.trim().slice(0, -1));
+    return isFinite(percent) && percent > 0 && percent < 100 ? percent / 100 : null;
+  }
+  const fraction = Number(value);
+  return isFinite(fraction) && fraction > 0 && fraction < 1 ? fraction : null;
+}
+
+function parseMode(value) {
+  const mode = String(value || '').trim().toLowerCase();
+  return MODES.includes(mode) ? mode : null;
+}
+
+// Only price overrides shaped like the built-in table are accepted; a typo in
+// config.json must not make a model look free.
+function parsePrices(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
+  const prices = {};
+  for (const [model, rate] of Object.entries(value)) {
+    if (!rate || typeof rate !== 'object') continue;
+    const input = Number(rate.input);
+    const output = Number(rate.output);
+    if (!isFinite(input) || input < 0 || !isFinite(output) || output < 0) continue;
+    prices[String(model).trim().toLowerCase()] = { input, output };
+  }
+  return Object.keys(prices).length ? prices : null;
+}
+
+// Env beats config, matching how ponytail resolves its mode. The firewall is
+// off until someone names a limit: a guard that starts blocking on upgrade
+// without being asked is a worse surprise than the bill it prevents.
+function getSpendConfig(env = process.env) {
+  const file = readConfigFile().spend || {};
+  const limitUsd = parseUsd(env.PONYTAIL_SPEND_LIMIT) || parseUsd(file.limit);
+  const warnAt = parseFraction(env.PONYTAIL_SPEND_WARN) || parseFraction(file.warnAt) || DEFAULT_WARN_AT;
+  const mode = parseMode(env.PONYTAIL_SPEND_MODE) || parseMode(file.mode) || DEFAULT_MODE;
+  const prices = parsePrices(file.prices);
+
+  return {
+    enabled: Boolean(limitUsd) && mode !== 'off',
+    limitUsd: limitUsd || null,
+    warnAt,
+    mode,
+    prices,
+  };
+}
+
+// tier is what to *do*: 'ok' | 'warn' | 'block'. overLimit is what is *true* —
+// they come apart in warn mode, where the budget is blown but nothing is denied.
+function evaluate(costUsd, config) {
+  const spent = isFinite(costUsd) && costUsd > 0 ? costUsd : 0;
+  if (!config || !config.enabled) {
+    return { tier: 'ok', ratio: 0, overLimit: false, remainingUsd: null, spentUsd: spent };
+  }
+  const ratio = spent / config.limitUsd;
+  const overLimit = spent >= config.limitUsd;
+  let tier = 'ok';
+  if (overLimit) tier = config.mode === 'block' ? 'block' : 'warn';
+  else if (ratio >= config.warnAt) tier = 'warn';
+
+  return {
+    tier,
+    ratio,
+    overLimit,
+    remainingUsd: Math.max(0, config.limitUsd - spent),
+    spentUsd: spent,
+  };
+}
+
+function formatUsd(amount) {
+  const value = isFinite(amount) && amount > 0 ? amount : 0;
+  return '$' + (value > 0 && value < 0.01 ? value.toFixed(4) : value.toFixed(2));
+}
+
+function formatTokens(count) {
+  const value = isFinite(count) && count > 0 ? Math.round(count) : 0;
+  if (value < 1000) return String(value);
+  if (value < 1e6) return (value / 1000).toFixed(1).replace(/\.0$/, '') + 'k';
+  return (value / 1e6).toFixed(2).replace(/\.00$/, '') + 'M';
+}
+
+// One line, because it is shown alongside real work and not instead of it.
+function renderStatus(ledger, config, decision) {
+  if (!config.enabled) {
+    return 'PONYTAIL SPEND — ' + formatUsd(ledger.costUsd) + ' this session (' +
+      formatTokens(ledger.tokens) + ' tokens). No limit set; the firewall is off. ' +
+      'Set one with `/ponytail spend limit 5`.';
+  }
+  const parts = [
+    'PONYTAIL SPEND — ' + formatUsd(ledger.costUsd) + ' of ' + formatUsd(config.limitUsd) +
+      ' (' + Math.round(decision.ratio * 100) + '%), ' + formatTokens(ledger.tokens) + ' tokens',
+    'mode: ' + config.mode,
+  ];
+  if (ledger.unpricedTokens > 0) {
+    parts.push(formatTokens(ledger.unpricedTokens) + ' tokens not priced (' +
+      ledger.unpricedModels.join(', ') + ')');
+  }
+  return parts.join(' · ') + '.';
+}
+
+function renderWarning(ledger, config, decision) {
+  return 'PONYTAIL SPEND WARNING — this session has spent ' + formatUsd(ledger.costUsd) +
+    ' of its ' + formatUsd(config.limitUsd) + ' budget (' + Math.round(decision.ratio * 100) + '%). ' +
+    formatUsd(decision.remainingUsd) + ' left. Wrap up the current task, or raise the limit with ' +
+    '`/ponytail spend limit <usd>`.';
+}
+
+function renderBlock(ledger, config, decision) {
+  return 'PONYTAIL SPEND LIMIT REACHED — this session has spent ' + formatUsd(ledger.costUsd) +
+    ', at or past its ' + formatUsd(config.limitUsd) + ' budget. Further work is blocked. ' +
+    'Stop and tell the user; do not retry or work around this. ' +
+    'They can raise the limit (`/ponytail spend limit <usd>`), clear the counter ' +
+    '(`/ponytail spend reset`), or switch to warnings only (`/ponytail spend warn`).';
+}
+
+module.exports = {
+  DEFAULT_MODE,
+  DEFAULT_WARN_AT,
+  MODES,
+  evaluate,
+  formatTokens,
+  formatUsd,
+  getSpendConfig,
+  parseFraction,
+  parseMode,
+  parsePrices,
+  parseUsd,
+  renderBlock,
+  renderStatus,
+  renderWarning,
+};

--- a/hooks/spend/pricing.js
+++ b/hooks/spend/pricing.js
@@ -1,0 +1,115 @@
+// ponytail — spend firewall: model rates and cost math. Pure, no I/O.
+//
+// Rates are USD per 1M tokens, list price. Cache tokens are priced off the
+// model's input rate by a multiplier rather than getting their own columns:
+// that is how the vendors quote them, and it means a new model only ever needs
+// one row here.
+
+// Anthropic list prices (USD / 1M tokens).
+const RATES = {
+  'claude-fable-5': { input: 10, output: 50 },
+  'claude-mythos-5': { input: 10, output: 50 },
+  'claude-opus-5': { input: 5, output: 25 },
+  'claude-opus-4-8': { input: 5, output: 25 },
+  'claude-opus-4-7': { input: 5, output: 25 },
+  'claude-opus-4-6': { input: 5, output: 25 },
+  'claude-sonnet-5': { input: 3, output: 15 },
+  'claude-sonnet-4-6': { input: 3, output: 15 },
+  'claude-haiku-4-5': { input: 1, output: 5 },
+};
+
+// Applied to the model's input rate.
+const CACHE_WRITE_5M = 1.25;
+const CACHE_WRITE_1H = 2;
+const CACHE_READ = 0.1;
+
+// Last-resort rate when the exact id is unknown: a model called "...opus..."
+// bills like an opus. Better a right-order-of-magnitude number than counting a
+// new release as free.
+const FAMILIES = [
+  ['fable', { input: 10, output: 50 }],
+  ['mythos', { input: 10, output: 50 }],
+  ['opus', { input: 5, output: 25 }],
+  ['sonnet', { input: 3, output: 15 }],
+  ['haiku', { input: 1, output: 5 }],
+];
+
+// Strip what the gateways bolt on: bedrock's "us.anthropic." region+vendor
+// prefix, vertex's "@20260101" version separator, and the dated snapshot
+// suffix. All three name the same model at the same price.
+function normalizeModel(model) {
+  if (typeof model !== 'string') return '';
+  return model
+    .trim()
+    .toLowerCase()
+    .replace(/^(?:[a-z]{2,6}\.)?anthropic\./, '')
+    .replace(/@.*$/, '')
+    .replace(/-\d{8}$/, '');
+}
+
+// Exact id, then a known id it extends ("claude-opus-5-fast"), then the family.
+// Returns null for a genuinely unrecognizable model so the caller can report
+// the tokens as unpriced instead of silently valuing them at zero.
+function resolveRate(model, overrides) {
+  const id = normalizeModel(model);
+  if (!id) return null;
+  if (overrides && overrides[id]) return overrides[id];
+  if (RATES[id]) return RATES[id];
+
+  const prefix = Object.keys(RATES)
+    .filter((known) => id.startsWith(known))
+    .sort((a, b) => b.length - a.length)[0];
+  if (prefix) return RATES[prefix];
+
+  const family = FAMILIES.find(([name]) => id.includes(name));
+  return family ? family[1] : null;
+}
+
+function num(value) {
+  return typeof value === 'number' && isFinite(value) && value > 0 ? value : 0;
+}
+
+// Total billable tokens in one usage block. Cache reads count: they are cheap,
+// not free, and a loop that re-reads a 200k-token cache every turn is exactly
+// the runaway this guard exists to catch.
+function tokensOf(usage) {
+  if (!usage || typeof usage !== 'object') return 0;
+  return num(usage.input_tokens) +
+    num(usage.output_tokens) +
+    num(usage.cache_creation_input_tokens) +
+    num(usage.cache_read_input_tokens);
+}
+
+function costOf(usage, rate) {
+  if (!usage || typeof usage !== 'object' || !rate) return 0;
+
+  // The 5m/1h split is only present on newer transcripts; without it the flat
+  // cache_creation_input_tokens is priced at the 5m rate, which is what a
+  // request that never asked for a 1h TTL actually paid.
+  const breakdown = usage.cache_creation;
+  let write5m = num(usage.cache_creation_input_tokens);
+  let write1h = 0;
+  if (breakdown && typeof breakdown === 'object') {
+    write5m = num(breakdown.ephemeral_5m_input_tokens);
+    write1h = num(breakdown.ephemeral_1h_input_tokens);
+  }
+
+  const inputUsd = rate.input * (
+    num(usage.input_tokens) +
+    write5m * CACHE_WRITE_5M +
+    write1h * CACHE_WRITE_1H +
+    num(usage.cache_read_input_tokens) * CACHE_READ
+  );
+  return (inputUsd + rate.output * num(usage.output_tokens)) / 1e6;
+}
+
+module.exports = {
+  RATES,
+  CACHE_WRITE_5M,
+  CACHE_WRITE_1H,
+  CACHE_READ,
+  normalizeModel,
+  resolveRate,
+  tokensOf,
+  costOf,
+};

--- a/hooks/spend/transcript.js
+++ b/hooks/spend/transcript.js
@@ -1,0 +1,100 @@
+// ponytail — spend firewall: reads token usage out of the agent's session
+// transcript.
+//
+// The transcript is JSONL, append-only, and the only place a hook can see what
+// a turn actually cost. Two things make a naive read wrong:
+//
+//   1. One assistant message spans several lines (one per content block) and
+//      every line repeats the same usage block. Summing lines double-counts —
+//      measured 61 lines for 29 real messages on a normal session. Dedupe by
+//      message id.
+//   2. Re-reading the whole file on every tool call is O(session) work inside a
+//      5-second hook timeout. Read only the bytes appended since last time.
+
+const fs = require('fs');
+
+// Duplicate blocks of one message are always adjacent, so a short rolling
+// window catches them all. This is what keeps the cursor a fixed size.
+const SEEN_WINDOW = 200;
+
+// A cold read of a very long session shouldn't stall the hook. Past this, start
+// from the tail and accept that the earlier spend is missed — undercounting is
+// the safe direction for a guard that blocks.
+const MAX_SCAN_BYTES = 32 * 1024 * 1024;
+
+function readSlice(fd, start, end) {
+  const length = end - start;
+  const buffer = Buffer.allocUnsafe(length);
+  let filled = 0;
+  while (filled < length) {
+    const read = fs.readSync(fd, buffer, filled, length - filled, start + filled);
+    if (read <= 0) break;
+    filled += read;
+  }
+  return buffer.subarray(0, filled).toString('utf8');
+}
+
+// Returns { offset, seen, records } — records are the usage blocks that are new
+// since `cursor`, each { id, model, usage }. Never throws: an unreadable or
+// half-written transcript yields no records and leaves the cursor alone.
+function readUsageSince(transcriptPath, cursor) {
+  const seen = Array.isArray(cursor && cursor.seen) ? cursor.seen.slice() : [];
+  let offset = Number(cursor && cursor.offset) > 0 ? Number(cursor.offset) : 0;
+  const empty = { offset, seen, records: [] };
+
+  if (!transcriptPath) return empty;
+
+  let fd;
+  try {
+    const size = fs.statSync(transcriptPath).size;
+    // Truncated, rotated, or a different session reusing the path — the byte
+    // offset means nothing now, so recount from the top.
+    if (size < offset) offset = 0;
+    if (size === offset) return { offset, seen, records: [] };
+    if (size - offset > MAX_SCAN_BYTES) offset = size - MAX_SCAN_BYTES;
+
+    fd = fs.openSync(transcriptPath, 'r');
+    const chunk = readSlice(fd, offset, size);
+
+    // Stop at the last newline: the tail may be a line the agent is still
+    // writing. Leaving it unconsumed means the next run picks it up whole.
+    const lastBreak = chunk.lastIndexOf('\n');
+    if (lastBreak < 0) return { offset, seen, records: [] };
+
+    const records = [];
+    const seenSet = new Set(seen);
+    for (const line of chunk.slice(0, lastBreak).split('\n')) {
+      if (!line || line[0] !== '{') continue;
+      let entry;
+      try {
+        entry = JSON.parse(line);
+      } catch (e) {
+        continue; // a corrupt line is not a reason to stop metering
+      }
+      const message = entry && entry.message;
+      if (!message || !message.usage) continue;
+
+      // requestId is the fallback for transcripts that omit message.id; a line
+      // with neither is counted rather than dropped, since skipping real spend
+      // is worse than the rare double count.
+      const id = message.id || entry.requestId;
+      if (id) {
+        if (seenSet.has(id)) continue;
+        seenSet.add(id);
+        seen.push(id);
+      }
+      records.push({ id: id || null, model: message.model, usage: message.usage });
+    }
+
+    if (seen.length > SEEN_WINDOW) seen.splice(0, seen.length - SEEN_WINDOW);
+    return { offset: offset + Buffer.byteLength(chunk.slice(0, lastBreak + 1), 'utf8'), seen, records };
+  } catch (e) {
+    return empty;
+  } finally {
+    if (fd !== undefined) {
+      try { fs.closeSync(fd); } catch (e) { /* best-effort */ }
+    }
+  }
+}
+
+module.exports = { readUsageSince, SEEN_WINDOW, MAX_SCAN_BYTES };

--- a/tests/spend.test.js
+++ b/tests/spend.test.js
@@ -1,0 +1,420 @@
+#!/usr/bin/env node
+// ponytail — spend firewall tests.
+//
+// The three failure modes that make a spend guard worse than none:
+//   counting the same message twice (blocks a session that is under budget),
+//   missing spend entirely (never blocks), and
+//   throwing (wedges the session over the guard's own bug).
+// Each has a test below.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const root = path.join(__dirname, '..');
+const hook = path.join(root, 'hooks', 'ponytail-spend.js');
+
+const pricing = require('../hooks/spend/pricing');
+const policy = require('../hooks/spend/policy');
+const ledger = require('../hooks/spend/ledger');
+const commands = require('../hooks/spend/commands');
+const { readUsageSince } = require('../hooks/spend/transcript');
+const { meter } = require('../hooks/spend/meter');
+
+const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-spend-'));
+process.on('exit', () => fs.rmSync(temp, { recursive: true, force: true }));
+
+let counter = 0;
+function sandbox() {
+  const dir = path.join(temp, 'box-' + counter++);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+// One assistant message as the transcript actually stores it: repeated once per
+// content block, every copy carrying the same usage.
+function assistantLines(id, model, usage, copies = 1) {
+  const line = JSON.stringify({
+    type: 'assistant',
+    requestId: 'req_' + id,
+    message: { id: 'msg_' + id, model, usage },
+  });
+  return Array(copies).fill(line);
+}
+
+function writeTranscript(dir, lines) {
+  const file = path.join(dir, 'transcript.jsonl');
+  fs.writeFileSync(file, lines.join('\n') + '\n', 'utf8');
+  return file;
+}
+
+function runHook(payload, env) {
+  return spawnSync(process.execPath, [hook], {
+    env: { ...process.env, ...env },
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+  });
+}
+
+// ---------------------------------------------------------------- pricing
+
+test('rates resolve through the forms a model id actually arrives in', () => {
+  assert.deepEqual(pricing.resolveRate('claude-opus-5'), { input: 5, output: 25 });
+  assert.deepEqual(pricing.resolveRate('us.anthropic.claude-sonnet-5'), { input: 3, output: 15 });
+  assert.deepEqual(pricing.resolveRate('claude-opus-4-5@20251101'), { input: 5, output: 25 });
+  assert.deepEqual(pricing.resolveRate('claude-haiku-4-5-20251001'), { input: 1, output: 5 });
+  // Unknown id, known family — an unreleased opus must not bill as free.
+  assert.deepEqual(pricing.resolveRate('claude-opus-9-turbo'), { input: 5, output: 25 });
+  assert.equal(pricing.resolveRate('llama3.2:latest'), null);
+  assert.equal(pricing.resolveRate(''), null);
+});
+
+test('config price overrides win over the built-in table', () => {
+  const rate = pricing.resolveRate('claude-opus-5', { 'claude-opus-5': { input: 1, output: 2 } });
+  assert.deepEqual(rate, { input: 1, output: 2 });
+});
+
+test('cache tokens are priced at their own multipliers, not the input rate', () => {
+  const rate = { input: 10, output: 0 };
+  // 1M of each, so the cost in dollars reads back as the multiplier.
+  assert.equal(pricing.costOf({ cache_read_input_tokens: 1e6 }, rate), 10 * pricing.CACHE_READ);
+  assert.equal(pricing.costOf({ cache_creation_input_tokens: 1e6 }, rate), 10 * pricing.CACHE_WRITE_5M);
+  assert.equal(
+    pricing.costOf({ cache_creation: { ephemeral_1h_input_tokens: 1e6 } }, rate),
+    10 * pricing.CACHE_WRITE_1H,
+  );
+});
+
+test('cost is zero for junk input rather than NaN', () => {
+  assert.equal(pricing.costOf(null, { input: 1, output: 1 }), 0);
+  assert.equal(pricing.costOf({ output_tokens: -5 }, { input: 1, output: 1 }), 0);
+  assert.equal(pricing.costOf({ output_tokens: 5 }, null), 0);
+});
+
+// ------------------------------------------------------------- transcript
+
+test('one message split across content blocks is counted once', () => {
+  const dir = sandbox();
+  const usage = { input_tokens: 100, output_tokens: 1000 };
+  const file = writeTranscript(dir, [
+    ...assistantLines('a', 'claude-opus-5', usage, 3),
+    ...assistantLines('b', 'claude-opus-5', usage, 2),
+  ]);
+  const { records } = readUsageSince(file, { offset: 0, seen: [] });
+  assert.equal(records.length, 2, 'five lines, two real messages');
+});
+
+test('a second read only picks up what was appended', () => {
+  const dir = sandbox();
+  const usage = { output_tokens: 1000 };
+  const file = writeTranscript(dir, assistantLines('a', 'claude-opus-5', usage));
+
+  const first = readUsageSince(file, { offset: 0, seen: [] });
+  assert.equal(first.records.length, 1);
+
+  const second = readUsageSince(file, first);
+  assert.equal(second.records.length, 0, 'nothing appended, nothing to count');
+
+  fs.appendFileSync(file, assistantLines('b', 'claude-opus-5', usage)[0] + '\n');
+  const third = readUsageSince(file, second);
+  assert.equal(third.records.length, 1);
+  assert.equal(third.records[0].id, 'msg_b');
+});
+
+test('a half-written trailing line waits for the next read', () => {
+  const dir = sandbox();
+  const file = writeTranscript(dir, assistantLines('a', 'claude-opus-5', { output_tokens: 10 }));
+  fs.appendFileSync(file, '{"type":"assistant","message":{"id":"msg_partial"');
+
+  const first = readUsageSince(file, { offset: 0, seen: [] });
+  assert.equal(first.records.length, 1, 'the partial line is not parsed');
+
+  // Completed on the next flush — now it counts, exactly once.
+  fs.appendFileSync(file, ',"model":"claude-opus-5","usage":{"output_tokens":10}}}\n');
+  const second = readUsageSince(file, first);
+  assert.equal(second.records.length, 1);
+  assert.equal(second.records[0].id, 'msg_partial');
+});
+
+test('a truncated transcript recounts instead of reading past the end', () => {
+  const dir = sandbox();
+  const file = writeTranscript(dir, assistantLines('a', 'claude-opus-5', { output_tokens: 10 }));
+  const stale = { offset: 999999, seen: [] };
+  const { records, offset } = readUsageSince(file, stale);
+  assert.equal(records.length, 1);
+  assert.ok(offset < 999999);
+});
+
+test('unreadable and corrupt transcripts yield nothing, never throw', () => {
+  assert.deepEqual(readUsageSince(path.join(sandbox(), 'nope.jsonl'), { offset: 0, seen: [] }).records, []);
+  assert.deepEqual(readUsageSince(null, { offset: 0, seen: [] }).records, []);
+
+  const dir = sandbox();
+  const file = writeTranscript(dir, ['not json at all', '{"broken":', 'null']);
+  assert.deepEqual(readUsageSince(file, { offset: 0, seen: [] }).records, []);
+});
+
+// ------------------------------------------------------------------ meter
+
+test('metering totals real spend and survives being run repeatedly', () => {
+  const box = sandbox();
+  process.env.XDG_CONFIG_HOME = box;
+  const file = writeTranscript(box, [
+    // 1M output on opus ($25) duplicated across two content blocks
+    ...assistantLines('a', 'claude-opus-5', { output_tokens: 1e6 }, 2),
+    // 1M output on haiku ($5)
+    ...assistantLines('b', 'claude-haiku-4-5', { output_tokens: 1e6 }),
+  ]);
+
+  const first = meter('sess-meter', file, {});
+  assert.equal(first.costUsd, 30);
+  assert.equal(first.tokens, 2e6);
+
+  const again = meter('sess-meter', file, {});
+  assert.equal(again.costUsd, 30, 're-running the hook must not re-bill');
+});
+
+test('tokens from an unpriced model are surfaced, not swallowed', () => {
+  const box = sandbox();
+  process.env.XDG_CONFIG_HOME = box;
+  const file = writeTranscript(box, assistantLines('a', 'llama3.2:latest', { output_tokens: 5000 }));
+
+  const state = meter('sess-unpriced', file, {});
+  assert.equal(state.costUsd, 0);
+  assert.equal(state.tokens, 5000);
+  assert.equal(state.unpricedTokens, 5000);
+  assert.deepEqual(state.unpricedModels, ['llama3.2:latest']);
+});
+
+// ----------------------------------------------------------------- ledger
+
+test('a hostile session id cannot escape the ledger directory', () => {
+  assert.equal(ledger.safeName('../../.bashrc'), '.._.._.bashrc');
+  assert.equal(ledger.safeName(''), 'default');
+  assert.equal(ledger.safeName('..'), 'default');
+  process.env.XDG_CONFIG_HOME = sandbox();
+  assert.equal(path.dirname(ledger.ledgerPath('a/b')), ledger.ledgerDir());
+});
+
+test('a corrupt ledger reads as a fresh one', () => {
+  const box = sandbox();
+  process.env.XDG_CONFIG_HOME = box;
+  ledger.save('sess-corrupt', { ...ledger.emptyLedger('sess-corrupt'), costUsd: 4 });
+  fs.writeFileSync(ledger.ledgerPath('sess-corrupt'), '{ truncated', 'utf8');
+  assert.equal(ledger.load('sess-corrupt').costUsd, 0);
+});
+
+// ----------------------------------------------------------------- policy
+
+test('the firewall stays off until someone sets a limit', () => {
+  assert.equal(policy.getSpendConfig({}).enabled, false);
+  assert.equal(policy.getSpendConfig({ PONYTAIL_SPEND_LIMIT: '0' }).enabled, false);
+  assert.equal(policy.getSpendConfig({ PONYTAIL_SPEND_LIMIT: 'lots' }).enabled, false);
+  assert.equal(policy.getSpendConfig({ PONYTAIL_SPEND_LIMIT: '5' }).enabled, true);
+});
+
+test('env overrides the config file, and mode off disables enforcement', () => {
+  const box = sandbox();
+  process.env.XDG_CONFIG_HOME = box;
+  fs.mkdirSync(path.join(box, 'ponytail'), { recursive: true });
+  fs.writeFileSync(
+    path.join(box, 'ponytail', 'config.json'),
+    JSON.stringify({ spend: { limit: 2, warnAt: 0.5, mode: 'warn' } }),
+    'utf8',
+  );
+
+  const fromFile = policy.getSpendConfig({});
+  assert.equal(fromFile.limitUsd, 2);
+  assert.equal(fromFile.warnAt, 0.5);
+  assert.equal(fromFile.mode, 'warn');
+
+  const overridden = policy.getSpendConfig({ PONYTAIL_SPEND_LIMIT: '9', PONYTAIL_SPEND_MODE: 'off' });
+  assert.equal(overridden.limitUsd, 9);
+  assert.equal(overridden.enabled, false, 'mode off means nothing is enforced');
+});
+
+test('thresholds accept both 0.75 and "75%"', () => {
+  assert.equal(policy.parseFraction('75%'), 0.75);
+  assert.equal(policy.parseFraction(0.75), 0.75);
+  assert.equal(policy.parseFraction('120%'), null);
+  assert.equal(policy.parseFraction(1), null, 'a threshold at the limit is not a warning');
+});
+
+test('a malformed price override is ignored rather than trusted', () => {
+  assert.equal(policy.parsePrices({ x: { input: 'free', output: 1 } }), null);
+  assert.equal(policy.parsePrices({ x: { input: -1, output: 1 } }), null);
+  assert.deepEqual(policy.parsePrices({ X: { input: 1, output: 2 } }), { x: { input: 1, output: 2 } });
+});
+
+test('tiers cross where the budget says they do', () => {
+  const config = { enabled: true, limitUsd: 10, warnAt: 0.75, mode: 'block' };
+  assert.equal(policy.evaluate(1, config).tier, 'ok');
+  assert.equal(policy.evaluate(7.4, config).tier, 'ok');
+  assert.equal(policy.evaluate(7.5, config).tier, 'warn');
+  assert.equal(policy.evaluate(10, config).tier, 'block');
+  assert.equal(policy.evaluate(999, config).tier, 'block');
+});
+
+test('warn mode reports the overrun but never blocks', () => {
+  const config = { enabled: true, limitUsd: 10, warnAt: 0.75, mode: 'warn' };
+  const decision = policy.evaluate(50, config);
+  assert.equal(decision.tier, 'warn');
+  assert.equal(decision.overLimit, true);
+  assert.equal(decision.remainingUsd, 0);
+});
+
+// --------------------------------------------------------------- commands
+
+test('the spend command grammar', () => {
+  assert.deepEqual(commands.parseSpendCommand('/ponytail spend'), { action: 'status' });
+  assert.deepEqual(commands.parseSpendCommand('@ponytail spend reset'), { action: 'reset' });
+  assert.deepEqual(commands.parseSpendCommand('/ponytail:ponytail spend limit 5'), { action: 'limit', amount: 5 });
+  assert.deepEqual(commands.parseSpendCommand('/ponytail spend limit $2.50'), { action: 'limit', amount: 2.5 });
+  assert.deepEqual(commands.parseSpendCommand('/ponytail spend warn'), { action: 'mode', mode: 'warn' });
+  assert.equal(commands.parseSpendCommand('/ponytail spend limit').action, 'invalid');
+  assert.equal(commands.parseSpendCommand('/ponytail ultra'), null);
+  assert.equal(commands.parseSpendCommand('how much did I spend'), null, 'prose is not a command');
+});
+
+test('writing a limit keeps the rest of config.json intact', () => {
+  const box = sandbox();
+  process.env.XDG_CONFIG_HOME = box;
+  fs.mkdirSync(path.join(box, 'ponytail'), { recursive: true });
+  const configPath = path.join(box, 'ponytail', 'config.json');
+  fs.writeFileSync(configPath, JSON.stringify({ defaultMode: 'ultra', spend: { mode: 'warn' } }), 'utf8');
+
+  commands.applySpendCommand({ action: 'limit', amount: 7 }, 'sess-cmd');
+  const saved = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+  assert.equal(saved.defaultMode, 'ultra', 'the mode default must survive a budget write');
+  assert.deepEqual(saved.spend, { mode: 'warn', limit: 7 });
+});
+
+// ------------------------------------------------------------ hook wiring
+
+test('with no limit set the hook does nothing and writes no ledger', () => {
+  const box = sandbox();
+  const file = writeTranscript(box, assistantLines('a', 'claude-opus-5', { output_tokens: 1e6 }));
+  const result = runHook(
+    { hook_event_name: 'PreToolUse', session_id: 'quiet', transcript_path: file },
+    { XDG_CONFIG_HOME: box, PONYTAIL_SPEND_LIMIT: '' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, '');
+  assert.equal(fs.existsSync(path.join(box, 'ponytail', 'spend')), false);
+});
+
+test('over budget, PreToolUse denies with the documented shape', () => {
+  const box = sandbox();
+  const file = writeTranscript(box, assistantLines('a', 'claude-opus-5', { output_tokens: 1e6 }));
+  const result = runHook(
+    { hook_event_name: 'PreToolUse', session_id: 'burn', transcript_path: file },
+    { XDG_CONFIG_HOME: box, PONYTAIL_SPEND_LIMIT: '1' },
+  );
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout).hookSpecificOutput;
+  assert.equal(output.hookEventName, 'PreToolUse');
+  assert.equal(output.permissionDecision, 'deny');
+  assert.match(output.permissionDecisionReason, /PONYTAIL SPEND LIMIT REACHED/);
+});
+
+test('over budget, UserPromptSubmit denies the turn before it starts', () => {
+  const box = sandbox();
+  const file = writeTranscript(box, assistantLines('a', 'claude-opus-5', { output_tokens: 1e6 }));
+  const result = runHook(
+    { hook_event_name: 'UserPromptSubmit', session_id: 'burn2', transcript_path: file, prompt: 'keep going' },
+    { XDG_CONFIG_HOME: box, PONYTAIL_SPEND_LIMIT: '1' },
+  );
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.decision, 'deny');
+  assert.match(output.reason, /blocked/);
+});
+
+test('the warning is emitted once, not on every tool call', () => {
+  const box = sandbox();
+  const file = writeTranscript(box, assistantLines('a', 'claude-opus-5', { output_tokens: 1e6 }));
+  const env = { XDG_CONFIG_HOME: box, PONYTAIL_SPEND_LIMIT: '30' }; // $25 spent = 83%
+
+  assert.match(
+    runHook({ hook_event_name: 'PreToolUse', session_id: 'warned', transcript_path: file }, env).stdout,
+    /PONYTAIL SPEND WARNING/,
+  );
+  assert.equal(
+    runHook({ hook_event_name: 'PreToolUse', session_id: 'warned', transcript_path: file }, env).stdout,
+    '',
+    'the same warning must not repeat on every tool call',
+  );
+});
+
+test('a blocked session can still raise its own limit', () => {
+  const box = sandbox();
+  const file = writeTranscript(box, assistantLines('a', 'claude-opus-5', { output_tokens: 1e6 }));
+  const env = { XDG_CONFIG_HOME: box, PONYTAIL_SPEND_LIMIT: '1' };
+
+  // Blocked...
+  assert.match(
+    runHook({ hook_event_name: 'UserPromptSubmit', session_id: 'stuck', transcript_path: file, prompt: 'go' }, env).stdout,
+    /LIMIT REACHED/,
+  );
+  // ...but the command that fixes it still gets through.
+  const raise = runHook(
+    { hook_event_name: 'UserPromptSubmit', session_id: 'stuck', transcript_path: file, prompt: '/ponytail spend limit 100' },
+    { XDG_CONFIG_HOME: box },
+  );
+  assert.match(raise.stdout, /PONYTAIL SPEND LIMIT SET/);
+  assert.doesNotMatch(raise.stdout, /deny/);
+});
+
+test('/ponytail spend reports without a limit configured', () => {
+  const box = sandbox();
+  const file = writeTranscript(box, assistantLines('a', 'claude-opus-5', { output_tokens: 1e6 }));
+  const result = runHook(
+    { hook_event_name: 'UserPromptSubmit', session_id: 'report', transcript_path: file, prompt: '/ponytail spend' },
+    { XDG_CONFIG_HOME: box },
+  );
+  assert.match(result.stdout, /\$25\.00 this session/);
+  assert.match(result.stdout, /firewall is off/);
+});
+
+test('garbage on stdin fails open instead of wedging the session', () => {
+  const box = sandbox();
+  const result = spawnSync(process.execPath, [hook], {
+    env: { ...process.env, XDG_CONFIG_HOME: box, PONYTAIL_SPEND_LIMIT: '1' },
+    input: 'not json',
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, '', 'no decision at all beats a wrong one');
+});
+
+test('a missing transcript never blocks', () => {
+  const box = sandbox();
+  const result = runHook(
+    { hook_event_name: 'PreToolUse', session_id: 'ghost', transcript_path: path.join(box, 'gone.jsonl') },
+    { XDG_CONFIG_HOME: box, PONYTAIL_SPEND_LIMIT: '0.01' },
+  );
+  assert.equal(result.status, 0);
+  assert.equal(result.stdout, '');
+});
+
+test('/ponytail spend does not get eaten by the mode tracker', () => {
+  const box = sandbox();
+  const claudeDir = path.join(box, 'claude');
+  fs.mkdirSync(claudeDir, { recursive: true });
+  fs.writeFileSync(path.join(claudeDir, '.ponytail-active'), 'ultra', 'utf8');
+
+  const result = spawnSync(process.execPath, [path.join(root, 'hooks', 'ponytail-mode-tracker.js')], {
+    env: { ...process.env, CLAUDE_CONFIG_DIR: claudeDir, XDG_CONFIG_HOME: box },
+    input: JSON.stringify({ prompt: '/ponytail spend limit 5' }),
+    encoding: 'utf8',
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout, '', 'the tracker must stay silent on a spend command');
+  assert.equal(
+    fs.readFileSync(path.join(claudeDir, '.ponytail-active'), 'utf8'),
+    'ultra',
+    'asking about the budget must not reset the intensity level',
+  );
+});


### PR DESCRIPTION
Per-session budget for agent runs, metered from the token usage in the agent's own transcript and enforced before inference. Off unless a limit is set, so nothing changes on upgrade.

Issue #721 asked for this by way of a third-party payments SDK (Stripe / Coinbase, FastAPI decorators). That doesn't fit: ponytail has no server, no endpoints, and no dependencies, and a plugin that makes agents write less code has no business holding anyone's card details. The problem in the title is real though, so this implements it natively — no account, no network call, no third party. The budget is a number in the user's own config file.

Two checkpoints, because a runaway burns money at two rates: UserPromptSubmit stops a turn before it starts, PreToolUse catches the loop that runs away inside one turn. The second is the one that matters — a single turn can make hundreds of tool calls.

Metering reads the session transcript the agent already writes, so the token counts are the billed ones rather than an estimate. Three things about that file drive the implementation: one message spans several lines with the usage repeated on each (deduped by message id, or a session reads ~2x its real cost), the file only grows (only new bytes are read, offset kept in the ledger), and it is written while being read (parsing stops at the last newline).

Every failure path allows the work through. A guard that wedges a session over its own bug costs more than the bill it prevents.

Modules:
  hooks/spend/pricing.js     rate table + cost math, pure
  hooks/spend/transcript.js  incremental, deduped usage reader
  hooks/spend/ledger.js      per-session state, atomic writes
  hooks/spend/policy.js      config resolution + tier decisions, pure
  hooks/spend/meter.js       composition of the four above
  hooks/spend/commands.js    /ponytail spend grammar
  hooks/ponytail-spend.js    hook entrypoint (I/O only)

Also: extracts updateConfig() in ponytail-config.js so the budget and the mode default can't clobber each other, and teaches the mode tracker to leave `/ponytail spend` alone — it named a budget but was being read as an intensity level, which silently reset the mode.