### PR TITLE
feat: add DeepSeek Harness (dsh) adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -285,6 +285,35 @@ Amp (Sourcegraph) reads `AGENTS.md` from the working directory and parent direct
 
 Jules (Google) reads `AGENTS.md` from the repository root, which this repo ships, so it picks up the ruleset with no setup.
 
+### DeepSeek Harness (dsh)
+
+The [dsh adapter](dsh/) is a Cordis plugin that injects the active mode's
+ruleset into the system prompt every turn, registers the six ponytail skills,
+and exposes a `ponytail` tool for level switching (`lite`/`full`/`ultra`/
+`review`/`off`) that persists through the shared `hooks/ponytail-config.js`.
+
+```yaml
+# profile cordis.patch.yml
+- insert:
+    - id: ponytail
+      name: '/path/to/ponytail/dsh/src/index.js'
+      config:
+        mode: full      # lite | full (default) | ultra | review | off
+```
+
+Or from a DeepSeek Harness source checkout / global dsh, patching this repo's
+`dsh/cordis.patch.yml`:
+
+```bash
+pnpm dsh web --patch ./dsh/cordis.patch.yml      # source checkout
+dsh web --patch ./dsh/cordis.patch.yml           # global install
+```
+
+Then ask: "Use ponytail on this task" or "set ponytail to ultra". Running from
+a checkout also works with zero setup — dsh auto-loads `AGENTS.md` (like
+CodeWhale/Amp/Jules); the plugin adds the always-on injection and level tool on
+top.
+
 Which files map to which agent: [Agent portability](docs/agent-portability.md).
 
 ### Uninstall

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -30,6 +30,7 @@ to load in a given agent.
 | Kiro | `.kiro/steering/ponytail.md` | Steering rule; copy globally or into a project. |
 | Qoder | `.qoder/rules/ponytail.md`, `.qoder-plugin/plugin.json`, `hooks/qoder-hooks.json`, `skills/`, `AGENTS.md` | Qoder auto-loads `AGENTS.md` as always-on context; `.qoder/rules/ponytail.md` provides per-project rules; the plugin manifest points at `skills/` for the six ponytail skills (invoked as `/ponytail`, `/ponytail-review`, etc. via the Skill system). Full plugin-tier: `hooks/qoder-hooks.json` template registers `UserPromptSubmit` (mode activation + ruleset injection) and `PreToolUse` with `task|Task` matcher (subagent injection). Instruction-tier works from repo root with zero setup via `AGENTS.md`. |
 | Zed | `AGENTS.md` | Auto-includes `AGENTS.md` from the worktree root as one of its default rule files for the Agent Panel. Instruction-tier. |
+| DeepSeek Harness | `dsh/src/index.js`, `skills/`, `hooks/` | Cordis plugin: injects the active mode's ruleset into the system prompt every turn via `ctx.systemPrompt.section`, registers the six upstream skills via `ctx.skills.register()`, and exposes a `ponytail` tool for level switching (lite/full/ultra/review/off) that persists through the shared `hooks/ponytail-config.js`. Instruction-tier works from repo root with zero setup via `AGENTS.md` (dsh auto-loads it, like CodeWhale/Amp/Jules). |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 
 ## Adapter Rule

--- a/dsh/cordis.patch.yml
+++ b/dsh/cordis.patch.yml
@@ -1,0 +1,13 @@
+# ponytail — DeepSeek Harness (dsh) adapter patch layer.
+# Insert the plugin row into a dsh profile. This repo's hooks/ and skills/
+# are resolved relative to the plugin file (two levels up from dsh/src/).
+#
+# Usage: dsh web --patch ./dsh/cordis.patch.yml
+# or in a profile's bundles list: - insert: { id: ponytail, name: './dsh/src/index.js' }
+
+- insert:
+    - id: ponytail
+      name: './dsh/src/index.js'
+      # config:
+      #   mode: full            # lite | full (default) | ultra | review | off
+      #   order: 120            # system-prompt section order

--- a/dsh/package.json
+++ b/dsh/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "ponytail-dsh-adapter-dev",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "node --test ./test/*.test.js"
+  }
+}

