### PR TITLE
feat: gate git writes on ponytail review

### DIFF
--- a/.agents/rules/ponytail.md
+++ b/.agents/rules/ponytail.md
@@ -22,6 +22,7 @@ Rules:
 - No new dependency if it can be avoided.
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
+- Before any `git commit` or `git push`, invoke `/ponytail-review` on the current diff. Do not commit or push until it has run for the exact changes; if the diff changes, run it again.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.

--- a/.clinerules/ponytail.md
+++ b/.clinerules/ponytail.md
@@ -22,6 +22,7 @@ Rules:
 - No new dependency if it can be avoided.
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
+- Before any `git commit` or `git push`, invoke `/ponytail-review` on the current diff. Do not commit or push until it has run for the exact changes; if the diff changes, run it again.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.

--- a/.cursor/rules/ponytail.mdc
+++ b/.cursor/rules/ponytail.mdc
@@ -28,6 +28,7 @@ Rules:
 - No new dependency if it can be avoided.
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
+- Before any `git commit` or `git push`, invoke `/ponytail-review` on the current diff. Do not commit or push until it has run for the exact changes; if the diff changes, run it again.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -22,6 +22,7 @@ Rules:
 - No new dependency if it can be avoided.
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
+- Before any `git commit` or `git push`, invoke `/ponytail-review` on the current diff. Do not commit or push until it has run for the exact changes; if the diff changes, run it again.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.

--- a/.kiro/steering/ponytail.md
+++ b/.kiro/steering/ponytail.md
@@ -27,6 +27,7 @@ Rules:
 - No new dependency if it can be avoided.
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
+- Before any `git commit` or `git push`, invoke `/ponytail-review` on the current diff. Do not commit or push until it has run for the exact changes; if the diff changes, run it again.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.

--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -46,6 +46,7 @@ every sibling caller still broken. Fix it once, where all callers route through.
 - No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
 - No boilerplate, no scaffolding "for later", later can scaffold for itself.
 - Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Before any `git commit` or `git push`, invoke `/ponytail-review` on the current diff. Do not commit or push until it has run for the exact changes; if the diff changes, run it again.
 - Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
 - Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
 - Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.

--- a/.qoder/rules/ponytail.md
+++ b/.qoder/rules/ponytail.md
@@ -22,6 +22,7 @@ Rules:
 - No new dependency if it can be avoided.
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
+- Before any `git commit` or `git push`, invoke `/ponytail-review` on the current diff. Do not commit or push until it has run for the exact changes; if the diff changes, run it again.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.

--- a/.windsurf/rules/ponytail.md
+++ b/.windsurf/rules/ponytail.md
@@ -22,6 +22,7 @@ Rules:
 - No new dependency if it can be avoided.
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
+- Before any `git commit` or `git push`, invoke `/ponytail-review` on the current diff. Do not commit or push until it has run for the exact changes; if the diff changes, run it again.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ Rules:
 - No new dependency if it can be avoided.
 - No boilerplate nobody asked for.
 - Deletion over addition. Boring over clever. Fewest files possible.
+- Before any `git commit` or `git push`, invoke `/ponytail-review` on the current diff. Do not commit or push until it has run for the exact changes; if the diff changes, run it again.
 - Shortest working diff wins, but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
 - Question complex requests: "Do you actually need X, or does Y cover it?"
 - Pick the edge-case-correct option when two stdlib approaches are the same size, lazy means less code, not the flimsier algorithm.

--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ The Claude Code and Codex plugins run two tiny Node.js lifecycle hooks, so `node
 ```
 (You have to send two separate prompts for the install to work) 
 
+The installed hooks block agent-issued `git commit` and `git push` commands until
+`/ponytail-review` has reviewed the exact current diff. Run the review again
+after changing the diff.
+
 Same steps in the Claude Code Desktop app's Code tab: type the two `/plugin` commands above into the prompt box, or click the **+** button next to it, choose **Plugins** → **Add plugin** to browse your configured marketplaces, and manage marketplaces from **Customize** in the sidebar.
 
 ### Codex

--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -36,6 +36,19 @@
           }
         ]
       }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-review-gate.js\"",
+            "timeout": 5,
+            "statusMessage": "Checking Ponytail review gate..."
+          }
+        ]
+      }
     ]
   }
 }

--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -5,6 +5,7 @@
 const { getDefaultMode, isDeactivationCommand, writeDefaultMode } = require('./ponytail-config');
 const { clearMode, isQoder, readMode, setMode, writeHookOutput } = require('./ponytail-runtime');
 const { getPonytailInstructions } = require('./ponytail-instructions');
