### PR TITLE
fix(pi): keep before_agent_start systemPrompt as array for OMP

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -203,9 +203,12 @@ export default function ponytailExtension(pi) {
 
   pi.on("before_agent_start", async (event) => {
     if (!currentMode || currentMode === "off") return;
-    // Guard a null/undefined event or a missing systemPrompt: don't crash, and
-    // don't prepend the literal string "undefined" to the prompt (#439, #440).
-    const base = event?.systemPrompt ? `${event.systemPrompt}\n\n` : "";
-    return { systemPrompt: `${base}${getPonytailInstructions(currentMode)}` };
+    const instr = getPonytailInstructions(currentMode);
+    const base = event?.systemPrompt;
+    if (Array.isArray(base)) {
+      return { systemPrompt: [...base, instr] };
+    }
+    const prefix = base ? `${base}\n\n` : "";
+    return { systemPrompt: `${prefix}${instr}` };
   });
 }


### PR DESCRIPTION
## Summary

event.systemPrompt is string[] in OMP (project prompt block with workstation, cwd and loaded CLAUDE.md/AGENTS.md contexts). The previous template literal \\\n\n\ coerced it via Array.prototype.toString() into a single comma-joined string, merging the block into part 0 and breaking /context token counts (0 tokens).

## Changes

- Return an array when the incoming prompt is an array ([...base, instr]), string when it is a string (\\\n\n\\`), preserving the multi-part structure.
- Keeps backward compatibility with Pi tests that use string systemPrompt.

## Testing

- 
pm --prefix pi-extension test — 23/23 passing (previously 6 failing on array split into chars)
- Verified OMP case: ['BASE1','BASE2'] → ['BASE1','BASE2','PONYTAIL MODE ACTIVE...'] instead of 'BASE1,BASE2\n\nPONYTAIL...'

## Related Issue

Fixes #776