### PR TITLE
fix: repair backslashed PLUGIN_ROOT in copilot bash hooks (#646)

### DIFF
--- a/hooks/copilot-hooks.json
+++ b/hooks/copilot-hooks.json
@@ -4,7 +4,7 @@
     "sessionStart": [
       {
         "type": "command",
-        "bash": "node \"${PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
+        "bash": "node \"${PLUGIN_ROOT//\\\\//}/hooks/ponytail-activate.js\"",
         "powershell": "node \"${PLUGIN_ROOT}\\hooks\\ponytail-activate.js\"",
         "timeoutSec": 5
       }
@@ -12,7 +12,7 @@
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": "node \"${PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
+        "bash": "node \"${PLUGIN_ROOT//\\\\//}/hooks/ponytail-mode-tracker.js\"",
         "powershell": "node \"${PLUGIN_ROOT}\\hooks\\ponytail-mode-tracker.js\"",
         "timeoutSec": 5
       }

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -11,7 +11,8 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
-const { spawn } = require('child_process');
+const os = require('os');
+const { spawn, spawnSync } = require('child_process');
 
 const root = path.join(__dirname, '..');
 const HOOKS_JSON = 'hooks/claude-codex-hooks.json';
@@ -110,5 +111,35 @@ test('Claude and Codex manifests point at the shared host-specific hook config',
   for (const rel of HOST_PLUGIN_MANIFESTS) {
     const manifest = JSON.parse(fs.readFileSync(path.join(root, rel), 'utf8'));
     assert.equal(manifest.hooks, `./${HOOKS_JSON}`, `${rel} must not rely on root hooks auto-discovery`);
+  }
+});
+
+// Issue #646: under WSL2 the host expands the plugin root with Windows
+// separators (\home\user\...). A backslashed string is not absolute on Linux,
+// so node resolves the hook relative to cwd and every session start and prompt
+// dies with MODULE_NOT_FOUND. The bash commands have to repair the separators
+// before the path reaches node. Only copilot-hooks.json can do this: its bash
+// and powershell commands are separate fields, so bash-only syntax is safe
+// there, unlike the shared `command` field asserted on above.
+test('copilot bash hooks survive a Windows-separated PLUGIN_ROOT (WSL2)', () => {
+  const config = JSON.parse(fs.readFileSync(path.join(root, 'hooks/copilot-hooks.json'), 'utf8'));
+  const commands = Object.values(config.hooks).flat().map((h) => h.bash);
+  assert.ok(commands.length > 0, 'expected at least one bash hook command');
+
+  const pluginData = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-wsl-'));
+  const env = {
+    ...process.env,
+    PLUGIN_ROOT: root.replace(/\//g, '\\'),
+    COPILOT_PLUGIN_DATA: pluginData,
+  };
+
+  try {
+    for (const cmd of commands) {
+      // input: '' closes stdin so the prompt hook does not wait on it.
+      const result = spawnSync('bash', ['-c', cmd], { env, input: '', encoding: 'utf8' });
+      assert.equal(result.status, 0, `hook failed with a backslashed PLUGIN_ROOT: ${cmd}\n${result.stderr}`);
+    }
+  } finally {
+    fs.rmSync(pluginData, { recursive: true, force: true });
   }
 });


### PR DESCRIPTION
Fixes the Copilot half of #646.

## Problem

Under WSL2 the host expands the plugin root with Windows separators (`\home\user\.copilot\installed-plugins\ponytail\ponytail`). That string is not absolute on Linux, so node resolves the hook **relative to the current working directory**:

```
Error: Cannot find module '/home/user/dev/myrepo/\home\user\.copilot\installed-plugins\ponytail\ponytail/hooks/ponytail-mode-tracker.js'
  code: 'MODULE_NOT_FOUND'
```

Note the shape the issue calls out: `<cwd>` + backslashed root + `/hooks/...js` from the JSON template. It fires on every session start and every prompt submission, before any ponytail code runs — so nothing inside the hook scripts can guard against it.

## Fix

Repair the separators in the two `bash` commands, so the path handed to node is a valid POSIX path:

```json
"bash": "node \"${PLUGIN_ROOT//\\\\//}/hooks/ponytail-mode-tracker.js\""
```

A no-op when the root is already POSIX, so nothing changes for Linux/macOS hosts.

Bash parameter expansion rather than the `tr` pipeline suggested in the issue: no subprocess, and it repairs the root without adding the missing-`node`/missing-script guards, which are separate failure modes and a separate change.

## Scope

`hooks/copilot-hooks.json` only. `claude-codex-hooks.json` has the same weakness, but its single shared `command` field also runs under PowerShell (`commandWindows` was dropped in #601 for marketplace validation), and the existing *shared hook commands are shell-agnostic* test in `tests/hooks-windows.test.js` rightly forbids bash-only syntax there. That half of #646 needs a different answer, so I left it open rather than breaking Windows to fix WSL.

## Verification

New regression test in `tests/hooks-windows.test.js` runs each `bash` command through bash with `PLUGIN_ROOT` set to a backslashed repo root and asserts the hook exits 0. It fails on `main` with the exact `MODULE_NOT_FOUND` above, passes with the fix.

- `node --test tests/*.test.js` — 85 pass, 0 fail
- `node scripts/check-rule-copies.js`, `node scripts/check-versions.js` — clean
- Also verified live: Copilot CLI 1.0.75 in WSL2, hooks fire and `.ponytail-active` is written; the CLI runs the `bash` field under bash, so the expansion is available.