### PR TITLE
feat(plugin): conform to Agent Plugins v1 specification

### DIFF
--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -4,13 +4,33 @@ Ponytail is an agent-portable skill distribution. The skills in `skills/` hold
 the core behavior; host-specific files are adapters that make that behavior easy
 to load in a given agent.
 
+## Agent Plugins v1 portable core
+
+The repository root is a conforming [Agent Plugins v1](https://agent-plugins.org/specification)
+package. Any client that implements the spec loads ponytail with no adapter:
+
+| Path | Role |
+|------|------|
+| `plugin.json` | The one portable manifest (`$schema` pins spec `1.0.0`). Metadata only — the schema is closed, so it carries no component paths. |
+| `skills/<name>/SKILL.md` | The six skills, discovered from the fixed `skills/` location. Each conforms to the [Agent Skills](https://agentskills.io/specification) spec. |
+| `mcp.json` | Not shipped. `ponytail-mcp/` is a private workspace package with uninstalled dependencies, so declaring it here would hand clients a server that cannot start. Wire it up manually per `ponytail-mcp/README.md`. |
+
+Everything else below is a host adapter, not a portable component. Agent Plugins
+v1 standardizes only skills and MCP servers: commands, hooks, rules, and
+marketplace metadata have no portable form, so they stay on the host-specific
+paths each agent already discovers. `tests/agent-plugins.test.js` guards the
+core — most importantly that no adapter's component keys (`skills`, `commands`,
+`hooks`) leak into root `plugin.json`, and that no `SKILL.md` grows a
+frontmatter field that would make a conforming client silently skip the skill.
+
 ## Supported Adapters
 
 | Host | Files | Notes |
 |------|-------|-------|
+| Agent Plugins v1 clients | `plugin.json`, `skills/` | Portable core, see above. No adapter needed. |
 | Claude Code | `.claude-plugin/plugin.json`, `commands/`, `hooks/claude-codex-hooks.json`, `hooks/` | Full plugin install with session activation, mode tracking, commands, and statusline support. |
 | Codex | `.codex-plugin/plugin.json`, `hooks/claude-codex-hooks.json`, `hooks/`, `skills/` | Plugin install with the same skills plus lifecycle hooks for activation and mode tracking. |
-| Grok Build | root `plugin.json`, `.grok-plugin/marketplace.json`, `skills/`, `commands/` | `grok plugin install DietrichGebert/ponytail --trust`, then enable. Grok can auto-invoke ponytail from its coding-task skill description; `/ponytail` makes activation explicit. Grok lifecycle hooks are not used because passive hook output cannot inject instructions. |
+| Grok Build | root `plugin.json`, `.grok-plugin/marketplace.json`, `skills/`, `commands/` | `grok plugin install DietrichGebert/ponytail --trust`, then enable. Reads the portable manifest directly. Grok can auto-invoke ponytail from its coding-task skill description; `/ponytail` makes activation explicit. Grok lifecycle hooks are not used because passive hook output cannot inject instructions. |
 | OpenCode | `.opencode/plugins/ponytail.mjs`, `.opencode/command/`, `hooks/`, `skills/` | Server plugin injects the ruleset each turn via `experimental.chat.system.transform` and persists `/ponytail` switches; reuses the shared instruction builder. |
 | pi | `pi-extension/`, `skills/`, `hooks/` | Package extension: injects the ruleset each turn through the shared instruction builder and registers the `/ponytail` commands. |
 | Hermes Agent | `plugin.yaml`, `__init__.py`, `skills/` | Native Hermes plugin: injects active mode through `pre_llm_call`, rewrites gateway `/ponytail-*` skill commands into agent prompts, registers `/ponytail` mode switching, and exposes bundled skills as `ponytail:<skill>`. |
@@ -36,7 +56,9 @@ to load in a given agent.
 
 Keep adapters thin. When a host supports skills or hooks, point it at the
 existing `skills/` and `hooks/` files. When a host only supports project
-instructions, keep its copied rule text aligned with `AGENTS.md`.
+instructions, keep its copied rule text aligned with `AGENTS.md`. Never add
+component paths or host-specific keys to root `plugin.json`; it is the portable
+Agent Plugins v1 manifest and its schema is closed.
 
 ## Portable Behavior
 

--- a/plugin.json
+++ b/plugin.json
@@ -1,3 +1,14 @@
 {
-  "name": "ponytail"
+  "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
+  "name": "ponytail",
+  "version": "4.9.0",
+  "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
+  "author": {
+    "name": "Dietrich Gebert",
+    "url": "https://github.com/DietrichGebert"
+  },
+  "homepage": "https://github.com/DietrichGebert/ponytail",
+  "repository": "https://github.com/DietrichGebert/ponytail",
+  "license": "MIT",
+  "keywords": ["yagni", "minimalism", "code-review", "productivity"]
 }

--- a/scripts/check-versions.js
+++ b/scripts/check-versions.js
@@ -24,6 +24,7 @@ const VERSION_FILES = [
   '.devin-plugin/plugin.json',   // Devin CLI plugin
   '.github/plugin/plugin.json',  // Copilot plugin
   '.qoder-plugin/plugin.json',   // Qoder plugin
+  'plugin.json',                 // Agent Plugins v1 portable manifest
   'gemini-extension.json',       // Gemini CLI extension
   'package.json',                // pi-package / repo root
   'ponytail-mcp/package.json',   // MCP server (private, internal-only)

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -13,8 +13,9 @@ description: >
   over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
   use for non-coding requests (general knowledge, prose, translation,
   summaries, recipes).
-argument-hint: "[lite|full|ultra]"
 license: MIT
+metadata:
+  argument-hint: "[lite|full|ultra]"
 ---
 
 # Ponytail

--- a/tests/agent-plugins.test.js
+++ b/tests/agent-plugins.test.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+// Agent Plugins v1 conformance guard for the portable core.
+//
+// The portable core is exactly three things: root plugin.json, skills/, and an
+// optional root mcp.json. Everything else in this repo (.claude-plugin/,
+// .codex-plugin/, .github/plugin/, .qoder-plugin/, hooks/, commands/, rules)
+// is a host adapter and is deliberately out of scope here.
+//
+// Two failure modes this catches, both of which have already bitten:
+//   1. Copying an adapter manifest's component keys ("skills", "commands",
+//      "hooks", "mcpServers") into root plugin.json. The v1 schema is closed and
+//      component locations are fixed, so those keys are nonconforming.
+//   2. A stray frontmatter key in a SKILL.md. Spec §7.1 says a client MUST *skip*
+//      a skill that fails Agent Skills validation, so one extra key silently
+//      removes the whole skill instead of erroring loudly. `argument-hint` did
+//      exactly that to skills/ponytail before the v1 migration.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const root = path.join(__dirname, '..');
+const PLUGIN_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/plugin.schema.json';
+const MCP_SCHEMA = 'https://agent-plugins.org/schemas/1.0.0/mcp.schema.json';
+
+// Spec §5.2: the manifest schema is closed.
+const MANIFEST_FIELDS = new Set([
+  '$schema', 'name', 'version', 'description', 'author',
+  'homepage', 'repository', 'license', 'keywords', 'extensions',
+]);
+// Agent Skills frontmatter is closed too; skills-ref rejects anything else.
+const SKILL_FIELDS = new Set([
+  'name', 'description', 'license', 'compatibility', 'metadata', 'allowed-tools',
+]);
+const PLUGIN_NAME = /^(?!.*(?:--|\.\.))[a-z0-9](?:[a-z0-9.-]*[a-z0-9])?$/;
+const SKILL_NAME = /^(?!.*--)[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$/;
+
+const read = (rel) => fs.readFileSync(path.join(root, rel), 'utf8').replace(/^\uFEFF/, '');
+
+// Top-level frontmatter keys only. Enough to catch a stray field without pulling
+// in a YAML parser; this repo ships zero runtime dependencies. If the bodies ever
+// grow nested structures worth validating, run skills-ref in CI instead.
+function frontmatterKeys(text) {
+  const match = /^---\n([\s\S]*?)\n---/.exec(text);
+  assert.ok(match, 'SKILL.md must open with YAML frontmatter');
+  return match[1].split('\n')
+    .map((line) => /^([A-Za-z][\w-]*):/.exec(line))
+    .filter(Boolean)
+    .map((m) => m[1]);
+}
+
+function frontmatterValue(text, key) {
+  const match = new RegExp(`^${key}:[ \\t]*(.*)$`, 'm').exec(text);
+  return match ? match[1].trim() : undefined;
+}
+
+test('root plugin.json is a conforming Agent Plugins v1 manifest', () => {
+  const manifest = JSON.parse(read('plugin.json'));
+
+  assert.equal(manifest.$schema, PLUGIN_SCHEMA);
+  assert.match(manifest.name, PLUGIN_NAME);
+  assert.ok(manifest.name.length <= 64);
+
+  const unknown = Object.keys(manifest).filter((key) => !MANIFEST_FIELDS.has(key));
+  assert.deepEqual(unknown, [], `plugin.json has non-portable top-level fields: ${unknown}`);
+
+  // Component locations are fixed (§6.1); the manifest cannot point at them.
+  for (const key of ['skills', 'commands', 'hooks', 'mcpServers', 'rules', 'interface']) {
+    assert.equal(manifest[key], undefined, `"${key}" belongs in a host adapter manifest, not plugin.json`);
+  }
+
+  if (manifest.author) {
+    const badAuthor = Object.keys(manifest.author).filter((k) => !['name', 'email', 'url'].includes(k));
+    assert.deepEqual(badAuthor, [], `author may only carry name/email/url, got: ${badAuthor}`);
+  }
+});
+
+test('every skill in skills/ conforms to the Agent Skills spec', () => {
+  const dirs = fs.readdirSync(path.join(root, 'skills'), { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+  assert.ok(dirs.length > 0, 'skills/ must contain at least one skill directory');
+
+  for (const dir of dirs) {
+    // §7.1: only immediate children with a regular SKILL.md are discovered.
+    const skillPath = path.join(root, 'skills', dir, 'SKILL.md');
+    assert.ok(fs.statSync(skillPath).isFile(), `skills/${dir}/SKILL.md must be a regular file`);
+
+    const text = read(path.join('skills', dir, 'SKILL.md'));
+    const keys = frontmatterKeys(text);
+
+    const unknown = keys.filter((key) => !SKILL_FIELDS.has(key));
+    assert.deepEqual(unknown, [], `skills/${dir} has unexpected frontmatter (client would skip it): ${unknown}`);
+
+    const name = frontmatterValue(text, 'name');
+    assert.equal(name, dir, `skills/${dir}: frontmatter name must match its directory`);
+    assert.match(name, SKILL_NAME);
+    assert.ok(keys.includes('description'), `skills/${dir}: description is required`);
+  }
+});
+
+test('MCP config, if it ever ships, targets the matching spec version', () => {
+  // Intentionally absent today: ponytail-mcp/ is a private, unbuilt workspace
+  // package, so shipping it here would hand clients a server that cannot start.
+  const mcpPath = path.join(root, 'mcp.json');
+  if (!fs.existsSync(mcpPath)) return;
+
+  const mcp = JSON.parse(read('mcp.json'));
+  assert.equal(mcp.$schema, MCP_SCHEMA, 'mcp.json version must match plugin.json (§10.1)');
+  assert.deepEqual(Object.keys(mcp).sort(), ['$schema', 'mcpServers']);
+  for (const [name, server] of Object.entries(mcp.mcpServers)) {
+    assert.ok(['stdio', 'streamable-http', 'sse'].includes(server.type), `${name}: unknown transport`);
+    if (server.type === 'stdio') {
+      assert.doesNotMatch(server.command, /\s/, `${name}: command must be one executable token`);
+    }
+  }
+});


### PR DESCRIPTION
Makes the repo root a conforming [Agent Plugins v1](https://agent-plugins.org/specification) package, so any client implementing the spec loads ponytail with no adapter. Every existing host adapter is untouched.

## The bug this surfaced

`skills/ponytail/SKILL.md` carried an `argument-hint` frontmatter key. That is not an Agent Skills field, so `skills-ref` rejects it — and spec §7.1 says a conformant client **MUST skip** a skill that fails validation. Any strict client was silently dropping the *main* ponytail skill, with no error and no way to notice.

```
$ npx skills-ref validate skills/ponytail/
Validation failed for skills/ponytail/:
  - Unexpected fields in frontmatter: argument-hint.
    Only allowed-tools, compatibility, description, license, metadata, name are allowed.
```

Moved under `metadata`, the spec's sanctioned escape hatch for non-standard keys. The hint text is preserved verbatim. All six skills now validate, up from five.

## Changes

| File | Change |
|---|---|
| `plugin.json` | Was `{"name": "ponytail"}`. Now pins `$schema` to `1.0.0` and carries the shared metadata. |
| `skills/ponytail/SKILL.md` | `argument-hint` → `metadata.argument-hint`. |
| `scripts/check-versions.js` | Root manifest now declares a version, so it joins the drift guard (8 files → 9). |
| `tests/agent-plugins.test.js` | New conformance guard (3 tests). |
| `docs/agent-portability.md` | Documents the portable core and the adapter boundary. |

## What deliberately did *not* change

**No component paths in root `plugin.json`.** The v1 schema is closed and `skills/`/`mcp.json` are fixed locations, so a `"skills"` or `"hooks"` key there is nonconforming. Those stay on the adapter manifests.

**No adapter was migrated or removed.** v1 standardizes only skills and MCP servers. Hooks, commands, agents, and rules have no portable form, so `.claude-plugin/`, `.codex-plugin/`, `.github/plugin/`, `.qoder-plugin/`, `.devin-plugin/`, `gemini-extension.json`, `plugin.yaml`, `.opencode/`, `pi-extension/`, `hooks/`, `commands/`, and the rule copies are all unchanged. I did not invent vendor extension namespaces for them — that only pays off once a client documents one.

**No `mcp.json`.** `ponytail-mcp` is `private: true`, absent from the npm `files` list, and has uninstalled dependencies, so declaring it would hand clients a server that cannot start. The new test validates one if it ever ships.

## Validation

- `plugin.json` → **VALID** against the official schema (ajv, draft 2020-12).
- All 6 skills → **Valid skill** via `skills-ref@0.1.5` (was 5/6).
- `check-rule-copies.js` ✅ · `check-versions.js` ✅ (9 files @ 4.9.0).
- Suite: **83 → 86 pass**. One pre-existing failure on `main` is unrelated (`csv: correct pandas one-liner passes` — local pandas env).
- The new guard is mutation-tested: leaking `skills`/`hooks` into the manifest, reintroducing `argument-hint`, and a skill name/directory mismatch each fail the intended assertion.

## Grok Build compatibility (verified against source)

My first draft of this note guessed that Grok needed a smoke test. I went and read the source instead — `xai-org/grok-build@77cd7eb6`. Two findings, one reassuring and one an honest regression.

**The manifest change is safe.** Grok's `PluginManifest` is a plain serde struct whose doc comment is explicit:

> `crates/codegen/xai-grok-agent/src/plugins/manifest.rs:132-137`
> ```rust
> /// Forward-compatible: unknown fields are silently ignored via
> /// `#[serde(deny_unknown_fields)]` NOT being set.
> #[derive(Debug, Clone, Default, Deserialize)]
> ```

`$schema` and the added metadata are simply skipped. There is an in-repo test for exactly this (`parse_manifest_ignores_unknown_fields`), and root `plugin.json` is the *first* entry in Grok's `MANIFEST_PATHS`, ahead of `.grok-plugin/` and `.claude-plugin/`. xAI's own marketplace `neon` plugin already ships an unknown `logo` key. So no `.grok-plugin/plugin.json` adapter is needed.

**One real cosmetic regression, disclosed.** Grok reads the argument hint from the *top level only*:

> `crates/codegen/xai-grok-tools/src/implementations/skills/discovery.rs:555`
> ```rust
> argument_hint: coerce_to_string(frontmatter.get("argument-hint")),
> ```

Its `parse_metadata` promotes only `short-description` and `author` out of the `metadata:` block, so `metadata.argument-hint` lands in a generic map and is never used. **Net effect: Grok's `/ponytail` autocomplete loses its `[lite|full|ultra]` hint.** The skill still loads and every mode still works.

I deliberately did **not** "fix" this by keeping a top-level `argument-hint` alongside the `metadata` copy. That would re-break `skills-ref` validation, and spec §7.1 says a conformant client MUST *skip* a skill that fails validation. The trade is:

| | top-level `argument-hint` | `metadata.argument-hint` (this PR) |
|---|---|---|
| Conformant v1 clients | **main skill silently dropped** | skill loads |
| Grok autocomplete hint | shown | **not shown** |

Losing one host's autocomplete hint beats every conformant client silently dropping the main skill. The hint is also still in the skill body (`Switch: /ponytail lite|full|ultra`) and in `SKILL.md` frontmatter under `metadata`, so nothing is lost but the inline UI affordance — and it comes back for free if Grok ever reads `metadata.argument-hint`. Happy to file that upstream if you'd like.

## Unrelated pre-existing observation (not touched)

While tracing the above I noticed Grok's plugin command discovery scans `.md` only (`scan_md_files`, `discovery.rs:86-102`), so the six `commands/*.toml` files appear to be inert under Grok — the `/ponytail*` entries there come from `skills/*/SKILL.md`. That predates this PR and is out of its scope, so I left it alone; flagging it only because `grok inspect` would confirm it in seconds.
