### PR TITLE
Fix broken Star History charts

### DIFF
--- a/README.es.md
+++ b/README.es.md
@@ -306,10 +306,10 @@ Ya sabes exactamente por qué.
 
 ## Historial de estrellas
 
-<a href="https://www.star-history.com/dietrichgebert/ponytail#history">
+<a href="https://star-history.dera.page/#DietrichGebert/ponytail&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=DietrichGebert/ponytail&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=DietrichGebert/ponytail&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=DietrichGebert/ponytail&type=Date" />
  </picture>
 </a>

--- a/README.ko.md
+++ b/README.ko.md
@@ -323,10 +323,10 @@ OpenClaw 스킬 패키지(`.openclaw/skills/`)는 `skills/`에서 생성된다. 
 
 ## Star History
 
-<a href="https://www.star-history.com/dietrichgebert/ponytail#history">
+<a href="https://star-history.dera.page/#DietrichGebert/ponytail&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=DietrichGebert/ponytail&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=DietrichGebert/ponytail&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=DietrichGebert/ponytail&type=Date" />
  </picture>
 </a>

--- a/README.md
+++ b/README.md
@@ -360,10 +360,10 @@ You know exactly why.
 
 ## Star History
 
-<a href="https://www.star-history.com/dietrichgebert/ponytail#history">
+<a href="https://star-history.dera.page/#DietrichGebert/ponytail&type=Date">
  <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date&theme=dark" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=DietrichGebert/ponytail&type=Date" />
+   <source media="(prefers-color-scheme: dark)" srcset="https://star-history.dera.page/svg?repos=DietrichGebert/ponytail&type=Date&theme=dark" />
+   <source media="(prefers-color-scheme: light)" srcset="https://star-history.dera.page/svg?repos=DietrichGebert/ponytail&type=Date" />
+   <img alt="Star History Chart" src="https://star-history.dera.page/svg?repos=DietrichGebert/ponytail&type=Date" />
  </picture>
 </a>


### PR DESCRIPTION
The Star History charts in the README files are currently broken, so this updates all localized chart blocks to the working chart URLs. The existing repository and date settings are preserved.