### PR TITLE
fix(hooks): do not persist review from /ponytail-review (#736)

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -28,9 +28,10 @@ function finish() {
       let mode = null;
       let isReportOnly = false;
 
-      if (cmd === '/ponytail-review' || cmd === '/ponytail:ponytail-review') {
-        mode = 'review';
-      } else if (cmd === '/ponytail' || cmd === '/ponytail:ponytail') {
+      // /ponytail-review is a one-shot skill, not a session level (#736).
+      // Matching it here used to setMode('review'), which latched
+      // INDEPENDENT_MODES for the rest of the session.
+      if (cmd === '/ponytail' || cmd === '/ponytail:ponytail') {
         // `/ponytail default <mode>` persists the default to config (survives
         // restarts). Plain switches stay session-scoped ("sticks until session
         // end"), so this is the only path that writes config. review is not a

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -489,4 +489,41 @@ try {
   if (prevEnvModeRev === undefined) delete process.env.PONYTAIL_DEFAULT_MODE; else process.env.PONYTAIL_DEFAULT_MODE = prevEnvModeRev;
 }
 
+// #736: /ponytail-review is a one-shot skill, not a session level. Persisting
+// `review` makes every later getPonytailInstructions() return a pointer line.
+const latchHome = path.join(temp, 'review-latch-home');
+const latchFlag = path.join(latchHome, '.claude', '.ponytail-active');
+fs.mkdirSync(path.dirname(latchFlag), { recursive: true });
+const latchEnv = { HOME: latchHome, USERPROFILE: latchHome };
+
+fs.writeFileSync(latchFlag, 'full');
+result = run('ponytail-mode-tracker.js', latchEnv, JSON.stringify({ prompt: '/ponytail-review' }));
+assert.equal(result.status, 0, result.stderr);
+assert.equal(
+  fs.readFileSync(latchFlag, 'utf8'),
+  'full',
+  '/ponytail-review must leave an active level untouched (#736)',
+);
+
+result = run(
+  'ponytail-mode-tracker.js',
+  latchEnv,
+  JSON.stringify({ prompt: '/ponytail:ponytail-review src/app.js' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(
+  fs.readFileSync(latchFlag, 'utf8'),
+  'full',
+  'namespaced /ponytail:ponytail-review must not latch review either (#736)',
+);
+
+fs.unlinkSync(latchFlag);
+result = run('ponytail-mode-tracker.js', latchEnv, JSON.stringify({ prompt: '/ponytail-review' }));
+assert.equal(result.status, 0, result.stderr);
+assert.equal(
+  fs.existsSync(latchFlag),
+  false,
+  '/ponytail-review must not create a review flag on a fresh session (#736)',
+);
+
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
## Summary
- `/ponytail-review` wrote `review` into the session mode flag, so later `getPonytailInstructions()` returned a pointer line for the rest of the session.
- Stop treating `/ponytail-review` (and `/ponytail:ponytail-review`) as a mode switch; the skill still dispatches, the flag stays on the real level.

Closes #736.

## Out of scope
- Making `review` a runtime level, or deleting `INDEPENDENT_MODES`
- OpenCode `/ponytail review` (the arg) persisting via `normalizePersistedMode` — sibling write, not this hook
- `#747` unknown-arg clobber (`/ponytail review` / `/ponytail bogus`)
- pi-extension: `/ponytail-review` is already an alias and does not latch

## Test plan
- [x] `node scripts/check-rule-copies.js`
- [x] `node scripts/check-versions.js`
- [x] `npm test`
- [x] `node tests/hooks.test.js` — `/ponytail-review` leaves `full` untouched and does not create a `review` flag (red on `upstream/main`, actual `review`)