### PR TITLE
fix: increase default correctness test timeout to 60s for slow pandas…

### DIFF
--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -13,7 +13,7 @@ const path = require('path');
 
 function correctnessTimeoutMs() {
   const value = Number.parseInt(process.env.PONYTAIL_CORRECTNESS_TIMEOUT_MS || '', 10);
-  return Number.isFinite(value) && value > 0 ? value : 30_000;
+  return Number.isFinite(value) && value > 0 ? value : 60_000;
 }
 
 // Extract fenced code blocks, tagged by language.


### PR DESCRIPTION
"Currently, the benchmark correctness test csv: correct pandas one-liner passes defaults to a 30_000 ms (30 seconds) timeout. On slower developer environments or virtualized CI runs (especially on Windows), importing pandas inside Python can take slightly longer, triggering a test timeout failure. This PR increases the default correctness timeout in benchmarks/correctness.js to 60_000 ms (60 seconds) to prevent test flakiness."