### PR TITLE
docs: add ZCode install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,20 @@ Start a new session (or reload plugins). Skills show as `/ponytail`, `/ponytail-
 
 `AGENTS.md` still works instruction-only from a checkout without the plugin.
 
+### ZCode
+
+ZCode loads skills from `~/.zcode/skills/` (global) or `.zcode/skills/` (per project). Copy the six skills there and refresh:
+
+```bash
+git clone https://github.com/DietrichGebert/ponytail
+mkdir -p ~/.zcode/skills
+cp -r ponytail/skills/* ~/.zcode/skills/
+```
+
+Then in ZCode: **Settings → Skills → Refresh** — the six skills should show up enabled. Invoke them from chat with `$ponytail`, or from the `/` menu's Skills group. Instruction-tier: no `/ponytail` level hooks; to turn it off, disable the skills in Settings → Skills.
+
+Using several agents? `~/.agents/skills/` works too — ZCode reads it, so other tools can share the same copy. If the skills already sit on disk for another agent, ZCode's **Settings → Skills → Import** (Copy or Symlink) is an alternative to `cp`.
+
 That was it. He'd be proud. He won't say it.
 
 Active every session, with a handful of commands (see [Commands](#commands)). `/ponytail ultra` exists for when the codebase has wronged you personally. Startup and mode-change text shows the current mode.
@@ -296,6 +310,7 @@ Which files map to which agent: [Agent portability](docs/agent-portability.md).
 | Devin CLI | `devin plugins remove ponytail` |
 | Grok Build | `grok plugin uninstall ponytail` |
 | Pi agent | `pi uninstall ponytail` |
+| ZCode | Delete the `ponytail*` folders in `~/.zcode/skills/` |
 | Cursor / Windsurf / Cline / Qoder / etc. | Delete the copied rule file |
 
 These remove the plugin's own files. They leave behind a small amount of state ponytail writes outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` to clean those up too. **Run it before the host remove command above** — the script is itself a plugin file, so removing the plugin first deletes it (or run it from a separate clone of this repo). It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched.

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -30,6 +30,7 @@ to load in a given agent.
 | Kiro | `.kiro/steering/ponytail.md` | Steering rule; copy globally or into a project. |
 | Qoder | `.qoder/rules/ponytail.md`, `.qoder-plugin/plugin.json`, `hooks/qoder-hooks.json`, `skills/`, `AGENTS.md` | Qoder auto-loads `AGENTS.md` as always-on context; `.qoder/rules/ponytail.md` provides per-project rules; the plugin manifest points at `skills/` for the six ponytail skills (invoked as `/ponytail`, `/ponytail-review`, etc. via the Skill system). Full plugin-tier: `hooks/qoder-hooks.json` template registers `UserPromptSubmit` (mode activation + ruleset injection) and `PreToolUse` with `task|Task` matcher (subagent injection). Instruction-tier works from repo root with zero setup via `AGENTS.md`. |
 | Zed | `AGENTS.md` | Auto-includes `AGENTS.md` from the worktree root as one of its default rule files for the Agent Panel. Instruction-tier. |
+| ZCode | `skills/` | Copy into `~/.zcode/skills/` (global) or `.zcode/skills/` (project), then Settings → Skills → Refresh. Instruction-tier: skills invoke via `$ponytail`; no slash commands or hooks. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 
 ## Adapter Rule


### PR DESCRIPTION
## What

- `README.md`: new `### ZCode` section under `## Install` — manual copy of the six skills into `~/.zcode/skills/` (or `.zcode/skills/` per project), then Settings → Skills → Refresh; invocation via `$ponytail`. Also a row in the Uninstall table.
- `docs/agent-portability.md`: ZCode row in the Supported Adapters table.

## Why

ZCode (Z.ai's coding agent) discovers skills from `~/.zcode/skills/` (global) or `.zcode/skills/` (per project), and also reads the shared `~/.agents/skills/` directory — but had no documented install path. This is instruction-tier only: no new adapter files, per the thin-adapter rule.

Verified: all six `skills/*/SKILL.md` `description` fields are under ZCode's 1024-character drop limit (measured 200–825 chars), so the skills load as-is without any frontmatter change.
