### PR TITLE
fix(ruleset): honor host plan/review gates and bound check runs

### DIFF
--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -51,6 +51,14 @@ every sibling caller still broken. Fix it once, where all callers route through.
 - Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path (`# ponytail: global lock, per-account locks if throughput matters`).
 
+## Plan mode & review gates
+
+When the host is in plan/review mode or asks you to plan first: stop at
+understanding and present the plan through the host's plan-review mechanism
+(`submit_plan` in OpenCode). "Never stall" governs execution choices, not a
+required review gate — never substitute a hand-written .md or prose summary
+for the review step.
+
 ## Output
 
 Code first. Then at most three short lines: what was skipped, when to add it.
@@ -97,7 +105,8 @@ loop, a parser, a money/security path) leaves ONE runnable check behind, the
 smallest thing that fails if the logic breaks: an `assert`-based
 `demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
 fixtures, no per-function suites unless asked. Trivial one-liners need no
-test, YAGNI applies to tests too.
+test, YAGNI applies to tests too. Run the check once under a bounded wait
+(`timeout`): a timeout is not a logic failure — fix or report it, no retry loops.
 
 ## Boundaries
 

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -69,7 +69,11 @@ function getFallbackInstructions(mode) {
     '## When NOT to be lazy\n\n' +
     'Never simplify away: understanding the problem (read it fully and trace the real flow before picking a rung — a small diff you do not understand is just laziness dressed up as efficiency), input validation at trust boundaries, error handling that prevents data loss, ' +
     'security measures, accessibility basics, the calibration real hardware needs (the platform is never the spec ideal), anything the user explicitly asked to keep. ' +
-    'Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind (assert-based demo/self-check or one small test file; no frameworks). Trivial one-liners need no test.\n\n' +
+    'Lazy code without its check is unfinished: non-trivial logic leaves ONE runnable check behind (assert-based demo/self-check or one small test file; no frameworks). Trivial one-liners need no test. ' +
+    'Run the check once under a bounded wait: a timeout is not a logic failure, no retry loops.\n\n' +
+    '## Plan mode & review gates\n\n' +
+    'When the host is in plan/review mode or asks you to plan first, present the plan through its plan-review tool (submit_plan in OpenCode); ' +
+    'never stall governs execution choices, not a required review gate, and never substitute a hand-written .md or prose summary for it.\n\n' +
     '## Boundaries\n\n' +
     'Ponytail governs what you build, not how you talk. "stop ponytail" or "normal mode": revert. Level persists until changed or session end.';
 }

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -63,6 +63,14 @@ every sibling caller still broken. Fix it once, where all callers route through.
 - Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
 - Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path (`# ponytail: global lock, per-account locks if throughput matters`).
 
+## Plan mode & review gates
+
+When the host is in plan/review mode or asks you to plan first: stop at
+understanding and present the plan through the host's plan-review mechanism
+(`submit_plan` in OpenCode). "Never stall" governs execution choices, not a
+required review gate — never substitute a hand-written .md or prose summary
+for the review step.
+
 ## Output
 
 Code first. Then at most three short lines: what was skipped, when to add it.
@@ -109,7 +117,8 @@ loop, a parser, a money/security path) leaves ONE runnable check behind, the
 smallest thing that fails if the logic breaks: an `assert`-based
 `demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
 fixtures, no per-function suites unless asked. Trivial one-liners need no
-test, YAGNI applies to tests too.
+test, YAGNI applies to tests too. Run the check once under a bounded wait
+(`timeout`): a timeout is not a logic failure — fix or report it, no retry loops.
 
 ## Boundaries
 

--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -101,4 +101,15 @@ test('parseCommandFile returns null when there is no frontmatter', () => {
   assert.equal(parseCommandFile(bare), null);
 });
 
+test('ruleset carries the plan-gate and bounded-check clauses in every mode and fallback', () => {
+  const { getPonytailInstructions, getFallbackInstructions } = require(path.join(__dirname, '..', 'hooks', 'ponytail-instructions'));
+  for (const mode of ['lite', 'full', 'ultra']) {
+    for (const text of [getPonytailInstructions(mode), getFallbackInstructions(mode)]) {
+      assert.match(text, /submit_plan/, mode + ': missing submit_plan clause');
+      assert.match(text, /review gate/, mode + ': missing review-gate clause');
+      assert.match(text, /no retry loops/, mode + ': missing bounded-check clause');
+    }
+  }
+});
+
 test.after(() => fs.rmSync(tmp, { recursive: true, force: true }));


### PR DESCRIPTION
Fixes #757.

## What

The ruleset is injected last into every turn's system prompt, so its unconditional "Code first." and "Never stall on an answer you can default" overrode hosts that require a plan/review gate before implementation (e.g. OpenCode's `submit_plan`). Agents obeyed ponytail and skipped the review step, writing spec `.md` files or prose summaries instead.

## Change

- New short section **"Plan mode & review gates"** in `skills/ponytail/SKILL.md`: when the host is in plan/review mode or asks for a plan first, stop at understanding and present the plan through the host's review mechanism; "never stall" governs execution choices, not a required review gate; never substitute a hand-written `.md` for it.
- Mirrored in `getFallbackInstructions()` (hooks/ponytail-instructions.js) so every host consuming the shared builder — Claude hooks, pi extension, MCP server — emits identical rules.
- Bounded the runnable-check rule: run the check once under a bounded wait (`timeout`); a timeout is not a logic failure — fix or report, no retry loops.
- Regenerated `.openclaw/skills/ponytail/SKILL.md` via `scripts/build-openclaw-skills.js`.

## Test

- Added `ruleset carries the plan-gate and bounded-check clauses in every mode and fallback` to tests/opencode-plugin.test.js — asserts all three clauses survive mode filtering (lite/full/ultra) in both the SKILL.md body and the fallback builder.
- `node --test tests/opencode-plugin.test.js tests/openclaw-skills.test.js` → 27 pass.
- `npm test --prefix ponytail-mcp` → 4 pass. `node scripts/check-rule-copies.js` → 9/9 invariants intact.
