### PR TITLE
fix(pi,opencode): make bare /ponytail report the current level

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -90,7 +90,12 @@ export default async ({ client } = {}) => {
       if (!input || input.command !== 'ponytail') return;
       // `off` is persisted like any mode; the transform reads it and stays silent.
       const args = String(input.arguments || '').trim();
-      const mode = args ? normalizePersistedMode(args) : getDefaultMode();
+      // README: no argument reports the current level — do not write a mode (#639).
+      if (!args) {
+        log('info', 'ponytail ' + readMode());
+        return;
+      }
+      const mode = normalizePersistedMode(args);
       if (!mode) return;
       writeMode(mode);
       log('info', 'ponytail ' + mode);

--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -37,11 +37,11 @@ export function resolveSessionMode(entries, fallbackMode = DEFAULT_MODE) {
 }
 
 export function parsePonytailCommand(text, defaultMode = DEFAULT_MODE) {
-  const fallback = normalizePersistedMode(defaultMode) || DEFAULT_MODE;
   const normalizedText = String(text || "").trim().toLowerCase();
 
+  // README + Claude Code: bare `/ponytail` reports the current level (#639).
   if (!normalizedText) {
-    return { type: "set-mode", mode: fallback === "off" ? "full" : fallback };
+    return { type: "status" };
   }
 
   const [primary, secondary] = normalizedText.split(/\s+/);

--- a/pi-extension/test/helpers.test.js
+++ b/pi-extension/test/helpers.test.js
@@ -13,8 +13,9 @@ import {
   writeDefaultMode,
 } from "../index.js";
 
-test("parsePonytailCommand falls back to full when invoked bare and default is off", () => {
-  assert.deepEqual(parsePonytailCommand("", "off"), { type: "set-mode", mode: "full" });
+test("parsePonytailCommand reports status when invoked bare (#639)", () => {
+  assert.deepEqual(parsePonytailCommand("", "off"), { type: "status" });
+  assert.deepEqual(parsePonytailCommand("   ", "full"), { type: "status" });
 });
 
 test("parsePonytailCommand parses modes, status, and default subcommand", () => {

--- a/tests/opencode-plugin.test.js
+++ b/tests/opencode-plugin.test.js
@@ -77,6 +77,17 @@ test('unsupported /ponytail arguments do not reset the current mode', async () =
   assert.equal(fs.readFileSync(statePath, 'utf8'), 'ultra');
 });
 
+test('bare /ponytail reports and does not write a mode (#639)', async () => {
+  const hooks = await loadPlugin({});
+  fs.writeFileSync(statePath, 'ultra');
+  await hooks['command.execute.before']({ command: 'ponytail', arguments: '', sessionID: 's' });
+  assert.equal(fs.readFileSync(statePath, 'utf8'), 'ultra');
+  await hooks['command.execute.before']({ command: 'ponytail', arguments: '   ', sessionID: 's' });
+  assert.equal(fs.readFileSync(statePath, 'utf8'), 'ultra');
+  const system = await transform(hooks);
+  assert.match(system[0], /PONYTAIL MODE ACTIVE — level: ultra/);
+});
+
 test('unrelated commands do not touch the flag', async () => {
   try { fs.unlinkSync(statePath); } catch (e) {}
   const hooks = await loadPlugin({});


### PR DESCRIPTION
## Problem

Fixes #639.

README (and Claude Code) say `/ponytail` with no argument reports the current level. On pi and OpenCode it wrote a mode instead: pi treated a bare invoke as `set-mode` (and forced `full` when the default was `off`), and OpenCode persisted `getDefaultMode()`, which can clobber the live session level.

## Triage / Root cause

- `pi-extension/index.js` `parsePonytailCommand("")` returned `{ type: "set-mode" }`.
- `.opencode/plugins/ponytail.mjs` `command.execute.before` used `args ? normalizePersistedMode(args) : getDefaultMode()` and always `writeMode`'d that.

Claude Code's mode tracker already reports on a bare command (`hooks/ponytail-mode-tracker.js`). pi already has a `status` path; it just was not used for empty args.

## Fix

- Empty / whitespace-only args → `{ type: "status" }` on pi (existing notify: current + default).
- OpenCode: log the current `readMode()` and return without writing the flag.

`/ponytail lite|full|ultra|off` is unchanged.

## Verification

```
node --test pi-extension/test/helpers.test.js tests/opencode-plugin.test.js
```

20/20 pass. The new helper assertion fails on pre-fix `parsePonytailCommand("")` (`set-mode` vs `status`).

`node --test tests/*.test.js`: 84 pass; the one failure (`csv: correct pandas one-liner passes` in `tests/correctness.test.js`) is present on current `main` without this diff.

Not tested in a live pi or OpenCode UI — the command handlers are covered by the unit tests above.

## Notes / Risks

- Earlier #654 attempted this and was closed by its author, not a maintainer reject. The bug is still on `main`.
- I did not change Hermes or other hosts; the report was pi + OpenCode, and those were the two call sites that wrote a mode on empty args.