### PR TITLE
perf(hooks): reduce Claude and Codex context tokens

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -3,13 +3,13 @@
 //
 // Runs on every session start:
 //   1. Writes flag file at $CLAUDE_CONFIG_DIR/.ponytail-active (defaults to ~/.claude; statusline reads this)
-//   2. Emits ponytail ruleset as hidden SessionStart context
+//   2. Emits compact Claude/Codex context or the full Copilot ruleset
 //   3. Detects missing statusline config and emits setup nudge
 
 const fs = require('fs');
 const path = require('path');
 const { getDefaultMode, getClaudeDir, isShellSafe } = require('./ponytail-config');
-const { getPonytailInstructions } = require('./ponytail-instructions');
+const { getPonytailActivationContext, getPonytailInstructions } = require('./ponytail-instructions');
 const {
   clearMode,
   isCodex,
@@ -38,8 +38,10 @@ try {
   // Silent fail -- flag is best-effort, don't block the hook
 }
 
-// 2. Emit the ponytail ruleset, filtered to the active intensity level.
-let output = getPonytailInstructions(mode);
+// 2. Emit compact Claude/Codex context or the full Copilot ruleset.
+let output = isCopilot
+  ? getPonytailInstructions(mode)
+  : getPonytailActivationContext(mode);
 
 // 3. Detect missing statusline config — nudge Claude to help set it up
 if (!isCodex && !isCopilot) try {

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -91,8 +91,19 @@ function getPonytailInstructions(mode) {
   }
 }
 
+function getPonytailActivationContext(mode) {
+  const configuredMode = normalizePersistedMode(mode) || DEFAULT_MODE;
+  const skill = INDEPENDENT_MODES.has(configuredMode)
+    ? 'ponytail-' + configuredMode
+    : 'ponytail';
+
+  return 'PONYTAIL MODE ACTIVE — level: ' + configuredMode +
+    '. Read and apply the canonical /' + skill + ' skill.';
+}
+
 module.exports = {
   filterSkillBodyForMode,
   getFallbackInstructions,
+  getPonytailActivationContext,
   getPonytailInstructions,
 };

--- a/hooks/ponytail-subagent.js
+++ b/hooks/ponytail-subagent.js
@@ -3,15 +3,16 @@
 //
 // SessionStart context is parent-thread only and never reaches subagents, so
 // without this every Task-spawned agent runs ponytail-unaware (issue #252).
-// When ponytail mode is active, inject the same ruleset into each subagent.
+// When ponytail mode is active, inject compact Claude/Codex context or the
+// full Qoder ruleset into each subagent.
 //
 // Scoping (opt-in, issue #506): set PONYTAIL_SUBAGENT_MATCHER to a regex and
-// the ruleset is injected only into subagents whose agent_type matches. The
+// the platform-specific context is injected only into subagents whose agent_type matches. The
 // regex is unanchored and case-insensitive — "explore|general" matches either,
 // "^general$" is exact. Unset means inject into every subagent, as before.
 
-const { getPonytailInstructions } = require('./ponytail-instructions');
-const { readMode, writeHookOutput } = require('./ponytail-runtime');
+const { getPonytailActivationContext, getPonytailInstructions } = require('./ponytail-instructions');
+const { isQoder, readMode, writeHookOutput } = require('./ponytail-runtime');
 
 const mode = readMode();
 
@@ -22,7 +23,10 @@ if (!mode || mode === 'off') {
 
 function inject() {
   try {
-    writeHookOutput('SubagentStart', mode, getPonytailInstructions(mode));
+    const context = isQoder
+      ? getPonytailInstructions(mode)
+      : getPonytailActivationContext(mode);
+    writeHookOutput('SubagentStart', mode, context);
   } catch (e) {
     // Silent fail — a stdout error at hook exit must not surface as a hook failure.
   }

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -26,6 +26,12 @@ function run(script, env, input = '') {
   });
 }
 
+function assertCompactPonytailContext(context, mode, skill = 'ponytail') {
+  assert.match(context, new RegExp('PONYTAIL MODE ACTIVE — level: ' + mode));
+  assert.match(context, new RegExp('Read and apply the canonical /' + skill + ' skill\\.'));
+  assert.doesNotMatch(context, /lazy senior developer/i);
+}
+
 // Keep the base env clean so the default-dir / native-Claude checks are
 // deterministic; the CLAUDE_CONFIG_DIR and codex/copilot cases set these
 // explicitly where needed. run() spreads process.env, so a PLUGIN_DATA /
@@ -62,10 +68,7 @@ let output = JSON.parse(result.stdout);
 assert.equal(output.systemMessage, 'PONYTAIL:ULTRA');
 assert.equal(output.additionalContext, undefined, 'Codex must not emit additionalContext at top level (#573)');
 assert.equal(output.hookSpecificOutput.hookEventName, 'SessionStart');
-assert.match(
-  output.hookSpecificOutput.additionalContext,
-  /PONYTAIL MODE ACTIVE — level: ultra/,
-);
+assertCompactPonytailContext(output.hookSpecificOutput.additionalContext, 'ultra');
 
 result = run(
   'ponytail-mode-tracker.js',
@@ -133,6 +136,7 @@ assert.equal(
   fs.readFileSync(path.join(home, '.claude', '.ponytail-active'), 'utf8'),
   'full',
 );
+assertCompactPonytailContext(result.stdout, 'full');
 
 // CLAUDE_CONFIG_DIR overrides ~/.claude for the flag file (issue #34).
 const home2 = path.join(temp, 'home2');
@@ -197,6 +201,7 @@ assert.equal(
 );
 output = JSON.parse(result.stdout);
 assert.match(output.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);
+assert.match(output.additionalContext, /lazy senior developer/i);
 
 // VS Code Copilot never sets COPILOT_PLUGIN_DATA — it only injects
 // CLAUDE_PLUGIN_ROOT pointed at an agent-plugins/.../.vscode install path
@@ -248,9 +253,9 @@ assert.equal(
 output = JSON.parse(result.stdout);
 assert.deepEqual(output, {});
 
-// SubagentStart hook: when ponytail mode is active it injects the ruleset into
-// each subagent (issue #252). Native Claude must get the hookSpecificOutput JSON
-// form, not raw stdout, or the context is dropped.
+// SubagentStart hook: when ponytail mode is active it injects platform-specific
+// context into each subagent (issue #252). Native Claude must get the
+// hookSpecificOutput JSON form, not raw stdout, or the context is dropped.
 const subHome = path.join(temp, 'sub-home');
 const subFlag = path.join(subHome, '.claude', '.ponytail-active');
 fs.mkdirSync(path.dirname(subFlag), { recursive: true });
@@ -261,10 +266,14 @@ result = run('ponytail-subagent.js', subEnv);
 assert.equal(result.status, 0, result.stderr);
 output = JSON.parse(result.stdout);
 assert.equal(output.hookSpecificOutput.hookEventName, 'SubagentStart');
-assert.match(
-  output.hookSpecificOutput.additionalContext,
-  /PONYTAIL MODE ACTIVE — level: full/,
-);
+assertCompactPonytailContext(output.hookSpecificOutput.additionalContext, 'full');
+
+// Review remains an independent mode, so it must point to its own canonical skill.
+fs.writeFileSync(subFlag, 'review');
+result = run('ponytail-subagent.js', subEnv);
+assert.equal(result.status, 0, result.stderr);
+output = JSON.parse(result.stdout);
+assertCompactPonytailContext(output.hookSpecificOutput.additionalContext, 'review', 'ponytail-review');
 
 // No flag → ponytail off → inject nothing (empty stdout, no failure).
 fs.unlinkSync(subFlag);
@@ -283,7 +292,7 @@ output = JSON.parse(result.stdout);
 assert.equal(output.systemMessage, 'PONYTAIL:FULL');
 assert.equal(output.additionalContext, undefined, 'Codex must not emit additionalContext at top level (#573)');
 assert.equal(output.hookSpecificOutput.hookEventName, 'SubagentStart');
-assert.match(output.hookSpecificOutput.additionalContext, /PONYTAIL MODE ACTIVE — level: full/);
+assertCompactPonytailContext(output.hookSpecificOutput.additionalContext, 'full');
 
 // SubagentStart scoping (issue #506): PONYTAIL_SUBAGENT_MATCHER limits the
 // injection to agent types whose name matches the regex. Unset keeps the
@@ -422,6 +431,7 @@ assert.match(
   output.hookSpecificOutput.additionalContext,
   /PONYTAIL MODE ACTIVE — level: full/,
 );
+assert.match(output.hookSpecificOutput.additionalContext, /lazy senior developer/i);
 // writeDefaultMode must merge into existing config, not overwrite it (#490).
 const mergeHome = path.join(temp, 'merge-home');
 const mergeConfigDir = path.join(mergeHome, '.config', 'ponytail');


### PR DESCRIPTION
## 이 변경이 적용되면

- **Claude와 Codex의 Ponytail SessionStart·SubagentStart 컨텍스트가 21 tokens의 스킬 포인터로 줄어듭니다.**
- **Copilot과 Qoder는 스킬 자동 로딩에 기대지 않고 기존 전체 규칙 본문을 계속 받습니다.**

## 해결하는 문제

Claude와 Codex는 세션과 각 하위 에이전트가 시작할 때 이미 등록된 Ponytail 스킬의 전체 본문 1,264 tokens를 반복 주입받았습니다. 활성 수준과 정본 스킬을 가리키는 정보만으로 같은 규칙을 로드할 수 있으므로 이 중복은 하위 에이전트 수에 비례해 커졌습니다. 이 Pull Request는 스킬을 직접 읽을 수 있는 Claude·Codex 경로만 축약하고, 같은 스크립트를 공유하지만 전체 본문이 필요한 Copilot·Qoder 경로는 보존합니다.

## 변경 내용

- **짧은 활성화 컨텍스트 생성기를 추가했습니다** (`hooks/ponytail-instructions.js`)
  - 방식: 활성 수준과 일반 `/ponytail` 또는 독립 `/ponytail-review` 스킬 포인터만 반환합니다.
- **공유 훅을 런타임별 출력으로 분기했습니다** (`hooks/ponytail-activate.js`, `hooks/ponytail-subagent.js`)
  - 검토 관점: Claude·Codex는 compact context, Copilot SessionStart와 Qoder subagent는 전체 본문을 받습니다.
- **훅 테스트가 compact와 full 출력을 구별하게 했습니다** (`tests/hooks.test.js`)
  - 방식: Claude·Codex에서는 스킬 포인터와 전체 본문 부재를, Copilot·Qoder에서는 전체 본문 고유 문구를 확인합니다.

## 구조와 흐름

다음 흐름도는 공유 훅에서 런타임별로 선택하는 컨텍스트를 보여 주며, 리뷰어는 토큰 축약 대상과 보존 대상을 구분해 확인할 수 있습니다.

```mermaid
flowchart LR
    Hook["SessionStart 또는 SubagentStart"] --> Runtime{"런타임"}
    Runtime -->|Claude 또는 Codex| Compact["활성 수준 + 정본 스킬 포인터"]
    Runtime -->|Copilot 또는 Qoder| Full["기존 전체 Ponytail 본문"]
```

## 검증

다음 표는 직접 훅 계약과 전체 저장소 기준선의 실패 집합을 확인한 결과입니다.

| 검사 | 명령 | 결과 |
|---|---|---|
| 훅 계약 | `node --test tests/hooks.test.js` | 종료 0, 1 pass |
| 전체 테스트 | `npm test` | 변경 전·후 모두 83 pass, 동일한 CSV correctness 1건만 fail |
| 런타임별 토큰 | 실제 훅 JSON의 `additionalContext`를 `o200k_base`로 측정 | Claude·Codex 21, Copilot·Qoder 1,264 |
| diff 형식 | `git diff --check 2ed6c52c...HEAD` | 종료 0 |

전체 `npm test`의 유일한 실패는 merge-base와 현재 head에서 모두 `csv: correct pandas one-liner passes`이며, 이 변경이 수정하는 훅 계약 테스트는 두 회차 모두 통과합니다.

## 변경 전·후 증거

merge-base와 현재 head의 실제 Codex 훅 JSON에서 `additionalContext`를 추출해 같은 `o200k_base` 토크나이저로 측정했습니다.

| 항목 | 변경 전 | 변경 후 |
|---|---|---|
| SessionStart | 1,264 tokens (`2ed6c52c`) | 21 tokens (`6cba29be`) |
| SubagentStart | 1,264 tokens (`2ed6c52c`) | 21 tokens (`6cba29be`) |
| Copilot SessionStart | 1,264 tokens (`2ed6c52c`) | 1,264 tokens (`6cba29be`) |
| Qoder subagent | 1,264 tokens (`2ed6c52c`) | 1,264 tokens (`6cba29be`) |

## 티켓 증거

- 티켓 비적용: 연결된 작업 티켓 없이 설치된 훅의 토큰 사용량을 측정해 만든 독립 개선입니다.

## 리뷰 지적과 행선지

다음 표는 제출 전 리뷰에서 확인한 지적과 반영 결과를 보여 주며, 리뷰어는 공유 런타임의 보존 경계가 최종 diff에 남았는지 확인할 수 있습니다.

| 리뷰 원문 또는 링크 | 차단 | 처리 | 근거 | 행선지 |
|---|---|---|---|---|
| 공유 훅 축약이 Copilot·Qoder의 전체 본문까지 제거함 | 예 | 반영 | 런타임 분기와 식별력 있는 회귀 검사를 추가함 | 이 Pull Request |
| 런타임 분기와 주석 설명이 어긋남 | 아니요 | 반영 | 주석을 compact/full 경계에 맞춤 | 이 Pull Request |

## 관련 항목

- 연결된 티켓이나 기존 Pull Request가 없습니다.
