### PR TITLE
fix(pi): keep decorative startup UI out of RPC mode

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -71,6 +71,7 @@ export default function ponytailExtension(pi) {
   function syncStatus(ctx) {
     if (ctx) lastCtx = ctx;
     const c = ctx || lastCtx;
+    if (c?.mode !== "tui") return;
     // ponytail: hide the indicator but keep the ruleset active (#324).
     if (hideStatus) return;
     if (!c?.ui?.setStatus) return;
@@ -186,7 +187,7 @@ export default function ponytailExtension(pi) {
     hideStatus = getHideStatus();
     currentMode = resolveSessionMode(entries, configuredDefaultMode);
     syncStatus(ctx);
-    if (!getQuietStartup()) {
+    if (ctx?.mode === "tui" && !getQuietStartup()) {
       ctx?.ui?.notify?.(`Ponytail loaded: ${currentMode}`, "info");
     }
   });

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -33,6 +33,7 @@ function createPiHarness() {
 
 function createCommandContext(overrides = {}) {
   return {
+    mode: "tui",
     isIdle: () => true,
     sessionManager: { getEntries: () => [] },
     ui: { notify() {} },
@@ -177,6 +178,28 @@ test("status bar renders the mode and flips active on agent_start", async () => 
   assert.equal(statusWrites.at(-2).key, "ponytail");
   assert.match(statusWrites.at(-2).text, /○.*ULTRA/);
   assert.match(statusWrites.at(-1).text, /●.*ULTRA/);
+}));
+
+test("RPC startup keeps Ponytail active without decorative UI", async () => withTempConfig(async () => {
+  const { events } = createPiHarness();
+  const notifications = [];
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    mode: "rpc",
+    ui: {
+      notify: (message) => notifications.push(message),
+      setStatus: (key, text) => statusWrites.push({ key, text }),
+      theme: { fg: (_color, text) => text },
+    },
+  });
+
+  await events.get("session_start")({ reason: "startup" }, ctx);
+  await events.get("agent_start")({}, ctx);
+  const injected = await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx);
+
+  assert.deepEqual(notifications, []);
+  assert.deepEqual(statusWrites, []);
+  assert.match(injected.systemPrompt, /PONYTAIL MODE ACTIVE/);
 }));
 
 test("status bar stays silent when ui lacks a theme", async () => withTempConfig(async () => {


### PR DESCRIPTION
## What changed

- Show Ponytail’s styled status only in Pi’s local TUI.
- Show the startup-loaded notification only in the local TUI.
- Keep Ponytail prompt injection and explicit command notifications active in RPC mode.

## Why

Pi RPC forwards `notify` and `setStatus` calls to remote clients. The status contains terminal color escapes, so browser clients show both an unnecessary startup toast and a block of raw escape characters above the composer. These values are decorative terminal UI, not remote functionality.

## Checks

- `node --test pi-extension/test/*.test.js` (24 passed)
- Added an RPC startup regression that verifies no notification or status while the Ponytail instructions still inject.
- The full root suite has one unrelated timing-sensitive pandas correctness failure on this machine.