### PR TITLE
fix: identify Node built-in imports

### DIFF
--- a/.opencode/plugins/ponytail.mjs
+++ b/.opencode/plugins/ponytail.mjs
@@ -9,11 +9,11 @@
 // OpenCode loads this as a server plugin — add it to your opencode.json:
 //   { "plugin": ["@dietrichgebert/ponytail"] }
 
-import { createRequire } from 'module';
-import fs from 'fs';
-import os from 'os';
-import path from 'path';
-import { fileURLToPath } from 'url';
+import { createRequire } from 'node:module';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 


### PR DESCRIPTION
## Summary

Use explicit `node:` specifiers for the five Node built-in imports in the OpenCode plugin entry.

## Why

`@pi-kaush/pi-welcome-screen` checks a package's `main` entry for undeclared imports. Ponytail's `main` points to `.opencode/plugins/ponytail.mjs`.

The checker excludes `node:` specifiers, but it treats the equivalent bare names as package imports. It therefore reports:

```
Warning: @dietrichgebert/ponytail: 5 undeclared imports
```

The five names are `module`, `fs`, `os`, `path`, and `url`. They are Node built-ins, not missing npm dependencies. This warning is a false positive.

The explicit `node:` form removes that ambiguity. It does not change Node runtime behavior.

## Test

- `node --test tests/opencode-plugin.test.js` — 8 passed
- `npm test` — OpenCode and other JavaScript tests passed; one unrelated pandas probe failed because pandas is not installed on the test host
