### PR TITLE
fix(copilot): defer plugin root expansion to bash

### DIFF
--- a/hooks/copilot-hooks.json
+++ b/hooks/copilot-hooks.json
@@ -4,7 +4,7 @@
     "sessionStart": [
       {
         "type": "command",
-        "bash": "node \"${PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
+        "bash": "node \"$PLUGIN_ROOT/hooks/ponytail-activate.js\"",
         "powershell": "node \"${PLUGIN_ROOT}\\hooks\\ponytail-activate.js\"",
         "timeoutSec": 5
       }
@@ -12,7 +12,7 @@
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": "node \"${PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
+        "bash": "node \"$PLUGIN_ROOT/hooks/ponytail-mode-tracker.js\"",
         "powershell": "node \"${PLUGIN_ROOT}\\hooks\\ponytail-mode-tracker.js\"",
         "timeoutSec": 5
       }

--- a/tests/copilot-plugin.test.js
+++ b/tests/copilot-plugin.test.js
@@ -5,7 +5,9 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
+const { spawnSync } = require('child_process');
 
 const root = path.join(__dirname, '..');
 const REQUIRED_COMMAND_FILES = [
@@ -31,5 +33,46 @@ test('copilot plugin command directory includes ponytail-debt', () => {
       fs.existsSync(path.join(root, manifest.commands, file)),
       `missing command file: ${manifest.commands}${file}`,
     );
+  }
+});
+
+test('copilot hook commands use platform-native plugin root expansion', () => {
+  const manifest = readJSON('hooks/copilot-hooks.json');
+  const hooks = Object.values(manifest.hooks).flat();
+
+  for (const hook of hooks) {
+    assert.match(hook.bash, /"\$PLUGIN_ROOT\/hooks\//);
+    assert.doesNotMatch(hook.bash, /\$\{PLUGIN_ROOT\}\//);
+    assert.match(hook.powershell, /"\$\{PLUGIN_ROOT\}\\hooks\\/);
+  }
+});
+
+test('copilot bash hooks resolve a plugin root containing spaces', (t) => {
+  const manifest = readJSON('hooks/copilot-hooks.json');
+  const hooks = Object.values(manifest.hooks).flat();
+
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail plugin '));
+  const pluginRoot = path.join(temp, 'root with spaces');
+  const home = path.join(temp, 'home');
+  fs.cpSync(path.join(root, 'hooks'), path.join(pluginRoot, 'hooks'), { recursive: true });
+  fs.mkdirSync(home);
+
+  for (const hook of hooks) {
+    const result = spawnSync('bash', ['-c', hook.bash], {
+      env: {
+        ...process.env,
+        PLUGIN_ROOT: pluginRoot,
+        HOME: home,
+        USERPROFILE: home,
+        PONYTAIL_DEFAULT_MODE: 'full',
+      },
+      input: '',
+      encoding: 'utf8',
+    });
+    if (result.error?.code === 'ENOENT') {
+      t.skip('bash is unavailable');
+      return;
+    }
+    assert.equal(result.status, 0, result.stderr);
   }
 });


### PR DESCRIPTION
Closes #759

## Summary
- use Bash-native `$PLUGIN_ROOT` expansion for Copilot hook commands
- retain PowerShell `${PLUGIN_ROOT}` syntax unchanged
- verify platform-specific command forms and execute both Bash hooks with a plugin path containing spaces

## Verification
- `node --test tests/copilot-plugin.test.js`: 2 passed; Bash execution skipped because Bash is unavailable on this Windows host
- root `npm test`: 84 passed, 1 skipped, with one unrelated existing pandas correctness fixture failure
- `git diff --check`