### PR TITLE
fix: report real correctness failures; unknown /ponytail args no longer clobber mode

### DIFF
--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -43,7 +43,10 @@ function exec(cmd, opts = {}) {
     execSync(cmd, { timeout: correctnessTimeoutMs(), encoding: 'utf8', stdio: 'pipe', ...opts });
     return { ok: true, stderr: '' };
   } catch (e) {
-    return { ok: false, stderr: (e.stderr || e.message || '').slice(0, 500) };
+    // Harnesses print their FAIL verdicts to stdout (and tracebacks to
+    // stderr); prefer stderr, but fall back to stdout so the verdict isn't
+    // swallowed into a bare "Command failed" message.
+    return { ok: false, stderr: (e.stderr || e.stdout || e.message || '').slice(0, 500) };
   }
 }
 
@@ -196,15 +199,18 @@ import io
 _stdout = sys.stdout
 sys.stdout = io.StringIO()
 
+_error = None
 try:
 ${patched.split('\n').map((l) => '    ' + l).join('\n')}
 except Exception as e:
-    sys.stdout = _stdout
-    # If it needs sales.csv in cwd, write it there and retry
-    pass
+    _error = repr(e)
 
 output = sys.stdout.getvalue()
 sys.stdout = _stdout
+
+if _error is not None:
+    print("FAIL: generated code raised: " + _error)
+    sys.exit(1)
 
 # Check output contains the number 351 (100.5 + 200.0 + 50.5)
 # Match as a standalone number (not as substring of e.g. 13510)

--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -50,9 +50,11 @@ function finish() {
         else if (arg === '') {
           isReportOnly = true;
           mode = readMode() || getDefaultMode();
-        } else {
-          mode = getDefaultMode();
         }
+        // Unknown arg (typo, or a mode like `review` that isn't a switchable
+        // level): leave the current mode untouched rather than silently
+        // resetting it to the default — the pi extension rejects these as
+        // invalid, so the hooks must not quietly clobber an active session.
       }
 
       if (isReportOnly) {

--- a/tests/correctness.test.js
+++ b/tests/correctness.test.js
@@ -106,6 +106,43 @@ test('csv: value containing 351 as substring fails (e.g. 13510)', () => {
   assert.equal(result.score, 0);
 });
 
+// Regression: the CSV harness used to restore sys.stdout inside its except
+// branch, so any exception the generated code raised (wrong column name,
+// missing module, …) surfaced as a misleading
+// "_io.TextIOWrapper' object has no attribute 'getvalue'" instead of the
+// real failure — a broken gate can't say why an answer failed.
+test('csv: generated code that raises reports the real exception, not the harness crash', () => {
+  const result = check(
+    "Write Python code that reads sales.csv and sums the 'amount' column.",
+    'python',
+    `import pandas as pd
+df = pd.read_csv('sales.csv')
+print(df['missing'].sum())`,
+  );
+  assert.equal(result.pass, false);
+  assert.equal(result.score, 0);
+  // Whatever the environment lacks (pandas here, a bad column in CI), the
+  // reason must name the generated code's actual exception — not the harness
+  // crashing on its own stdout capture.
+  assert.match(result.reason, /generated code raised/);
+  assert.ok(
+    !result.reason.includes("'getvalue'"),
+    'reason must not be the harness AttributeError masking the real failure',
+  );
+});
+
+// Regression: harness FAIL verdicts are printed to stdout; exec() must
+// surface them in the reason instead of a bare "Command failed".
+test('csv: FAIL verdict text is preserved in the failure reason', () => {
+  const result = check(
+    "Write Python code that reads sales.csv and sums the 'amount' column.",
+    'python',
+    `print(999)`,
+  );
+  assert.equal(result.pass, false);
+  assert.match(result.reason, /output was/);
+});
+
 test('csv: timeout can be raised for slow pandas startup', () => {
   const previous = process.env.PONYTAIL_CORRECTNESS_TIMEOUT_MS;
   try {

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -120,6 +120,32 @@ assert.equal(
   'incidental "normal mode" in a request must not turn ponytail off',
 );
 
+// Unknown /ponytail args (a typo, or a level that isn't a switchable mode like
+// "review") must leave the active mode untouched — silently resetting an
+// active lite session to the default was surprising and clobbered user state.
+result = run(
+  'ponytail-mode-tracker.js',
+  codexEnv,
+  JSON.stringify({ prompt: '/ponytail bogus' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(
+  fs.readFileSync(codexState, 'utf8'),
+  'lite',
+  'an unknown /ponytail arg must not reset the active mode',
+);
+result = run(
+  'ponytail-mode-tracker.js',
+  codexEnv,
+  JSON.stringify({ prompt: '/ponytail review' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(
+  fs.readFileSync(codexState, 'utf8'),
+  'lite',
+  'review is not a switchable level; it must not clobber the active mode',
+);
+
 const claudeEnv = {
   HOME: home,
   USERPROFILE: home,


### PR DESCRIPTION
## What

Three small fixes found while auditing the repo:

### 1. Correctness gate masks the real failure (`benchmarks/correctness.js`)

The CSV harness restored `sys.stdout` **inside** its `except` branch, so any
exception the generated code raised — a bad column name, a missing module, a
typo — surfaced as a misleading

```
AttributeError: '_io.TextIOWrapper' object has no attribute 'getvalue'
```

instead of the actual error. A gate whose whole job is to say *why* an answer
failed was crashing on its own stdout capture, and the `# If it needs
sales.csv in cwd, write it there and retry` branch was dead code (the retry
never existed).

**Fix:** capture the exception, restore stdout *after* `getvalue()`, and report
`FAIL: generated code raised: <exception>` as the reason.

### 2. FAIL verdicts swallowed into "Command failed" (`benchmarks/correctness.js`)

`exec()` only surfaced `e.stderr`, but the harnesses print their FAIL verdicts
to **stdout** (e.g. `FAIL: output was: '999\n'`). Every wrong-answer reason
collapsed into a bare `Command failed: python3 ...`, so even the verdict text
was lost. `execSync` captures it in `e.stdout`; fall back to it when stderr is
empty.

### 3. Unknown `/ponytail` args silently reset the session mode (`hooks/ponytail-mode-tracker.js`)

`/ponytail bogus` or `/ponytail review` fell through to `mode = getDefaultMode()`,
silently clobbering an active `lite`/`ultra` session back to the default. The
pi extension rejects unknown levels as invalid (`invalid-mode`); the hooks now
leave the current mode untouched instead of quietly resetting it. `/ponytail-review`
still enters review mode, and bare `/ponytail` still reports the active level.

## Tests

- `tests/correctness.test.js`: two regression tests — a raising CSV answer
  must report its real exception (never the harness `getvalue` crash), and the
  FAIL verdict text must survive into the reason.
- `tests/hooks.test.js`: `/ponytail bogus` and `/ponytail review` must not
  change an active `lite` mode.

Full suite green (86 root + 23 pi-extension + 3 MCP = 112), plus
`benchmarks/correctness.test.js`, `loc.test.js`, `check-rule-copies.js`,
`check-versions.js`. (The pandas CSV check needs pandas installed, which CI
already does via `pip install pandas`.)