+const { markReview } = require('./ponytail-review-state');
 
 let input = '';
 let done = false;
@@ -29,7 +30,10 @@ function finish() {
       let isReportOnly = false;
 
       if (cmd === '/ponytail-review' || cmd === '/ponytail:ponytail-review') {
-        mode = 'review';
+        // Review is a one-shot command, not a persistent intensity level. The
+        // marker gates the next commit/push for this exact diff and session.
+        markReview(data.cwd || process.cwd(), data.session_id);
+        return;
       } else if (cmd === '/ponytail' || cmd === '/ponytail:ponytail') {
         // `/ponytail default <mode>` persists the default to config (survives
         // restarts). Plain switches stay session-scoped ("sticks until session

--- a/hooks/ponytail-review-gate.js
+++ b/hooks/ponytail-review-gate.js
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Deny agent-issued commits and pushes until /ponytail-review saw this diff.
+
+const fs = require('fs');
+const { hasFreshReview } = require('./ponytail-review-state');
+
+function isGitWrite(command) {
+  // Split only at shell command boundaries. Quoted text stays one token, so
+  // `echo "git commit"` is not mistaken for a Git write.
+  return String(command || '').split(/[;&|()\n`]+/).some(part => {
+    const tokens = (part.trim().match(/"(?:\\.|[^"])*"|'(?:\\.|[^'])*'|\S+/g) || []).map(token => token.replace(/^['"]|['"]$/g, ''));
+    let i = 0;
+    while (i < tokens.length && (/^[A-Za-z_][A-Za-z0-9_]*=/.test(tokens[i]) || ['sudo', 'env', 'command', 'exec', 'nohup', 'time'].includes(tokens[i]))) i += 1;
+    if (tokens[i] === 'env') i += 1;
+    if (i >= tokens.length || !/(?:^|[\\/])git(?:\.exe)?$/i.test(tokens[i])) return false;
+    for (i += 1; i < tokens.length; i += 1) {
+      if (['-C', '-c', '--git-dir', '--work-tree', '--namespace'].includes(tokens[i])) { i += 1; continue; }
+      if (tokens[i].startsWith('-')) continue;
+      return /^(commit|push)$/i.test(tokens[i]);
+    }
+    return false;
+  });
+}
+
+let event;
+try {
+  event = JSON.parse(fs.readFileSync(0, 'utf8').replace(/^\uFEFF/, ''));
+} catch (_) {
+  process.exit(0);
+}
+
+const input = event && event.tool_input || {};
+const command = String(input.command || event.command || '');
+const toolName = String(event.tool_name || 'Bash');
+if (toolName !== 'Bash' || !isGitWrite(command)) process.exit(0);
+if (hasFreshReview(String(event.cwd || process.cwd()), event.session_id)) process.exit(0);
+
+process.stdout.write(JSON.stringify({ hookSpecificOutput: {
+  hookEventName: 'PreToolUse',
+  permissionDecision: 'deny',
+  permissionDecisionReason: 'Ponytail review gate: run /ponytail-review on the current diff before git commit or git push, then retry the command.',
+} }) + '\n');

--- a/hooks/ponytail-review-state.js
+++ b/hooks/ponytail-review-state.js
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+// Review markers are kept outside repositories so the gate works everywhere.
+
+const crypto = require('crypto');
+const fs = require('fs');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { getConfigDir } = require('./ponytail-config');
+
+const statePath = () => process.env.PONYTAIL_REVIEW_STATE_PATH || path.join(getConfigDir(), 'review-state.json');
+const git = (cwd, args) => {
+  const result = spawnSync('git', ['-C', cwd, ...args], { encoding: 'utf8', maxBuffer: 64 * 1024 * 1024 });
+  return result.error || result.status !== 0 ? null : result.stdout;
+};
+
+function snapshot(cwd) {
+  if (typeof cwd !== 'string' || !cwd.trim()) return null;
+  const root = (git(cwd, ['rev-parse', '--show-toplevel']) || '').trim();
+  const status = git(cwd, ['status', '--porcelain=v1', '-z', '--untracked-files=all']);
+  const diff = git(cwd, ['diff', 'HEAD', '--binary']) || git(cwd, ['diff', '--binary']);
+  if (!root || status === null || diff === null) return null;
+  let resolvedRoot;
+  try { resolvedRoot = fs.realpathSync.native(root); } catch (_) { resolvedRoot = path.resolve(root); }
+  return {
+    root: resolvedRoot,
+    fingerprint: crypto.createHash('sha256').update(status + '\0' + diff).digest('hex'),
+  };
+}
+
+function read() {
+  try {
+    const value = JSON.parse(fs.readFileSync(statePath(), 'utf8').replace(/^\uFEFF/, ''));
+    return value && Array.isArray(value.reviews) ? value : { version: 1, reviews: [] };
+  } catch (_) {
+    return { version: 1, reviews: [] };
+  }
+}
+
+function write(value) {
+  const target = statePath();
+  fs.mkdirSync(path.dirname(target), { recursive: true, mode: 0o700 });
+  const temporary = `${target}.${process.pid}.tmp`;
+  fs.writeFileSync(temporary, JSON.stringify(value, null, 2) + '\n', { mode: 0o600 });
+  fs.renameSync(temporary, target);
+}
+
+const session = value => typeof value === 'string' ? value.trim() : '';
+
+function markReview(cwd, sessionId) {
+  const current = snapshot(cwd);
+  if (!current) return false;
+  const id = session(sessionId);
+  const state = read();
+  state.version = 1;
+  state.reviews = [
+    { ...current, session_id: id, reviewed_at: new Date().toISOString() },
+    ...state.reviews.filter(item => !(item && item.root === current.root && session(item.session_id) === id)),
+  ].slice(0, 64);
+  write(state);
+  return true;
+}
+
+function hasFreshReview(cwd, sessionId) {
+  const current = snapshot(cwd);
+  if (!current) return false;
+  const id = session(sessionId);
+  return read().reviews.some(item => item && item.root === current.root && item.fingerprint === current.fingerprint && session(item.session_id) === id);
+}
+
+module.exports = { hasFreshReview, markReview, snapshot, statePath };

--- a/hooks/ponytail-review-state.js
+++ b/hooks/ponytail-review-state.js
@@ -16,12 +16,11 @@ const git = (cwd, args) => {
 function snapshot(cwd) {
   if (typeof cwd !== 'string' || !cwd.trim()) return null;
   const root = (git(cwd, ['rev-parse', '--show-toplevel']) || '').trim();
-  const status = git(cwd, ['status', '--porcelain=v1', '-z', '--untracked-files=all']);
   const diff = git(cwd, ['diff', 'HEAD', '--binary']) || git(cwd, ['diff', '--binary']);
-  if (!root || status === null || diff === null) return null;
+  if (!root || diff === null) return null;
   let resolvedRoot;
   try { resolvedRoot = fs.realpathSync.native(root); } catch (_) { resolvedRoot = path.resolve(root); }
-  const hash = crypto.createHash('sha256').update(status + '\0' + diff);
+  const hash = crypto.createHash('sha256').update(diff);
   const untracked = git(cwd, ['ls-files', '--others', '--exclude-standard', '-z']);
   if (untracked === null) return null;
   for (const name of untracked.split('\0').filter(Boolean)) {

--- a/hooks/ponytail-review-state.js
+++ b/hooks/ponytail-review-state.js
@@ -21,9 +21,18 @@ function snapshot(cwd) {
   if (!root || status === null || diff === null) return null;
   let resolvedRoot;
   try { resolvedRoot = fs.realpathSync.native(root); } catch (_) { resolvedRoot = path.resolve(root); }
+  const hash = crypto.createHash('sha256').update(status + '\0' + diff);
+  const untracked = git(cwd, ['ls-files', '--others', '--exclude-standard', '-z']);
+  if (untracked === null) return null;
+  for (const name of untracked.split('\0').filter(Boolean)) {
+    try {
+      hash.update('\0' + name + '\0');
+      hash.update(fs.readFileSync(path.join(resolvedRoot, name)));
+    } catch (_) { return null; }
+  }
   return {
     root: resolvedRoot,
-    fingerprint: crypto.createHash('sha256').update(status + '\0' + diff).digest('hex'),
+    fingerprint: hash.digest('hex'),
   };
 }
 

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -58,6 +58,7 @@ every sibling caller still broken. Fix it once, where all callers route through.
 - No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
 - No boilerplate, no scaffolding "for later", later can scaffold for itself.
 - Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
+- Before any `git commit` or `git push`, invoke `/ponytail-review` on the current diff. Do not commit or push until it has run for the exact changes; if the diff changes, run it again.
 - Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
 - Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
 - Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.

--- a/tests/review-gate.test.js
+++ b/tests/review-gate.test.js
@@ -42,6 +42,7 @@ test('commit and push require a review for the unchanged diff', () => {
   assert.equal(marked.status, 0, marked.stderr);
   assert.equal(marked.stdout, '', 'one-shot review should not replace the user prompt');
 
+  git(repo, 'add', 'file.txt');
   assert.equal(run(gate, env, event('git commit -am update')).stdout, '');
   assert.equal(run(gate, env, event('git -C "' + repo + '" push')).stdout, '');
   assert.equal(run(gate, env, event('git -C "/path with spaces" push')).stdout, '');

--- a/tests/review-gate.test.js
+++ b/tests/review-gate.test.js
@@ -1,0 +1,67 @@
+#!/usr/bin/env node
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = path.join(__dirname, '..');
+const gate = path.join(root, 'hooks', 'ponytail-review-gate.js');
+const tracker = path.join(root, 'hooks', 'ponytail-mode-tracker.js');
+
+function run(script, env, input) {
+  return spawnSync(process.execPath, [script], { env: { ...process.env, ...env }, input, encoding: 'utf8' });
+}
+
+function git(cwd, ...args) {
+  const result = spawnSync('git', ['-C', cwd, ...args], { encoding: 'utf8' });
+  assert.equal(result.status, 0, result.stderr);
+}
+
+test('commit and push require a review for the unchanged diff', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-review-gate-'));
+  const repo = path.join(temp, 'repo');
+  const state = path.join(temp, 'state.json');
+  fs.mkdirSync(repo);
+  git(repo, 'init', '-q');
+  git(repo, 'config', 'user.name', 'test');
+  git(repo, 'config', 'user.email', 'test@example.com');
+  fs.writeFileSync(path.join(repo, 'file.txt'), 'before\n');
+  git(repo, 'add', 'file.txt');
+  git(repo, 'commit', '-qm', 'init');
+  fs.writeFileSync(path.join(repo, 'file.txt'), 'after\n');
+
+  const env = { HOME: temp, USERPROFILE: temp, PONYTAIL_REVIEW_STATE_PATH: state };
+  const event = cwd => JSON.stringify({ tool_name: 'Bash', tool_input: { command: cwd }, cwd: repo, session_id: 'session-1' });
+  const denied = run(gate, env, event('git commit -am update'));
+  assert.equal(JSON.parse(denied.stdout).hookSpecificOutput.permissionDecision, 'deny');
+
+  const marked = run(tracker, env, JSON.stringify({ prompt: '/ponytail-review', cwd: repo, session_id: 'session-1' }));
+  assert.equal(marked.status, 0, marked.stderr);
+  assert.equal(marked.stdout, '', 'one-shot review should not replace the user prompt');
+
+  assert.equal(run(gate, env, event('git commit -am update')).stdout, '');
+  assert.equal(run(gate, env, event('git -C "' + repo + '" push')).stdout, '');
+  assert.equal(run(gate, env, event('git -C "/path with spaces" push')).stdout, '');
+
+  fs.writeFileSync(path.join(repo, 'file.txt'), 'changed again\n');
+  const stale = run(gate, env, event('git commit -am update'));
+  assert.equal(JSON.parse(stale.stdout).hookSpecificOutput.permissionDecision, 'deny');
+});
+
+test('the gate ignores reads, status, quoted examples, and non-Bash tools', () => {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-review-gate-'));
+  const env = { HOME: temp, USERPROFILE: temp, PONYTAIL_REVIEW_STATE_PATH: path.join(temp, 'state.json') };
+  for (const command of ['git status', 'git log -1', 'echo "git commit -m demo"', 'printf "git push"']) {
+    assert.equal(run(gate, env, JSON.stringify({ tool_name: 'Bash', tool_input: { command } })).stdout, '');
+  }
+  assert.equal(run(gate, env, JSON.stringify({ tool_name: 'Read', tool_input: { command: 'git commit' } })).stdout, '');
+});
+
+test('the plugin manifest includes the review gate before Bash tools', () => {
+  const config = JSON.parse(fs.readFileSync(path.join(root, 'hooks', 'claude-codex-hooks.json'), 'utf8'));
+  const preToolUse = config.hooks.PreToolUse;
+  assert.ok(preToolUse.some(group => group.matcher === 'Bash' && group.hooks.some(hook => hook.command.includes('ponytail-review-gate.js'))));
+});


### PR DESCRIPTION
Adds a review rule and a synchronous Claude/Codex PreToolUse gate for agent-issued git commits and pushes.

- records /ponytail-review against the current repo snapshot and session
- denies commit/push until the marker matches; any diff change requires another review
- keeps /ponytail-review one-shot instead of persisting review mode
- includes tests and synchronized rule copies

Validation: npm test