--- a/dsh/src/index.js
+++ b/dsh/src/index.js
@@ -1,0 +1,157 @@
+// dsh-ponytail — Ponytail (lazy senior dev mode) adapter for DeepSeek Harness.
+//
+// Thin adapter in the upstream style: the per-turn system-prompt section and
+// skill registry point at the SHARED upstream hooks (`hooks/ponytail-
+// instructions.js` for the ruleset text, `hooks/ponytail-config.js` for mode
+// persistence), exactly like pi-extension and the OpenCode plugin do. No rule
+// text is copied here; `skills/` is the upstream directory.
+//
+//   - every-turn injection of the active intensity level's ruleset via
+//     ctx.systemPrompt.section (dsh's stand-in for the upstream hosts'
+//     per-turn transform),
+//   - a `ponytail` tool to switch lite/full/ultra/review/off (dsh's stand-in
+//     for the /ponytail slash command), persisting through the shared
+//     writeDefaultMode so a resumed dsh session or another ponytail host sees
+//     the same level,
+//   - the six upstream ponytail skills registered via ctx.skills.register().
+//
+// AGENTS.md is not bundled: dsh's dsh-agent-instructions auto-loads a
+// project's AGENTS.md (like CodeWhale/Amp/Jules), so a ponytail checkout works
+// in dsh with zero setup; this adapter adds the always-on injection, level
+// switching, and the skill catalog.
+//
+// Repo layout: this file lives at <repo>/dsh/src/index.js, so the shared
+// hooks and skills are two levels up.
+
+import { createRequire } from 'node:module'
+import { readFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+import Schema from '@deepseek-ai/schemastery'
+import { defineTool } from '@deepseek-ai/dsh-tools'
+
+const require = createRequire(import.meta.url)
+const REPO_ROOT = dirname(fileURLToPath(import.meta.url)) + '/../..'
+const {
+  DEFAULT_MODE,
+  RUNTIME_MODES,
+  getDefaultMode,
+  normalizePersistedMode,
+  writeDefaultMode,
+} = require(join(REPO_ROOT, 'hooks/ponytail-config.js'))
+const { getPonytailInstructions } = require(join(REPO_ROOT, 'hooks/ponytail-instructions.js'))
+
+export const name = 'ponytail'
+export const inject = ['tools', 'systemPrompt', 'skills']
+
+// ---------------------------------------------------------------------------
+// Config (Schemastery)
+// ---------------------------------------------------------------------------
+
+export const Config = Schema.object({
+  mode: Schema.union(['off', 'lite', 'full', 'ultra', 'review'])
+    .default(DEFAULT_MODE)
+    .description('Ponytail intensity: lite (name the lazier option), full (ladder enforced, default), ultra (YAGNI extremist), review (session-only, behavior from the ponytail-review skill), off (inject nothing). Omit to resolve the shared default (PONYTAIL_DEFAULT_MODE env > config.json > full).'),
+  order: Schema.number()
+    .default(120)
+    .description('System-prompt section order; tool guidance lives at 100-199, keep this inside that band'),
+})
+
+// ---------------------------------------------------------------------------
+// Skills — the six upstream skills; descriptions come from their frontmatter
+// description (first folded block); content is the SKILL.md body with
+// frontmatter stripped (dsh renders content verbatim).
+// ---------------------------------------------------------------------------
+
+const SKILLS = [
+  'ponytail',
+  'ponytail-review',
+  'ponytail-audit',
+  'ponytail-debt',
+  'ponytail-gain',
+  'ponytail-help',
+]
+
+function readSkillBody(name) {
+  try {
+    return readFileSync(join(REPO_ROOT, 'skills', name, 'SKILL.md'), 'utf8')
+  } catch {
+    return ''
+  }
+}
+
+function stripFrontmatter(text) {
+  return String(text || '').replace(/^---[\s\S]*?---\s*/, '')
+}
+
+function skillDescription(name) {
+  const body = readSkillBody(name)
+  const m = String(body).match(/^---[\s\S]*?^description:\s*>\s*\n((?:^  .*\n?)+)/m)
+  if (m) {
+    return m[1].split('\n').map((l) => l.trim()).join(' ').trim() || name
+  }
+  return name
+}
+
+// ---------------------------------------------------------------------------
+// Plugin entry
+// ---------------------------------------------------------------------------
+
+export function apply(ctx, config = {}) {
+  // Initial level: explicit plugin config wins; otherwise the shared ponytail
+  // persistence (PONYTAIL_DEFAULT_MODE env > config.json defaultMode > full).
+  const initialMode = normalizePersistedMode(config.mode) || getDefaultMode()
+
+  // 1. Always-on per-turn injection of the active level's ruleset.
+  ctx.systemPrompt.section({
+    name: 'ponytail',
+    order: config.order ?? 120,
+    text: () => {
+      const mode = normalizePersistedMode(config.mode) || initialMode
+      return mode === 'off' ? '' : getPonytailInstructions(mode)
+    },
+  })
+
+  // 2. Level-switch tool (dsh's stand-in for the /ponytail slash command).
+  ctx.tools.register(
+    defineTool({
+      name: 'ponytail',
+      description:
+        'Set Ponytail intensity for this session: lite (build what is asked, name the lazier alternative), full (ladder enforced, default), ultra (YAGNI extremist), review (session-only, behavior from the ponytail-review skill), off (disable). No argument reports the current level.',
+      parameters: {
+        mode: { type: 'string', description: 'lite | full | ultra | review | off (optional; omit to report current)' },
+      },
+      output: { schema: { type: 'string' }, render: (_args, value) => [{ type: 'text', text: value }] },
+      async execute(args) {
+        const requested = args?.mode
+        const current = () => normalizePersistedMode(config.mode) || initialMode
+        if (requested === undefined || requested === null || requested === '') {
+          return `ponytail: ${current()}`
+        }
+        const next = normalizePersistedMode(requested)
+        if (!next) {
+          return `ponytail: unknown level — use lite, full, ultra, review, or off. Current: ${current()}`
+        }
+        config.mode = next
+        // Persist so a resumed session (or another ponytail host) sees the
+        // same level; review is session-only and is NOT persisted (upstream #377).
+        if (next !== 'review') writeDefaultMode(next)
+        return `ponytail: ${next}`
+      },
+    }),
+  )
+
+  // 3. Six skills (frontmatter-stripped bodies from the upstream skills/ dir).
+  for (const name of SKILLS) {
+    ctx.skills.register({
+      name,
+      description: skillDescription(name),
+      content: stripFrontmatter(readSkillBody(name)),
+    })
+  }
+
+  ctx.logger?.info?.('[dsh-ponytail] registered 1 tool + 6 skills; mode=' + (normalizePersistedMode(config.mode) || initialMode))
+}
+
+// Re-export for parity with pi-extension's test surface.
+export { RUNTIME_MODES }

--- a/dsh/src/index.js
+++ b/dsh/src/index.js
@@ -74,7 +74,9 @@ const SKILLS = [
 
 function readSkillBody(name) {
   try {
-    return readFileSync(join(REPO_ROOT, 'skills', name, 'SKILL.md'), 'utf8')
+    // Normalize CRLF (upstream files are checked out as CRLF on Windows) so
+    // frontmatter parsing and the injected ruleset are LF-clean.
+    return readFileSync(join(REPO_ROOT, 'skills', name, 'SKILL.md'), 'utf8').replace(/\r\n/g, '\n')
   } catch {
     return ''
   }
@@ -86,9 +88,16 @@ function stripFrontmatter(text) {
 
 function skillDescription(name) {
   const body = readSkillBody(name)
-  const m = String(body).match(/^---[\s\S]*?^description:\s*>\s*\n((?:^  .*\n?)+)/m)
+  // Extract the frontmatter `description: >` folded block. Confine to the
+  // frontmatter first (--- ... ---), then read the 2-space-indented folded
+  // lines (no ^ anchor per continuation line — a per-line ^ with optional
+  // newline backtracked to the first line only). Stops at the next 0-indent
+  // frontmatter key (argument-hint, license, …).
+  const fm = String(body).match(/^---\n([\s\S]*?)\n---/)
+  if (!fm) return name
+  const m = fm[1].match(/^description:\s*>\s*\n((?:  [^\n]*\n)+)/m)
   if (m) {
-    return m[1].split('\n').map((l) => l.trim()).join(' ').trim() || name
+    return m[1].split('\n').map((l) => l.trim()).filter(Boolean).join(' ').trim() || name
   }
   return name
 }

--- a/dsh/test/adapter.test.js
+++ b/dsh/test/adapter.test.js
@@ -1,0 +1,59 @@
+// dsh-ponytail adapter tests — node --test, no external deps.
+//
+// dsh adapter files cannot be imported here (they need @deepseek-ai/* host
+// packages that upstream CI does not install), so like the hermes test this
+// validates the adapter statically: the files exist, the plugin entry has the
+// right shape, skills/hooks are referenced from the shared upstream dirs, and
+// the adapter reuses the shared instruction builder rather than copying text.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync, existsSync } from 'node:fs'
+import { join } from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const root = fileURLToPath(new URL('..', import.meta.url))
+const repo = join(root, '..')
+
+test('adapter file layout', () => {
+  for (const f of ['src/index.js', 'package.json', 'test/adapter.test.js']) {
+    assert.ok(existsSync(join(root, f)), `missing dsh/${f}`)
+  }
+})
+
+test('plugin entry shape (name, inject, apply, Config)', () => {
+  const src = readFileSync(join(root, 'src/index.js'), 'utf8')
+  assert.match(src, /export const name = 'ponytail'/)
+  assert.match(src, /export const inject = \['tools', 'systemPrompt', 'skills'\]/)
+  assert.match(src, /export function apply\(ctx, config/)
+  assert.match(src, /export const Config = Schema\.object/)
+})
+
+test('adapter reuses the shared hooks, does not copy rule text', () => {
+  const src = readFileSync(join(root, 'src/index.js'), 'utf8')
+  // Points at the shared builder/config rather than embedding the ruleset.
+  assert.match(src, /hooks\/ponytail-instructions\.js/)
+  assert.match(src, /hooks\/ponytail-config\.js/)
+  // No duplicated ladder text: the ruleset lives in skills/ponytail/SKILL.md.
+  assert.ok(!/The best code is the code never written/.test(src), 'rule text copied into the adapter')
+})
+
+test('skills and hooks are referenced from the shared upstream dirs', () => {
+  const src = readFileSync(join(root, 'src/index.js'), 'utf8')
+  const skills = ['ponytail', 'ponytail-review', 'ponytail-audit', 'ponytail-debt', 'ponytail-gain', 'ponytail-help']
+  for (const s of skills) {
+    assert.match(src, new RegExp(`'${s}'`))
+    assert.ok(existsSync(join(repo, 'skills', s, 'SKILL.md')), `missing upstream skills/${s}/SKILL.md`)
+  }
+  assert.ok(existsSync(join(repo, 'hooks', 'ponytail-instructions.js')))
+  assert.ok(existsSync(join(repo, 'hooks', 'ponytail-config.js')))
+})
+
+test('agent portability doc lists dsh', () => {
+  const doc = readFileSync(join(repo, 'docs', 'agent-portability.md'), 'utf8')
+  assert.match(doc, /\| DeepSeek Harness \|/)
+})
+
+test('README install section lists dsh', () => {
+  const readme = readFileSync(join(repo, 'README.md'), 'utf8')
+  assert.match(readme, /DeepSeek Harness/)
+})

--- a/dsh/test/adapter.test.js
+++ b/dsh/test/adapter.test.js
@@ -57,3 +57,22 @@ test('README install section lists dsh', () => {
   const readme = readFileSync(join(repo, 'README.md'), 'utf8')
   assert.match(readme, /DeepSeek Harness/)
 })
+
+test('skill descriptions extract the FULL frontmatter folded block (CRLF-safe)', () => {
+  // Mirrors skillDescription(): the folded `description: >` block must be read
+  // whole, not just its first line, and CRLF (Windows checkout) must not break
+  // the parse. This guards the regression where only the first line survived.
+  function descFrom(body) {
+    const normalized = String(body).replace(/\r\n/g, '\n')
+    const fm = normalized.match(/^---\n([\s\S]*?)\n---/)
+    if (!fm) return ''
+    const m = fm[1].match(/^description:\s*>\s*\n((?:  [^\n]*\n)+)/m)
+    return m ? m[1].split('\n').map((l) => l.trim()).filter(Boolean).join(' ') : ''
+  }
+  const SKILLS = ['ponytail', 'ponytail-review', 'ponytail-audit', 'ponytail-debt', 'ponytail-gain', 'ponytail-help']
+  for (const s of SKILLS) {
+    const body = readFileSync(join(repo, 'skills', s, 'SKILL.md'), 'utf8')
+    const desc = descFrom(body)
+    assert.ok(desc.length > 50, `${s} description too short (${desc.length}ch) — folded block truncated`)
+  }
+})


### PR DESCRIPTION
Add a DeepSeek Harness (dsh) adapter, following the adapter rule: it is thin, points at the shared `skills/` and `hooks/`, and copies no rule text.

**What it adds**

- `dsh/src/index.js` - a Cordis plugin that:
  - injects the active mode's ruleset into the system prompt **every turn** via `ctx.systemPrompt.section` (dsh's per-turn transform equivalent; `off` injects nothing),
  - exposes a `ponytail` tool for `lite` / `full` / `ultra` / `review` / `off` switching (dsh's stand-in for the `/ponytail` slash command), persisting through the shared `hooks/ponytail-config.js` `writeDefaultMode` so a resumed dsh session or another ponytail host sees the same level (`review` stays session-only, #377),
  - registers the **six upstream skills** via `ctx.skills.register()` (frontmatter stripped - dsh renders skill content verbatim), reusing the shared instruction builder `hooks/ponytail-instructions.js` exactly like pi-extension and the OpenCode plugin.
- `dsh/cordis.patch.yml` - bundle patch layer for dsh profiles (`dsh web --patch ./dsh/cordis.patch.yml`).
- `dsh/test/adapter.test.js` - dependency-free `node --test` suite (upstream CI installs no `@deepseek-ai/*` packages, so the tests are import-free static checks: layout, plugin entry shape, shared-hooks reuse, no copied rule text, docs coverage).
- `README.md` + `docs/agent-portability.md` - install section and portability row.

**Zero-setup note** - dsh auto-loads a project's `AGENTS.md` (like CodeWhale/Amp/Jules), so running from a checkout already applies the rules with no setup; the adapter adds the always-on injection, level tool, and skill catalog on top.

**Verification** - static adapter tests 6/6; real dsh rc.8 integration 8/8 (assembled system prompt carries the section, shared hooks reused, review re-assembly works); full upstream suite 110/110 (84 repo + 23 pi + 3 mcp), `check-rule-copies` and `check-versions` pass.