### PR TITLE
chore: declare agent-plugins.org 1.0.0 manifest in root plugin.json

### DIFF
--- a/plugin.json
+++ b/plugin.json
@@ -1,3 +1,14 @@
 {
-  "name": "ponytail"
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "ponytail",
+  "version": "4.9.0",
+  "description": "Lazy senior dev mode for AI agents. The best code is the code you never wrote.",
+  "author": {
+    "name": "Dietrich Gebert",
+    "url": "https://github.com/DietrichGebert"
+  },
+  "homepage": "https://github.com/DietrichGebert/ponytail",
+  "repository": "https://github.com/DietrichGebert/ponytail",
+  "license": "MIT",
+  "keywords": ["ponytail", "lazy", "yagni", "minimal", "code-review", "skills"]
 }


### PR DESCRIPTION
## Summary

- Upgrades the root `plugin.json` from a bare Claude-style stub to a valid [Agent Plugins](https://agent-plugins.org) 1.0.0 manifest (``, version, description, author, license, keywords).
- No other changes needed: `skills/` already holds all six skills in the portable Agent Skills layout, so compatible clients discover them as-is.

## Notes

- Metadata mirrors `package.json` (v4.9.0, MIT, same author/homepage).
- Zero runtime effect today — no client ships an Agent Plugins loader yet. This is free optionality for when they do; worst case it's one file to delete.
- Verified with a self-check that validates the manifest fields and discovers all six skills (`ponytail`, `ponytail-audit`, `ponytail-debt`, `ponytail-gain`, `ponytail-help`, `ponytail-review`) with matching frontmatter.