### PR TITLE
chore(skills): shorten skill descriptions to fit the listing budget

### DIFF
--- a/skills/ponytail-audit/SKILL.md
+++ b/skills/ponytail-audit/SKILL.md
@@ -1,12 +1,9 @@
 ---
 name: ponytail-audit
 description: >
-  Whole-repo audit for over-engineering. Like ponytail-review, but scans the
-  entire codebase instead of a diff: a ranked list of what to delete, simplify,
-  or replace with stdlib/native equivalents. Use when the user says "audit this
-  codebase", "audit for over-engineering", "what can I delete from this repo",
-  "find bloat", "ponytail-audit", or "/ponytail-audit". One-shot report, does
-  not apply fixes.
+  Whole-repo audit for over-engineering, a ranked list of what to delete,
+  simplify or replace with stdlib. Like ponytail-review but scans the entire
+  codebase instead of a diff. Use for "audit this codebase" or "find bloat".
 ---
 
 ponytail-review, repo-wide. Scan the whole tree instead of a diff. Rank

--- a/skills/ponytail-debt/SKILL.md
+++ b/skills/ponytail-debt/SKILL.md
@@ -1,11 +1,9 @@
 ---
 name: ponytail-debt
 description: >
-  Harvest every `ponytail:` comment in the codebase into a debt ledger, so the
-  deliberate shortcuts and deferrals ponytail leaves behind get tracked instead
-  of rotting into "later means never". Use when the user says "ponytail debt",
-  "/ponytail-debt", "what did ponytail defer", "list the shortcuts", "ponytail
-  ledger", or "what did we mark to do later". One-shot report, changes nothing.
+  Collect every ponytail marker comment in the codebase into a debt ledger so
+  deliberate shortcuts get tracked instead of rotting. Use for /ponytail-debt or
+  "what did ponytail defer".
 ---
 
 Every deliberate ponytail shortcut is marked with a `ponytail:` comment naming

--- a/skills/ponytail-gain/SKILL.md
+++ b/skills/ponytail-gain/SKILL.md
@@ -1,11 +1,8 @@
 ---
 name: ponytail-gain
 description: >
-  Show ponytail's measured impact as a compact scoreboard: less code, less
-  cost, more speed, from the benchmark medians. One-shot display, not a
-  persistent mode, and not a per-repo number. Trigger: /ponytail-gain,
-  "ponytail gain", "what does ponytail save", "show ponytail impact",
-  "ponytail scoreboard".
+  Compact scoreboard of ponytail's measured impact - less code, less cost, more
+  speed, from benchmark medians. Trigger: /ponytail-gain.
 ---
 
 # Ponytail Gain

--- a/skills/ponytail-help/SKILL.md
+++ b/skills/ponytail-help/SKILL.md
@@ -1,9 +1,8 @@
 ---
 name: ponytail-help
 description: >
-  Quick-reference card for all ponytail modes, skills, and commands.
-  One-shot display, not a persistent mode. Trigger: /ponytail-help,
-  "ponytail help", "what ponytail commands", "how do I use ponytail".
+  Quick-reference card for ponytail modes, skills and commands. Trigger:
+  /ponytail-help or "ponytail help".
 ---
 
 # Ponytail Help

--- a/skills/ponytail-review/SKILL.md
+++ b/skills/ponytail-review/SKILL.md
@@ -1,13 +1,9 @@
 ---
 name: ponytail-review
 description: >
-  Code review focused exclusively on over-engineering. Finds what to delete:
-  reinvented standard library, unneeded dependencies, speculative abstractions,
-  dead flexibility. One line per finding: location, what to cut, what replaces
-  it. Use when the user says "review for over-engineering", "what can we
-  delete", "is this over-engineered", "simplify review", or invokes
-  /ponytail-review. Complements correctness-focused review, this one only
-  hunts complexity.
+  Code review that hunts only over-engineering - reinvented stdlib, unneeded
+  dependencies, speculative abstractions, dead flexibility. One line per
+  finding. Reviews a diff; use ponytail-audit for a whole repo.
 ---
 
 Review diffs for unnecessary complexity. One line per finding: location, what

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -1,18 +1,14 @@
 ---
 name: ponytail
 description: >
-  Forces the laziest solution that actually works, simplest, shortest, most
-  minimal. Channels a senior dev who has seen everything: question whether the
-  task needs to exist at all (YAGNI), reach for the standard library before
-  custom code, native platform features before dependencies, one line before
-  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
+  Forces the laziest solution that actually works - question whether the task
+  needs to exist (YAGNI), stdlib before custom code, native platform before
+  dependencies, one line before fifty. Levels: lite, full, ultra. Use on ANY
   coding task: writing, adding, refactoring, fixing, reviewing, or designing
-  code, and choosing libraries or dependencies. Also use whenever the user
-  says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
-  solution", "yagni", "do less", or "shortest path", or complains about
-  over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
-  use for non-coding requests (general knowledge, prose, translation,
-  summaries, recipes).
+  code. Also when the user says "ponytail", "be lazy", "yagni", "simplest
+  solution", or complains about over-engineering or bloat. Do NOT use for
+  non-coding requests (general knowledge, prose, translation, summaries,
+  recipes).
 argument-hint: "[lite|full|ultra]"
 license: MIT
 ---


### PR DESCRIPTION
Claude Code spends a fixed character budget on the skill listing it puts in the model's context: `contextWindowTokens * 4 * skillListingBudgetFraction`, which is about 6,000 characters at the default fraction of 0.01. Overflow is binary per skill rather than proportional truncation: skills are ranked by recent usage and granted their full description in that order until the budget runs out, and everything past the cutoff renders as a bare name with no description at all.

The 6 ponytail skills spent 2,569 characters, roughly 43% of the entire default budget, which pushes unrelated skills past the cutoff on any install that carries more than a couple of plugins.

This rewrites the descriptions to 1,371 characters total. Every trigger phrase and every boundary clause is kept - the "Use on ANY coding task" wording and its verb list that `tests/grok-plugin.test.js` pins, the non-coding refusal, and ponytail-review's hand-off to ponytail-audit; what goes is restatement of the body, which the model reads anyway once the skill is selected. No skill body changes.

`node --test tests/*.test.js` passes except `csv: correct pandas one-liner passes`, which fails the same way on an unmodified checkout here (no pandas in this environment).

Signed-off-by: smoochy <34371932+smoochy@users.noreply.github.com>

