### PR TITLE
feat: one-line installer that detects every agent it can install

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,4 @@
+# Shells are parsed by line ending, so a Windows clone must not turn install.sh
+# into CRLF: bash then fails on `set -euo pipefail` and runs unguarded.
+*.sh text eol=lf
+*.ps1 text eol=crlf

--- a/README.es.md
+++ b/README.es.md
@@ -111,6 +111,32 @@ El mayor esfuerzo que ponytail te va a pedir:
 
 Los plugins de Claude Code y Codex ejecutan dos pequeños lifecycle hooks de Node.js, así que `node` debe estar en tu PATH (nota para usuarios de Nix/nvm: debe estar en el PATH del shell no-interactivo). Si no lo está, los skills igualmente funcionan, la activación automática simplemente queda en silencio en vez de lanzar un error en cada prompt.
 
+### Una línea, todos los agentes que tengas
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | bash
+```
+
+Detecta los agentes de esta máquina que se pueden instalar a nivel de máquina e instala ponytail en cada uno, ejecutando los mismos comandos por host que se documentan abajo. Los hosts que se configuran por proyecto quedan manuales; están más abajo. Necesita Node.js 18+. Se puede volver a ejecutar sin riesgo: una segunda pasada simplemente vuelve a lanzar el comando de instalación propio de cada host, y en un archivo compartido con vos se reescribe únicamente el bloque entre los marcadores de ponytail, así que lo que hayas escrito alrededor se queda. Un archivo propio de ponytail, como la regla de steering de Kiro, se reemplaza entero.
+
+Míralo primero, sin cambiar nada:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | bash -s -- --dry-run
+```
+
+Como cualquier `curl | bash`, esto ejecuta un script descargado de este repositorio. Ejecuta el comando de instalación propio de cada host, flags de confianza incluidas (`--trust`, `--enable`), porque son los comandos de abajo — `--dry-run` imprime la lista exacta antes. Desde un clon, `bash install.sh` corre la copia local. Para fijar una release, definí la variable en el shell que ejecuta el script, no en `curl`: `curl -fsSL <url> | PONYTAIL_REF=<tag> bash`.
+
+En Windows, con PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.ps1 | iex
+```
+
+`iex` no puede pasar flags, así que para usarlas ejecutalo como script block: `& ([scriptblock]::Create((irm https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.ps1))) --dry-run`. Desde un clon, Windows PowerShell bloquea scripts por defecto, así que usá `powershell -ExecutionPolicy Bypass -File .\install.ps1`.
+
+O instala host por host:
+
 ### Claude Code
 
 ```
@@ -119,6 +145,13 @@ Los plugins de Claude Code y Codex ejecutan dos pequeños lifecycle hooks de Nod
 ```
 
 La app de escritorio no tiene el comando `/plugin`. Instálala desde la interfaz: Customize, el + junto a los plugins personales, Create plugin and add marketplace, Add from repository, y luego ingresa la URL del repo (gracias @NiklasDHahn, #98).
+
+Desde una terminal en vez de una sesión, que es lo que ejecuta el instalador de arriba:
+
+```bash
+claude plugin marketplace add DietrichGebert/ponytail
+claude plugin install ponytail@ponytail
+```
 
 ### Codex
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -111,6 +111,32 @@ ponytail이 당신에게 요구할 수고의 최대치:
 
 Claude Code와 Codex 플러그인은 자그마한 Node.js 라이프사이클 훅 두 개를 돌리니, `node`가 PATH에 잡혀 있어야 한다(Nix/nvm 사용자라면 비대화형 셸의 PATH에 있어야 한다). 없어도 스킬은 멀쩡히 돌아간다. 다만 늘 켜져 있던 자동 활성화가 매 프롬프트마다 에러를 뱉는 대신 조용히 비활성으로 남을 뿐이다.
 
+### 한 줄로, 가진 에이전트 전부
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | bash
+```
+
+이 머신에서 머신 단위로 설치할 수 있는 에이전트를 찾아내서, 아래에 호스트별로 적어둔 그 명령들을 그대로 돌려 각각에 ponytail을 설치한다. 프로젝트 단위로 설정하는 호스트는 수동으로 남으며, 아래에 따로 적어두었다. Node.js 18+ 필요. 다시 돌려도 안전하다: 두 번째 실행은 각 호스트의 설치 명령을 그대로 다시 실행할 뿐이고, 사용자와 공유하는 파일에서는 ponytail 자체 마커 사이의 블록만 다시 쓰므로 그 주위에 직접 써둔 내용은 그대로 남는다. Kiro의 steering 규칙처럼 ponytail 소유인 파일은 통째로 교체된다.
+
+아무것도 건드리지 않고 먼저 확인:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | bash -s -- --dry-run
+```
+
+여느 `curl | bash`와 마찬가지로 이 저장소에서 받아온 스크립트를 실행한다. 각 호스트의 설치 명령을 신뢰 플래그(`--trust`, `--enable`)까지 그대로 실행한다. 아래에 적힌 그 명령들이기 때문이고, `--dry-run`이 실행 전에 정확한 목록을 출력한다. 클론에서는 `bash install.sh`가 로컬 사본을 돌린다. 릴리스를 고정하려면 `curl`이 아니라 스크립트를 실행하는 셸에 변수를 지정한다: `curl -fsSL <url> | PONYTAIL_REF=<tag> bash`.
+
+Windows에서는 PowerShell로:
+
+```powershell
+irm https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.ps1 | iex
+```
+
+`iex`는 플래그를 넘기지 못하니, 플래그가 필요하면 script block으로 실행한다: `& ([scriptblock]::Create((irm https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.ps1))) --dry-run`. 클론에서는 Windows PowerShell이 기본적으로 스크립트를 막으므로 `powershell -ExecutionPolicy Bypass -File .\install.ps1`으로 실행한다.
+
+또는 호스트별로 하나씩 설치:
+
 ### Claude Code
 
 ```
@@ -122,6 +148,13 @@ Claude Code와 Codex 플러그인은 자그마한 Node.js 라이프사이클 훅
 (설치가 되려면 두 프롬프트를 따로 보내야 한다)
 
 데스크톱 앱에는 `/plugin` 명령이 없다. 대신 UI에서 설치한다: Customize, 개인 플러그인 옆의 +, Create plugin and add marketplace, Add from repository, 그다음 저장소 URL 입력(감사합니다 @NiklasDHahn, #98).
+
+세션이 아니라 터미널에서, 그리고 위의 설치 스크립트가 실제로 돌리는 것:
+
+```bash
+claude plugin marketplace add DietrichGebert/ponytail
+claude plugin install ponytail@ponytail
+```
 
 ### Codex
 

--- a/README.md
+++ b/README.md
@@ -111,6 +111,32 @@ The most effort ponytail will ever ask of you:
 
 The Claude Code and Codex plugins run two tiny Node.js lifecycle hooks, so `node` needs to be on your PATH (note for Nix/nvm users: it must be on the non-interactive shell's PATH). If it isn't, the skills still work, the always-on activation just stays quiet instead of erroring on every prompt.
 
+### One line, every agent you have
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | bash
+```
+
+Detects the agents on this machine that can be installed machine-wide and installs ponytail into each, running the same per-host commands documented below. Hosts configured per project rather than machine-wide stay manual; they are covered further down. Needs Node.js 18+. Safe to rerun: a second run just re-issues each host's own install command, and in a file you share with it only the block between ponytail's own markers is rewritten, so anything you wrote around it stays. A file that is ponytail's own, like Kiro's steering rule, is replaced wholesale.
+
+See it first, change nothing:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | bash -s -- --dry-run
+```
+
+Like any `curl | bash`, this executes a script fetched from this repository. It runs each host's own install command, trust flags included (`--trust`, `--enable`), because those are the commands below — `--dry-run` prints the exact list first. From a clone, `bash install.sh` runs the local copy. To pin a release, set the variable for the shell that runs the script, not for `curl`: `curl -fsSL <url> | PONYTAIL_REF=<tag> bash`.
+
+On Windows, PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.ps1 | iex
+```
+
+`iex` cannot forward flags, so to pass any, run it as a script block: `& ([scriptblock]::Create((irm https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.ps1))) --dry-run`. From a clone, Windows PowerShell blocks scripts by default, so run `powershell -ExecutionPolicy Bypass -File .\install.ps1`.
+
+Or install one host at a time:
+
 ### Claude Code
 
 ```
@@ -120,6 +146,13 @@ The Claude Code and Codex plugins run two tiny Node.js lifecycle hooks, so `node
 /plugin install ponytail@ponytail
 ```
 (You have to send two separate prompts for the install to work) 
+
+From a terminal instead of a session, and what the installer above runs:
+
+```bash
+claude plugin marketplace add DietrichGebert/ponytail
+claude plugin install ponytail@ponytail
+```
 
 Same steps in the Claude Code Desktop app's Code tab: type the two `/plugin` commands above into the prompt box, or click the **+** button next to it, choose **Plugins** → **Add plugin** to browse your configured marketplaces, and manage marketplaces from **Customize** in the sidebar.
 
@@ -298,7 +331,7 @@ Which files map to which agent: [Agent portability](docs/agent-portability.md).
 | Pi agent | `pi uninstall ponytail` |
 | Cursor / Windsurf / Cline / Qoder / etc. | Delete the copied rule file |
 
-These remove the plugin's own files. They leave behind a small amount of state ponytail writes outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` to clean those up too. **Run it before the host remove command above** — the script is itself a plugin file, so removing the plugin first deletes it (or run it from a separate clone of this repo). It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched.
+These remove the plugin's own files. They leave behind a small amount of state ponytail writes outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, any ruleset the one-line installer wrote into a global instruction file, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` to clean those up too. **Run it before the host remove command above** — the script is itself a plugin file, so removing the plugin first deletes it (or run it from a separate clone of this repo). It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched.
 
 ## Commands
 
@@ -323,6 +356,8 @@ npm test
 ```
 
 The OpenClaw skill package (`.openclaw/skills/`) is generated from `skills/`; rerun `node scripts/build-openclaw-skills.js` after changing a skill, the test suite fails if it is stale. To publish the skills to ClawHub, run `clawhub login` once, then `node scripts/publish-openclaw-skills.js` (it publishes all six at the `package.json` version; pass `--dry-run` to preview).
+
+`scripts/install.js` mirrors the per-host install commands from the Install section above; when a host's command changes, update both. `node scripts/install.js --dry-run` prints the plan without touching anything.
 
 The correctness benchmark spawns Python for email and CSV checks; `python3` is tried before `python`. CSV checks need `pandas` installed locally.
 

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -32,6 +32,26 @@ to load in a given agent.
 | Zed | `AGENTS.md` | Auto-includes `AGENTS.md` from the worktree root as one of its default rule files for the Agent Panel. Instruction-tier. |
 | Generic agents | `AGENTS.md` or `skills/*/SKILL.md` | Copy the compact rule file or load the skill files directly. |
 
+## Installer
+
+`scripts/install.js` (via `install.sh`, or `install.ps1` on Windows) installs ponytail into every adapter it
+finds on the machine. Its host table is a copy of the per-host commands in the
+README; `tests/install.test.js` asserts each command appears verbatim in that
+host's README section, so the two cannot drift apart unnoticed. Rows
+are one of two kinds, matching the tiers above: plugin-tier hosts are detected
+by their CLI on PATH and installed with that host's own command;
+instruction-tier hosts are detected by the config directory they already have
+and get the ruleset written between `<!-- ponytail:begin -->` and
+`<!-- ponytail:end -->`, so rerunning never disturbs what the user wrote around
+it. A file that is ponytail's own, like Kiro's steering rule, is replaced
+wholesale instead, because its frontmatter has to stay on line 1. A host with neither a CLI nor a documented global path stays manual.
+
+Both shims fetch a source archive rather than the npm package, so the installer
+is deliberately absent from `package.json`'s `files`. The ruleset it writes
+comes from `.agents/rules/ponytail.md`, not `AGENTS.md`, whose closing note is
+addressed to agents working on this repo. `scripts/uninstall.js` removes the
+blocks it wrote.
+
 ## Adapter Rule
 
 Keep adapters thin. When a host supports skills or hooks, point it at the

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,133 @@
+# ponytail -- installer shim for Windows.
+#
+# Thin wrapper around scripts/install.js, the real installer. It is the
+# PowerShell twin of install.sh: both only locate Node and hand off, so there is
+# no install logic here to drift out of sync with the bash one.
+#
+# One-line install:
+#   irm https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.ps1 | iex
+#
+# With flags, `iex` cannot forward arguments, so run it as a script block:
+#   & ([scriptblock]::Create((irm https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.ps1))) --dry-run
+#
+# Local clone (Windows PowerShell blocks scripts by default):
+#   powershell -ExecutionPolicy Bypass -File .\install.ps1 [flags]
+#
+# Pin a release with $env:PONYTAIL_REF = '<tag>'.
+
+# Everything lives in a function so the piped form can set a code instead of
+# calling exit: under `irm | iex` an exit terminates the caller's whole
+# PowerShell session, closing an interactive window before the summary is read.
+#
+# The code travels in $script:PonytailExit, never through `return`: a returned
+# value shares the function's output stream with node's stdout, so assigning the
+# call to a variable would swallow every line the installer printed.
+function Invoke-PonytailInstall {
+  param([string[]] $InstallerArgs)
+
+  $script:PonytailExit = 1
+
+  # Set inside the function, not at top level: under `irm | iex` a top-level
+  # assignment overwrites these in the caller's own session and stays there.
+  $ErrorActionPreference = 'Stop'
+  # Windows PowerShell 5.1 renders a per-chunk progress bar that slows a
+  # download by an order of magnitude and can leave a stuck bar behind.
+  $ProgressPreference = 'SilentlyContinue'
+
+  $repo = 'DietrichGebert/ponytail'
+  $ref = if ($env:PONYTAIL_REF) { $env:PONYTAIL_REF } else { 'main' }
+
+  # ref lands in a URL path, where .NET's Uri normalization collapses dot
+  # segments -- a ref inherited from the environment could redirect the download.
+  if ($ref -notmatch '^[A-Za-z0-9][A-Za-z0-9._/-]*$' -or $ref -like '*..*') {
+    Write-Host "ponytail: refusing PONYTAIL_REF='$ref' -- expected a branch or tag name."
+    return
+  }
+
+  if (-not (Get-Command node -ErrorAction SilentlyContinue)) {
+    Write-Host 'ponytail: Node.js (>=18) required. Install from https://nodejs.org or `winget install OpenJS.NodeJS`.'
+    return
+  }
+
+  # Double quotes outside, single quotes inside -- the same nesting install.sh
+  # uses. Windows PowerShell 5.1 does not escape embedded double quotes in a
+  # native argument without spaces, so inverting this makes node print nothing
+  # and a modern Node read as version 0. Do not "fix" it to match the other
+  # order; that is the bug this line exists to avoid.
+  $nodeMajor = 0
+  [void][int]::TryParse((node -p "process.versions.node.split('.')[0]"), [ref] $nodeMajor)
+  if ($nodeMajor -lt 18) {
+    Write-Host "ponytail: need Node >=18 (got '$nodeMajor'). Upgrade: https://nodejs.org"
+    return
+  }
+
+  # Inside a clone: run the local installer -- no download, works offline.
+  # $PSScriptRoot is empty under `irm | iex`, the same way BASH_SOURCE is unset
+  # under `curl | bash`, so only trust it when it is set. AGENTS.md has to be
+  # there too, so a stray scripts/install.js elsewhere is not mistaken for a
+  # ponytail checkout. -LiteralPath because [ ] in a path are wildcards.
+  if ($PSScriptRoot) {
+    $entry = Join-Path $PSScriptRoot 'scripts/install.js'
+    if ((Test-Path -LiteralPath $entry) -and (Test-Path -LiteralPath (Join-Path $PSScriptRoot 'AGENTS.md'))) {
+      & node $entry @InstallerArgs
+      $script:PonytailExit = $LASTEXITCODE
+      return
+    }
+  }
+
+  # Unpack the repo into a temp dir and run the installer from there. The
+  # installer reads .agents/rules/ponytail.md and .kiro/steering/ponytail.md at
+  # runtime, and a source archive has the whole repo.
+  $tmp = Join-Path ([IO.Path]::GetTempPath()) ("ponytail-" + [Guid]::NewGuid().ToString('N'))
+  try {
+    New-Item -ItemType Directory -Path $tmp -Force | Out-Null
+    $zip = Join-Path $tmp 'ponytail.zip'
+    # TLS 1.2 for Windows PowerShell 5.1, whose older builds still default to
+    # TLS 1.0 and get refused by GitHub. Harmless on PowerShell 7. This one is
+    # process-wide static state, not a preference variable, so it is restored
+    # below -- under `irm | iex` it would otherwise outlive the install and
+    # change the caller's session.
+    $priorTls = [Net.ServicePointManager]::SecurityProtocol
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+    try {
+      Invoke-WebRequest -Uri "https://codeload.github.com/$repo/zip/$ref" -OutFile $zip -UseBasicParsing
+    } catch {
+      # A wrong ref is the common case here, and a raw error record buries that.
+      Write-Host "ponytail: could not download $repo at '$ref' -- check the ref name. ($($_.Exception.Message))"
+      return
+    }
+    Expand-Archive -LiteralPath $zip -DestinationPath $tmp -Force
+    $extracted = Get-ChildItem -LiteralPath $tmp -Directory | Select-Object -First 1
+    if (-not $extracted) {
+      Write-Host "ponytail: the archive for '$ref' unpacked empty."
+      return
+    }
+    $entry = Join-Path $extracted.FullName 'scripts/install.js'
+    # A ref older than the installer downloads fine and then has no entry point;
+    # without this the user gets Node's MODULE_NOT_FOUND stack instead.
+    if (-not (Test-Path -LiteralPath $entry)) {
+      Write-Host "ponytail: '$ref' has no scripts/install.js -- that ref predates the installer. Use a newer one."
+      return
+    }
+    & node $entry @InstallerArgs
+    $script:PonytailExit = $LASTEXITCODE
+    return
+  } finally {
+    if ($null -ne $priorTls) { [Net.ServicePointManager]::SecurityProtocol = $priorTls }
+    Remove-Item -LiteralPath $tmp -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+# Not assigned to a variable: the installer's own stdout flows through here to
+# the console, which is the point.
+Invoke-PonytailInstall -InstallerArgs $args
+# Only a real script invocation may exit. Under `irm | iex` an exit terminates
+# whatever is running the pipe -- an interactive session, or a calling script,
+# both measured on Windows PowerShell 5.1 and 7.6.5.
+#
+# $PSCommandPath is the right test because it is empty under `iex` even when
+# the `iex` sits inside another .ps1 (measured; $MyInvocation.MyCommand.Path is
+# NOT, it reports the calling script there). Running as a file is also the case
+# that needs the exit at all: -File does not propagate $LASTEXITCODE on its own,
+# so without this the flag-error exit code would be lost.
+if ($PSCommandPath) { exit $script:PonytailExit } else { $global:LASTEXITCODE = $script:PonytailExit }

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+# ponytail -- installer shim.
+#
+# Thin wrapper around scripts/install.js, the real installer. Every flag it takes
+# can be passed here; this script just forwards them.
+#
+# One-line install:
+#   curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | bash -s -- --dry-run
+#
+# Local clone:
+#   bash install.sh [flags]
+#
+# install.ps1 is the Windows twin. Both only locate Node and hand off; all the
+# install logic lives in scripts/install.js, so the pair has nothing to drift
+# out of sync. Pin a release by setting PONYTAIL_REF for the shell that runs
+# this script: curl -fsSL <url> | PONYTAIL_REF=<tag> bash
+
+set -euo pipefail
+
+# Everything runs inside main so a truncated `curl | bash` stream cannot execute
+# a half-read prefix of this file: the last line is what starts the work.
+main() {
+  local repo="DietrichGebert/ponytail"
+  local ref="${PONYTAIL_REF:-main}"
+
+  # ref lands in a URL path. curl applies RFC 3986 dot-segment removal, so a ref
+  # inherited from a profile or CI job could redirect the download elsewhere.
+  if [[ ! "$ref" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ || "$ref" == *".."* ]]; then
+    echo "ponytail: refusing PONYTAIL_REF='$ref' -- expected a branch or tag name." >&2
+    exit 1
+  fi
+
+  if ! command -v node >/dev/null 2>&1; then
+    echo "ponytail: Node.js (>=18) required. Install:" >&2
+    echo "  macOS:  brew install node" >&2
+    echo "  Linux:  https://nodejs.org or nvm (https://github.com/nvm-sh/nvm)" >&2
+    exit 1
+  fi
+
+  # Take the last line and require it to be digits only. Keeping every digit in
+  # the output instead would concatenate them, so a wrapper printing its own
+  # banner ("wrapper 2.0") ahead of Node 16 would read as 2016 and pass a check
+  # meant to reject it. Anything unparseable falls through to the message below.
+  local node_major
+  node_major="$(node -p "process.versions.node.split('.')[0]" 2>/dev/null | tail -n 1)"
+  case "$node_major" in
+    '' | *[!0-9]*) node_major='' ;;
+  esac
+  if [ -z "$node_major" ] || [ "$node_major" -lt 18 ]; then
+    echo "ponytail: need Node >=18 (got '${node_major:-unknown}'). Upgrade: https://nodejs.org" >&2
+    exit 1
+  fi
+
+  # Inside a clone: run the local installer -- no download, works offline.
+  # BASH_SOURCE is unset under `curl | bash`; dirname "" resolves to "." and
+  # would run an unrelated $PWD/scripts/install.js, so only use it when set.
+  # AGENTS.md has to be there too, so a stray scripts/install.js in some other
+  # project is not mistaken for a ponytail checkout.
+  local here="" source_path="${BASH_SOURCE[0]:-}"
+  if [ -n "$source_path" ]; then
+    here="$(cd "$(dirname "$source_path")" 2>/dev/null && pwd)" || here=""
+  fi
+  if [ -n "$here" ] && [ -f "$here/scripts/install.js" ] && [ -f "$here/AGENTS.md" ]; then
+    exec node "$here/scripts/install.js" "$@"
+  fi
+
+  for tool in curl tar; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      echo "ponytail: $tool required for the download." >&2
+      exit 1
+    fi
+  done
+
+  # Unpack the repo into a temp dir and run the installer from there. The
+  # installer reads .agents/rules/ponytail.md and .kiro/steering/ponytail.md at
+  # runtime, and a source tarball has the whole repo, so nothing has to be
+  # mirrored into package.json to keep this path working.
+  local tmp
+  tmp="$(mktemp -d)"
+  # No exec here: exec would replace this shell and the EXIT trap would never
+  # fire, leaking the temp dir. set -e propagates the installer's exit code.
+  trap 'rm -rf "$tmp"' EXIT
+  curl -fsSL "https://codeload.github.com/$repo/tar.gz/$ref" | tar -xzf - -C "$tmp" --strip-components=1
+  # A ref older than the installer downloads fine and then has no entry point;
+  # without this the user gets Node's MODULE_NOT_FOUND stack instead.
+  if [ ! -f "$tmp/scripts/install.js" ]; then
+    echo "ponytail: '$ref' has no scripts/install.js -- that ref predates the installer. Use a newer one." >&2
+    exit 1
+  fi
+  node "$tmp/scripts/install.js" "$@"
+}
+
+main "$@"

--- a/scripts/install.js
+++ b/scripts/install.js
@@ -1,0 +1,357 @@
+#!/usr/bin/env node
+// ponytail — one-shot installer.
+//
+// Finds the agents you actually have on this machine and installs ponytail into
+// each of them, running the same commands the README documents. Safe to rerun:
+// a second run just re-issues each host's own install command, and the
+// instruction-file installs rewrite only the block between ponytail's markers.
+//
+//   node scripts/install.js              install into every detected host
+//   node scripts/install.js --dry-run    print what it would do, change nothing
+
+const { spawnSync } = require('child_process');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const REPO = 'DietrichGebert/ponytail';
+const REPO_URL = `https://github.com/${REPO}`;
+const ROOT = path.join(__dirname, '..');
+const HOME = os.homedir();
+const BEGIN = '<!-- ponytail:begin -->';
+const END = '<!-- ponytail:end -->';
+const STEP_TIMEOUT_MS = 120000;
+
+// The ruleset written into instruction files. Not AGENTS.md: that ends with a
+// note addressed to agents working on this repo, which scripts/check-rule-copies.js
+// strips for exactly that reason. .agents/rules/ponytail.md is the host-agnostic
+// copy CI already keeps in sync with it.
+const RULES_FILE = '.agents/rules/ponytail.md';
+
+// Every host ponytail supports that can be installed without a human in the
+// loop. `cli` hosts are detected by their binary on PATH and installed with the
+// commands from the README; `dir` hosts have no installer CLI, so they get the
+// always-on ruleset written into the global instruction file they already read.
+// One row per host — adding an ecosystem is a row, not a branch.
+//
+// Every command in `steps` must succeed for the host to count as installed. A
+// `precondition` runs first and is allowed to fail, for the one host measured
+// to report an already-registered marketplace as an error; anywhere else a
+// failing command is a failing install, which is what the summary promises.
+const HOSTS = [
+  {
+    id: 'claude', name: 'Claude Code', cli: 'claude',
+    steps: [
+      ['plugin', 'marketplace', 'add', REPO],
+      ['plugin', 'install', 'ponytail@ponytail'],
+    ],
+  },
+  {
+    id: 'codex', name: 'Codex', cli: 'codex',
+    steps: [
+      ['plugin', 'marketplace', 'add', REPO],
+      ['plugin', 'add', 'ponytail@ponytail'],
+    ],
+    note: 'run `codex`, open /hooks, trust the two lifecycle hooks, then start a new thread',
+  },
+  {
+    id: 'copilot', name: 'GitHub Copilot CLI', cli: 'copilot',
+    // Measured: this exits 1 with "Marketplace already registered" on a second
+    // run, while the same command on claude and codex exits 0. It is the only
+    // host that needs its marketplace step treated as a precondition.
+    precondition: ['plugin', 'marketplace', 'add', REPO],
+    steps: [['plugin', 'install', 'ponytail@ponytail']],
+  },
+  {
+    id: 'gemini', name: 'Gemini CLI', cli: 'gemini',
+    steps: [['extensions', 'install', REPO_URL]],
+  },
+  {
+    id: 'antigravity', name: 'Antigravity CLI', cli: 'agy',
+    steps: [['plugin', 'install', REPO_URL]],
+  },
+  {
+    id: 'grok', name: 'Grok Build', cli: 'grok',
+    steps: [['plugin', 'install', REPO, '--trust']],
+    note: 'plugins are off by default; enable ponytail via /plugins or ~/.grok/config.toml',
+  },
+  {
+    id: 'pi', name: 'Pi agent harness', cli: 'pi',
+    steps: [['install', `git:github.com/${REPO}`]],
+  },
+  {
+    id: 'hermes', name: 'Hermes Agent', cli: 'hermes',
+    steps: [['plugins', 'install', REPO, '--enable']],
+    note: 'restart Hermes to pick up the plugin',
+  },
+  {
+    id: 'devin', name: 'Devin CLI', cli: 'devin',
+    steps: [['plugins', 'install', REPO]],
+  },
+  {
+    id: 'openclaw', name: 'OpenClaw', cli: 'clawhub',
+    steps: [['install', 'ponytail']],
+  },
+  {
+    id: 'swival', name: 'Swival', cli: 'swival',
+    steps: [
+      ['skills', 'add', '--global', REPO_URL],
+      ['skills', 'add', '--global', 'ponytail'],
+    ],
+  },
+  // Instruction-tier hosts: no installer CLI, but they auto-load a known global
+  // file. Detected by the config directory they create on first run — never
+  // created here, so an agent you don't have stays uninstalled.
+  {
+    id: 'amp', name: 'Amp (Sourcegraph)', dir: '.config/amp',
+    file: '.config/amp/AGENTS.md', merge: true,
+  },
+  {
+    id: 'kiro', name: 'Kiro', dir: '.kiro',
+    // copy, not merge: the Kiro steering file needs its YAML frontmatter on
+    // line 1, and a marker comment above that breaks Kiro's parser.
+    //
+    // `owner` is what makes replacing it safe. ~/.kiro/steering is the user's
+    // own directory of hand-written rules, not a plugin folder, so the file
+    // name alone does not make the file ours -- someone can have written their
+    // own ponytail.md. An existing file is only replaced when it carries this
+    // title, which every version of our copy has; uninstall uses the same
+    // string, so install and removal agree on what ownership means.
+    file: '.kiro/steering/ponytail.md', copy: '.kiro/steering/ponytail.md',
+    owner: 'title: Ponytail, lazy senior dev mode',
+  },
+  // Fallbacks: same host as a `cli` row above, used only when that CLI is
+  // missing, so a plugin install and an instruction copy never both land.
+  {
+    id: 'codex-instructions', name: 'Codex (instruction fallback)', dir: '.codex',
+    file: '.codex/AGENTS.md', merge: true, skipIfCli: 'codex',
+  },
+  {
+    id: 'copilot-instructions', name: 'Copilot CLI (instruction fallback)', dir: '.copilot',
+    file: '.copilot/copilot-instructions.md', merge: true, skipIfCli: 'copilot',
+  },
+];
+
+// Returns the absolute path of `cmd` on PATH, or null. It has to be the
+// resolved path, not just a yes/no: on Windows the host CLIs are .cmd shims
+// that Node can only spawn through cmd.exe, and cmd.exe resolves a bare name
+// from the CURRENT DIRECTORY before PATH — so a stray claude.cmd in whatever
+// folder the installer was started from would run instead of the real one.
+function onPath(cmd) {
+  const exts = process.platform === 'win32'
+    ? (process.env.PATHEXT || '.COM;.EXE;.CMD;.BAT').split(';').map((e) => e.trim()).filter(Boolean)
+    : [''];
+  const mode = process.platform === 'win32' ? fs.constants.F_OK : fs.constants.X_OK;
+  for (const raw of (process.env.PATH || '').split(path.delimiter)) {
+    // Windows PATH entries may be quoted; the quotes are not part of the path.
+    const dir = raw.replace(/^"|"$/g, '');
+    if (!dir) continue;
+    for (const ext of exts) {
+      const candidate = path.join(dir, cmd + ext);
+      try {
+        fs.accessSync(candidate, mode);
+        return candidate;
+      } catch (_) {
+        // not here, keep looking
+      }
+    }
+  }
+  return null;
+}
+
+// ponytail: detection is "binary on PATH" or "config dir exists" — no version
+// probe, no handshake. Ceiling: a renamed CLI, or a config directory left
+// behind by an agent that was uninstalled, costs one wasted install attempt,
+// reported in the summary. Probe `<cli> --version`, or require a known file
+// inside the directory, if that ever misfires often enough to matter.
+function detect(host) {
+  if (host.skipIfCli && onPath(host.skipIfCli)) return false;
+  if (host.cli) return onPath(host.cli) !== null;
+  return fs.existsSync(path.join(HOME, host.dir));
+}
+
+// Idempotency lives here: rerunning replaces ponytail's own block and leaves
+// everything the user wrote around it alone. Malformed markers throw instead of
+// guessing where the block ends — guessing is how a rewrite eats user text.
+function mergeBlock(existing, body) {
+  const block = `${BEGIN}\n${body}\n${END}`;
+  if (!existing.trim()) return `${block}\n`;
+
+  const begin = existing.indexOf(BEGIN);
+  const end = existing.indexOf(END);
+  if (begin === -1 && end === -1) return `${existing.trimEnd()}\n\n${block}\n`;
+  if (begin === -1 || end < begin) {
+    throw new Error(`ponytail markers are malformed (expected ${BEGIN} before ${END})`);
+  }
+  if (existing.indexOf(BEGIN, begin + 1) !== -1 || existing.indexOf(END, end + 1) !== -1) {
+    throw new Error('more than one ponytail block in this file');
+  }
+  return existing.slice(0, begin) + block + existing.slice(end + END.length);
+}
+
+function rules() {
+  return fs.readFileSync(path.join(ROOT, RULES_FILE), 'utf8').trim();
+}
+
+// Returns { changed, target }. Throws on a write it cannot do safely.
+//
+// A dry run takes the same path and stops before the write, so it is a real
+// preflight: a file that would be refused says so now instead of printing
+// "would write" and failing for the first time on the actual install.
+function installFile(host, dryRun) {
+  const target = path.join(HOME, host.file);
+  const current = fs.existsSync(target) ? fs.readFileSync(target, 'utf8') : null;
+  if (host.owner && current !== null && !current.includes(host.owner)) {
+    throw new Error(`${target} exists and is not ponytail's -- refusing to overwrite it`);
+  }
+  const next = host.copy
+    ? fs.readFileSync(path.join(ROOT, host.copy), 'utf8')
+    : mergeBlock(current || '', rules());
+  if (current === next) return { changed: false, target };
+  if (!dryRun) {
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, next, 'utf8');
+  }
+  return { changed: true, target };
+}
+
+function runStep(bin, args) {
+  // stdin is /dev/null so a host CLI that wants to prompt gets EOF and fails
+  // fast instead of hanging a `curl | bash` install forever.
+  //
+  // shell on Windows only: these CLIs install as .cmd shims, and since
+  // CVE-2024-27980 Node refuses to spawn a .cmd without a shell. `bin` is the
+  // absolute path onPath() resolved, quoted because shell:true does no quoting;
+  // every arg is a constant from HOSTS that tests/install.test.js keeps free of
+  // shell metacharacters, so cmd.exe has nothing to reinterpret.
+  const win = process.platform === 'win32';
+  const r = spawnSync(win ? `"${bin}"` : bin, args, {
+    shell: win,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: 'utf8',
+    timeout: STEP_TIMEOUT_MS,
+  });
+  const output = `${r.stdout || ''}${r.stderr || ''}`.trim();
+  if (r.error) return { ok: false, output: r.error.message };
+  return { ok: r.status === 0, output };
+}
+
+function parseArgs(argv) {
+  const opts = { dryRun: false, help: false };
+  for (const arg of argv) {
+    if (arg === '--dry-run') opts.dryRun = true;
+    else if (arg === '--help') opts.help = true;
+    else throw new Error(`unknown flag: ${arg}`);
+  }
+  return opts;
+}
+
+const USAGE = `ponytail installer - installs ponytail into every supported agent found on this machine.
+
+Usage: node scripts/install.js [--dry-run]
+
+  --dry-run   print what would run, change nothing
+
+Docs: ${REPO_URL}#install`;
+
+function main(argv) {
+  let opts;
+  try {
+    opts = parseArgs(argv);
+  } catch (e) {
+    console.error(`${e.message}\n\n${USAGE}`);
+    return 2;
+  }
+  if (opts.help) {
+    console.log(USAGE);
+    return 0;
+  }
+
+  const hosts = HOSTS.filter(detect);
+  if (hosts.length === 0) {
+    console.log('ponytail: found no agent that can be installed machine-wide.');
+    console.log(`Hosts configured per project are listed at ${REPO_URL}#install`);
+    return 0;
+  }
+
+  console.log(`ponytail: found ${hosts.length} agent(s): ${hosts.map((h) => h.id).join(', ')}`);
+
+  let installed = 0;
+  const failures = [];
+  const notes = [];
+
+  for (const host of hosts) {
+    // ASCII only: the Windows console's default codepage renders anything else
+    // as mojibake, and a curl-pipe install lands on exactly that console.
+    console.log(`\n== ${host.name}`);
+    if (host.file) {
+      try {
+        const { changed, target } = installFile(host, opts.dryRun);
+        const verb = changed ? (opts.dryRun ? 'would write' : 'wrote') : 'unchanged';
+        console.log(`  ${verb} ${target}`);
+        installed++;
+      } catch (e) {
+        console.log(`  failed: ${e.message}`);
+        failures.push(host.id);
+      }
+      continue;
+    }
+
+    const bin = onPath(host.cli);
+    const report = (result) => {
+      if (!result.ok) {
+        console.log(`    ${result.output.split('\n').slice(-3).join('\n    ') || 'failed'}`);
+      }
+    };
+    const show = (args) => {
+      const line = `${host.cli} ${args.join(' ')}`;
+      console.log(opts.dryRun ? `  would run: ${line}` : `  ${line}`);
+    };
+
+    // ponytail: the precondition's exit code is ignored, because one host was
+    // measured to report an already-registered marketplace as an error and
+    // that is the ordinary second-run path. Its output is still printed, and a
+    // failure that was real makes the step depending on it fail too. Ceiling:
+    // hosts beyond the three I could run are assumed to exit 0 on a redundant
+    // command; if one does not, a rerun reports it failed, which is the
+    // visible error rather than the silent one.
+    if (host.precondition) {
+      show(host.precondition);
+      if (!opts.dryRun) report(runStep(bin, host.precondition));
+    }
+
+    let ok = true;
+    for (const args of host.steps) {
+      show(args);
+      if (opts.dryRun) continue;
+      const result = runStep(bin, args);
+      report(result);
+      if (!result.ok) {
+        ok = false;
+        break;
+      }
+    }
+    if (ok) {
+      installed++;
+      if (host.note) notes.push(`${host.name}: ${host.note}`);
+    } else {
+      failures.push(host.id);
+    }
+  }
+
+  console.log(`\nponytail: ${installed} ok, ${failures.length} failed${opts.dryRun ? ' (dry run)' : ''}.`);
+  for (const note of notes) console.log(`  next: ${note}`);
+  if (failures.length) {
+    // Any host that did not install is a failed run — a caller piping this into
+    // a script must not read a partial install as success.
+    console.error(`ponytail: install by hand for the rest: ${REPO_URL}#install`);
+    return 1;
+  }
+  return 0;
+}
+
+// exitCode, not process.exit(): process.exit truncates buffered stdout when
+// stdout is a pipe, which is what a PowerShell or shell pipeline gives us.
+if (require.main === module) process.exitCode = main(process.argv.slice(2));
+
+module.exports = { HOSTS, mergeBlock, parseArgs, detect, onPath, main, BEGIN, END, RULES_FILE };

--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -1,13 +1,15 @@
 #!/usr/bin/env node
 // ponytail — removes state ponytail wrote outside the plugin's own files:
-// the mode flag, the config file, and the statusLine entry it added to
-// settings.json. Plugin files themselves are removed by each host's own
-// uninstall command (see README); this only cleans up what those commands
-// can't see.
+// the ruleset scripts/install.js wrote into global instruction files, the mode
+// flag, the config file, and the statusLine entry it added to settings.json.
+// Plugin files themselves are removed by each host's own uninstall command
+// (see README); this only cleans up what those commands can't see.
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { getConfigPath, getClaudeDir } = require('../hooks/ponytail-config');
+const { HOSTS, BEGIN, END } = require('./install.js');
 
 const STATUSLINE_SCRIPT = 'ponytail-statusline';
 
@@ -17,6 +19,42 @@ function removeIfExists(filePath, label) {
     console.log(`Removed ${label}: ${filePath}`);
   } catch (e) {
     if (e.code !== 'ENOENT') throw e;
+  }
+}
+
+// scripts/install.js writes the ruleset into instruction files the host CLIs
+// know nothing about, so their own uninstall commands cannot see them either.
+// Same job as the statusLine cleanup below: undo what ponytail wrote outside
+// the plugin folder.
+for (const host of HOSTS.filter((h) => h.file)) {
+  const target = path.join(os.homedir(), host.file);
+  let content;
+  try {
+    content = fs.readFileSync(target, 'utf8');
+  } catch (e) {
+    if (e.code === 'ENOENT') continue;
+    throw e;
+  }
+
+  if (host.copy) {
+    // Same ownership test the installer applies before it writes: the directory
+    // is the user's own, so a file that no longer carries our title is theirs.
+    if (host.owner && content.includes(host.owner)) {
+      removeIfExists(target, `${host.name} rules`);
+    }
+    continue;
+  }
+
+  const begin = content.indexOf(BEGIN);
+  const end = content.indexOf(END);
+  if (begin === -1 || end < begin) continue;
+  const stripped = (content.slice(0, begin) + content.slice(end + END.length)).trim();
+  if (stripped) {
+    fs.writeFileSync(target, `${stripped}\n`, 'utf8');
+    console.log(`Removed ponytail block from ${target}`);
+  } else {
+    // Nothing but our block was in there — the file only existed because of us.
+    removeIfExists(target, `${host.name} instructions`);
   }
 }
 

--- a/tests/install.test.js
+++ b/tests/install.test.js
@@ -1,0 +1,614 @@
+#!/usr/bin/env node
+// The installer is the one-line entry point users get from a curl pipe, and it
+// writes into files it does not own, so the guards here are: the host table's
+// shape, that a run actually installs the ruleset, and that a rerun cannot
+// duplicate or eat anything.
+
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+
+const root = path.join(__dirname, '..');
+const INSTALLER = path.join(root, 'scripts', 'install.js');
+const { HOSTS, mergeBlock, parseArgs, onPath, BEGIN, END, RULES_FILE } = require('../scripts/install.js');
+
+// Windows runs the host CLIs through cmd.exe (their .cmd shims cannot be
+// spawned without a shell), so every argument in the table has to be inert
+// there. Same spirit as the POSIX guard in hooks-windows.test.js.
+const SHELL_SAFE_ARG = /^[A-Za-z0-9@:/._#-]+$/;
+
+// Every spawn pins PATH and HOME: without that, detection depends on whichever
+// agents the developer or the CI runner happens to have, and a test could
+// install into a real one.
+function run(args, { home, binDir = '' } = {}) {
+  return spawnSync(process.execPath, [INSTALLER, ...args], {
+    env: { ...process.env, HOME: home, USERPROFILE: home, PATH: binDir },
+    encoding: 'utf8',
+  });
+}
+
+function tempHome(seed = () => {}) {
+  const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-install-'));
+  const home = path.join(temp, 'home');
+  fs.mkdirSync(home, { recursive: true });
+  seed(home);
+  return { temp, home, cleanup: () => fs.rmSync(temp, { recursive: true, force: true }) };
+}
+
+// A stand-in host CLI, so the CLI branch is exercised without touching a real
+// agent. Windows would need .cmd shims and a PATHEXT dance; the branch it would
+// prove is the same one, so POSIX-only is enough.
+// `codes` is the exit status per invocation, so a test can say "the first
+// command fails, the second succeeds" -- the case that decides whether a
+// failure early in a host's sequence is caught or swallowed.
+function fakeCli(name, codes) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-bin-'));
+  const bin = path.join(dir, name);
+  const ranLog = path.join(dir, 'ran.log');
+  const list = [].concat(codes);
+  const counter = path.join(dir, 'count');
+  // Builtins only: the tests pin PATH to this directory, so wc/tr/cat are not
+  // reachable from inside the script.
+  fs.writeFileSync(bin, [
+    '#!/bin/sh',
+    'n=0',
+    `[ -f "${counter}" ] && read n < "${counter}"`,
+    'n=$((n+1))',
+    `echo "$n" > "${counter}"`,
+    `echo "$@" >> "${ranLog}"`,
+    'case "$n" in',
+    ...list.map((code, i) => `  ${i + 1}) exit ${code} ;;`),
+    `  *) exit ${list[list.length - 1]} ;;`,
+    'esac',
+    '',
+  ].join('\n'));
+  fs.chmodSync(bin, 0o755);
+  return {
+    dir,
+    ran: () => fs.existsSync(ranLog),
+    calls: () => (fs.existsSync(ranLog) ? fs.readFileSync(ranLog, 'utf8').trim().split('\n') : []),
+    cleanup: () => fs.rmSync(dir, { recursive: true, force: true }),
+  };
+}
+
+const rulesBody = fs.readFileSync(path.join(root, RULES_FILE), 'utf8').trim();
+
+test('every host row is either a CLI install or a file install', () => {
+  const ids = new Set();
+  const clis = new Set(HOSTS.map((h) => h.cli).filter(Boolean));
+
+  for (const host of HOSTS) {
+    assert.ok(host.id && host.name, `host missing id/name: ${JSON.stringify(host)}`);
+    assert.ok(!ids.has(host.id), `duplicate host id: ${host.id}`);
+    ids.add(host.id);
+
+    if (host.cli) {
+      assert.ok(Array.isArray(host.steps) && host.steps.length, `${host.id}: cli host needs steps`);
+      for (const args of [...(host.precondition ? [host.precondition] : []), ...host.steps]) {
+        assert.ok(Array.isArray(args), `${host.id}: step args must be an array (no shell string)`);
+        for (const arg of args) {
+          assert.match(arg, SHELL_SAFE_ARG, `${host.id}: ${arg} is not safe for the Windows shell path`);
+        }
+      }
+    } else {
+      assert.ok(host.dir, `${host.id}: file host needs a detection dir`);
+      assert.ok(host.file, `${host.id}: file host needs a target file`);
+      assert.ok(host.merge || host.copy, `${host.id}: file host needs merge or copy`);
+      // A dir host must never be detected by a directory it also creates.
+      assert.ok(host.file.startsWith(host.dir), `${host.id}: target should live under ${host.dir}`);
+    }
+
+    // A fallback row is only suppressed if it names a CLI some row can detect.
+    if (host.skipIfCli) {
+      assert.ok(clis.has(host.skipIfCli), `${host.id}: skipIfCli '${host.skipIfCli}' is no host's cli`);
+    }
+  }
+});
+
+test('files a host copies verbatim exist in the repo and declare ownership', () => {
+  for (const host of HOSTS.filter((h) => h.copy)) {
+    const source = path.join(root, host.copy);
+    assert.ok(fs.existsSync(source), `${host.id}: missing source ${host.copy}`);
+    // A whole-file copy lands in a directory the user writes by hand, so it
+    // needs a marker that says the target is ours before it may be replaced.
+    assert.ok(host.owner, `${host.id}: a copy host must declare owner`);
+    assert.ok(
+      fs.readFileSync(source, 'utf8').includes(host.owner),
+      `${host.id}: the repo copy does not contain its own owner string`,
+    );
+  }
+  // The ruleset source is .agents/rules/ponytail.md, not AGENTS.md, whose
+  // trailing note is addressed to agents working on this repo.
+  assert.ok(rulesBody.length > 500, `${RULES_FILE} is empty or truncated`);
+  assert.ok(!rulesBody.includes('this file also applies to agents working on the ponytail repo'));
+});
+
+test('mergeBlock is idempotent and keeps the user content around it', () => {
+  const existing = '# My own instructions\n\nAlways use tabs.\n\nSee you later.\n';
+
+  const once = mergeBlock(existing, 'RULE ONE\nRULE TWO');
+  assert.ok(once.includes('Always use tabs.'), 'user content before the block was dropped');
+  assert.ok(once.includes(BEGIN) && once.includes(END), 'markers missing');
+
+  assert.equal(mergeBlock(once, 'RULE ONE\nRULE TWO'), once, 'rerunning changed the file');
+
+  // A ruleset update replaces the block instead of appending a second one, and
+  // whatever the user wrote on either side of it survives.
+  const withTail = `${once}\nmy tail notes\n`;
+  const updated = mergeBlock(withTail, 'RULE ONE\nRULE THREE');
+  assert.equal(updated.match(new RegExp(BEGIN, 'g')).length, 1, 'second block appended');
+  assert.ok(updated.includes('RULE THREE') && !updated.includes('RULE TWO'));
+  assert.ok(updated.includes('Always use tabs.'), 'leading user content lost on rewrite');
+  assert.ok(updated.includes('my tail notes'), 'trailing user content lost on rewrite');
+});
+
+test('mergeBlock writes a clean file when there is nothing there yet', () => {
+  assert.equal(mergeBlock('', 'BODY'), `${BEGIN}\nBODY\n${END}\n`);
+});
+
+test('mergeBlock refuses to guess when the markers are malformed', () => {
+  // Each of these used to append a second block, after which the next run
+  // matched from the first BEGIN to the only END and deleted the user's text
+  // in between. Refusing is the only option that cannot lose content.
+  const truncated = `notes\n${BEGIN}\nstale rules\n`;
+  const reversed = `${END}\nmine\n${BEGIN}\n`;
+  const doubled = `${BEGIN}\na\n${END}\nmine\n${BEGIN}\nb\n${END}\n`;
+
+  for (const [label, text] of [['truncated', truncated], ['reversed', reversed], ['doubled', doubled]]) {
+    assert.throws(() => mergeBlock(text, 'NEW'), /malformed|more than one/, `${label} should throw`);
+  }
+});
+
+test('parseArgs accepts the documented flags and rejects the rest', () => {
+  assert.equal(parseArgs(['--dry-run']).dryRun, true);
+  assert.equal(parseArgs(['--help']).help, true);
+  assert.throws(() => parseArgs(['--force']), /unknown flag/);
+  assert.throws(() => parseArgs(['-n']), /unknown flag/);
+});
+
+// The table is a second copy of the per-host commands in the README and nothing
+// generates one from the other, so bind them: every command the installer runs
+// must appear verbatim in that host's own README section.
+test('every host command appears verbatim in its README section', () => {
+  const readme = fs.readFileSync(path.join(root, 'README.md'), 'utf8');
+  const install = readme.slice(readme.indexOf('## Install'), readme.indexOf('### Uninstall'));
+  const sections = [...install.matchAll(/^### (.+)$/gm)].map((m) => m[1].trim());
+
+  for (const host of HOSTS.filter((h) => h.cli)) {
+    const start = install.indexOf(`### ${host.name}`);
+    assert.notEqual(start, -1, `${host.id}: no "### ${host.name}" section in the README Install section`);
+    const next = install.indexOf('\n### ', start + 1);
+    const body = install.slice(start, next === -1 ? undefined : next);
+    for (const args of [...(host.precondition ? [host.precondition] : []), ...host.steps]) {
+      const command = `${host.cli} ${args.join(' ')}`;
+      assert.ok(body.includes(command), `${host.id}: README section does not document \`${command}\``);
+    }
+  }
+
+  // Sections with no row are fine only when they are project-scoped hosts the
+  // installer deliberately leaves manual. Pin that list so a new CLI-installable
+  // host cannot be documented and then silently skipped by the installer.
+  const MANUAL = ['OpenCode', 'Qoder', 'CodeWhale'];
+  const OWN_SECTION = 'One line, every agent you have';
+  const covered = new Set(HOSTS.map((h) => h.name));
+  for (const section of sections.filter((s) => s !== OWN_SECTION)) {
+    assert.ok(
+      covered.has(section) || MANUAL.includes(section),
+      `README documents "${section}" but no installer row covers it (add a row, or add it to MANUAL with a reason)`,
+    );
+  }
+});
+
+// End-to-end against a throwaway home, the same way uninstall.test.js drives
+// scripts/uninstall.js. "Safe to rerun" is the README's claim, so it is checked
+// by actually rerunning it.
+test('installing into a temp home writes the ruleset and is idempotent', () => {
+  const { home, cleanup } = tempHome((h) => {
+    fs.mkdirSync(path.join(h, '.config', 'amp'), { recursive: true });
+    fs.mkdirSync(path.join(h, '.kiro'), { recursive: true });
+    fs.writeFileSync(path.join(h, '.config', 'amp', 'AGENTS.md'), '# My own rules\n\nAlways use tabs.\n');
+  });
+  try {
+    const ampFile = path.join(home, '.config', 'amp', 'AGENTS.md');
+    const kiroFile = path.join(home, '.kiro', 'steering', 'ponytail.md');
+
+    const first = run([], { home });
+    assert.equal(first.status, 0, first.stderr);
+    // The Windows console's default codepage turns anything else into mojibake,
+    // and a curl-pipe install lands on exactly that console.
+    assert.match(first.stdout, /^[\x00-\x7f]*$/, 'installer printed a non-ASCII character');
+
+    const amp = fs.readFileSync(ampFile, 'utf8');
+    assert.ok(amp.includes('Always use tabs.'), 'user content was dropped');
+    assert.ok(
+      amp.slice(amp.indexOf(BEGIN), amp.indexOf(END)).includes(rulesBody),
+      'the block does not contain the ruleset — an empty or wrong body would pass without this',
+    );
+    assert.equal(
+      fs.readFileSync(kiroFile, 'utf8'),
+      fs.readFileSync(path.join(root, '.kiro', 'steering', 'ponytail.md'), 'utf8'),
+      'Kiro steering file does not match the repo copy',
+    );
+
+    const second = run([], { home });
+    assert.equal(second.status, 0, second.stderr);
+    assert.equal(fs.readFileSync(ampFile, 'utf8'), amp, 'second run changed the merged file');
+    assert.equal(
+      fs.readFileSync(kiroFile, 'utf8'),
+      fs.readFileSync(path.join(root, '.kiro', 'steering', 'ponytail.md'), 'utf8'),
+      'second run rewrote the Kiro file with something else',
+    );
+    assert.equal(
+      (second.stdout.match(/unchanged/g) || []).length, 2,
+      'both hosts should report unchanged on a second run, not just one',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('--dry-run writes nothing and runs no host CLI', (t) => {
+  if (process.platform === 'win32') return t.skip('fake CLI fixture is POSIX-only');
+
+  const cli = fakeCli('clawhub', [0]);
+  const { home, cleanup } = tempHome((h) => {
+    fs.mkdirSync(path.join(h, '.config', 'amp'), { recursive: true });
+    fs.mkdirSync(path.join(h, '.kiro'), { recursive: true });
+  });
+  try {
+    const r = run(['--dry-run'], { home, binDir: cli.dir });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /would write/);
+    assert.match(r.stdout, /would run: clawhub install ponytail/);
+    assert.equal(fs.existsSync(path.join(home, '.config', 'amp', 'AGENTS.md')), false, '--dry-run wrote the amp file');
+    assert.equal(fs.existsSync(path.join(home, '.kiro', 'steering')), false, '--dry-run wrote the Kiro file');
+    assert.equal(cli.ran(), false, '--dry-run executed a host CLI');
+  } finally {
+    cli.cleanup();
+    cleanup();
+  }
+});
+
+test('an absent host is never detected and never gets a directory', () => {
+  const { home, cleanup } = tempHome();
+  try {
+    const r = run([], { home });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /found no agent/);
+    assert.equal(fs.existsSync(path.join(home, '.kiro')), false, 'installer created a directory for an absent host');
+    assert.equal(fs.existsSync(path.join(home, '.config')), false);
+  } finally {
+    cleanup();
+  }
+});
+
+test('a partial install reports the failure and still writes the host that worked', () => {
+  const { home, cleanup } = tempHome((h) => {
+    fs.mkdirSync(path.join(h, '.config', 'amp'), { recursive: true });
+    // Occupy the Kiro target with a directory so its write fails for a real reason.
+    fs.mkdirSync(path.join(h, '.kiro', 'steering', 'ponytail.md'), { recursive: true });
+  });
+  try {
+    const r = run([], { home });
+    assert.equal(r.status, 1, 'a failed host must not exit 0');
+    assert.match(r.stdout, /1 ok, 1 failed/);
+    assert.ok(
+      fs.readFileSync(path.join(home, '.config', 'amp', 'AGENTS.md'), 'utf8').includes(BEGIN),
+      'the host that could be installed was skipped because another failed',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('--help prints usage and installs nothing', () => {
+  const { home, cleanup } = tempHome((h) => fs.mkdirSync(path.join(h, '.kiro'), { recursive: true }));
+  try {
+    const r = run(['--help'], { home });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /Usage: node scripts\/install\.js/);
+    assert.match(r.stdout, /^[\x00-\x7f]*$/, 'usage text printed a non-ASCII character');
+    assert.equal(fs.existsSync(path.join(home, '.kiro', 'steering')), false, '--help installed something');
+  } finally {
+    cleanup();
+  }
+});
+
+test('an unknown flag is a usage error on stderr', () => {
+  const { home, cleanup } = tempHome();
+  try {
+    const r = run(['--force'], { home });
+    assert.equal(r.status, 2, 'unknown flag should exit 2');
+    assert.match(r.stderr, /unknown flag: --force/);
+    assert.match(r.stderr, /Usage: node/);
+  } finally {
+    cleanup();
+  }
+});
+
+test('a host CLI that succeeds is installed, one that fails exits non-zero', (t) => {
+  if (process.platform === 'win32') return t.skip('fake CLI fixture is POSIX-only');
+
+  for (const [exitCode, wantStatus, wantSummary] of [[0, 0, /1 ok, 0 failed/], [1, 1, /0 ok, 1 failed/]]) {
+    const cli = fakeCli('clawhub', [exitCode]);
+    const { home, cleanup } = tempHome();
+    try {
+      const r = run([], { home, binDir: cli.dir });
+      assert.match(r.stdout, /openclaw/, 'the fake CLI was not detected on PATH');
+      assert.equal(r.status, wantStatus, `exit ${exitCode} CLI should give status ${wantStatus}: ${r.stdout}`);
+      assert.match(r.stdout, wantSummary);
+    } finally {
+      cli.cleanup();
+      cleanup();
+    }
+  }
+});
+
+test('a host with its CLI present skips the instruction fallback', (t) => {
+  if (process.platform === 'win32') return t.skip('fake CLI fixture is POSIX-only');
+
+  const cli = fakeCli('codex', [0, 0]);
+  const { home, cleanup } = tempHome((h) => fs.mkdirSync(path.join(h, '.codex'), { recursive: true }));
+  try {
+    const r = run(['--dry-run'], { home, binDir: cli.dir });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /\bcodex\b/);
+    assert.doesNotMatch(r.stdout, /codex-instructions/, 'plugin install and instruction copy both landed');
+  } finally {
+    cli.cleanup();
+    cleanup();
+  }
+});
+
+// The win32 spawn path cannot be exercised from POSIX, so pin the property it
+// depends on: cmd.exe resolves a bare command name from the current directory
+// before PATH, so runStep must be handed the absolute path onPath() found.
+test('onPath returns the resolved absolute path, not just a yes/no', (t) => {
+  if (process.platform === 'win32') return t.skip('fake CLI fixture is POSIX-only');
+
+  const cli = fakeCli('clawhub', [0]);
+  const saved = process.env.PATH;
+  process.env.PATH = cli.dir;
+  try {
+    assert.equal(onPath('clawhub'), path.join(cli.dir, 'clawhub'));
+    assert.equal(onPath('ponytail-no-such-binary'), null);
+  } finally {
+    process.env.PATH = saved;
+    cli.cleanup();
+  }
+});
+
+// install.sh and install.ps1 are twins on purpose: neither holds install logic,
+// so the only thing that can drift is what they point at. Pin that.
+test('the bash and PowerShell shims agree on repo, default ref, and entry point', () => {
+  const sh = fs.readFileSync(path.join(root, 'install.sh'), 'utf8');
+  const ps = fs.readFileSync(path.join(root, 'install.ps1'), 'utf8');
+  for (const [name, text] of [['install.sh', sh], ['install.ps1', ps]]) {
+    assert.match(text, /DietrichGebert\/ponytail/, `${name}: repo slug missing`);
+    assert.match(text, /PONYTAIL_REF/, `${name}: PONYTAIL_REF override missing`);
+    assert.match(text, /'main'|:-main/, `${name}: default ref should be main`);
+    assert.match(text, /scripts\/install\.js/, `${name}: does not run scripts/install.js`);
+    assert.match(text, /codeload\.github\.com/, `${name}: no archive download path`);
+    assert.match(text, /A-Za-z0-9/, `${name}: PONYTAIL_REF reaches a URL path and must be validated`);
+  }
+});
+
+test('install.sh parses and runs the local installer from a clone', (t) => {
+  if (process.platform === 'win32') return t.skip('bash shim is not the Windows path');
+
+  const syntax = spawnSync('bash', ['-n', path.join(root, 'install.sh')], { encoding: 'utf8' });
+  assert.equal(syntax.status, 0, syntax.stderr);
+
+  const { home, cleanup } = tempHome();
+  try {
+    const r = spawnSync('bash', [path.join(root, 'install.sh'), '--help'], {
+      env: { ...process.env, HOME: home, USERPROFILE: home },
+      encoding: 'utf8',
+    });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /Usage: node scripts\/install\.js/, 'the shim did not exec the local installer');
+  } finally {
+    cleanup();
+  }
+});
+
+// Windows PowerShell 5.1 reads a BOM-less file as ANSI, and in CP1252 the
+// bytes of an em dash decode to a smart quote -- which its parser accepts as a
+// string delimiter, so one stray dash inside a string silently breaks the whole
+// script on the -File path (it survives `irm | iex`, which decodes UTF-8).
+test('the shims are pure ASCII', () => {
+  for (const name of ['install.sh', 'install.ps1']) {
+    const bytes = fs.readFileSync(path.join(root, name));
+    const at = bytes.findIndex((b) => b > 0x7f);
+    assert.equal(at, -1, `${name}: non-ASCII byte at offset ${at}`);
+  }
+});
+
+test('install.ps1 parses under PowerShell', (t) => {
+  const probe = spawnSync('pwsh', ['-NoProfile', '-Command', '$PSVersionTable.PSVersion.Major'], { encoding: 'utf8' });
+  if (probe.error) return t.skip('pwsh not installed (GitHub runners have it)');
+  const script = path.join(root, 'install.ps1').replace(/'/g, "''");
+  const r = spawnSync('pwsh', ['-NoProfile', '-Command',
+    `$e = $null; [System.Management.Automation.Language.Parser]::ParseFile('${script}', [ref]$null, [ref]$e) > $null; ` +
+    'if ($e.Count) { $e | ForEach-Object { $_.Message }; exit 1 }',
+  ], { encoding: 'utf8' });
+  assert.equal(r.status, 0, r.stdout + r.stderr);
+});
+
+// ~/.kiro/steering is the user's own directory of hand-written rules, so a file
+// that happens to be named ponytail.md is not automatically ours to replace.
+test('a foreign file at the Kiro target is refused, not overwritten', () => {
+  const mine = '---\ntitle: my own steering\n---\n\nmy rules\n';
+  const { home, cleanup } = tempHome((h) => {
+    fs.mkdirSync(path.join(h, '.kiro', 'steering'), { recursive: true });
+    fs.writeFileSync(path.join(h, '.kiro', 'steering', 'ponytail.md'), mine);
+  });
+  try {
+    const r = run([], { home });
+    assert.equal(r.status, 1, 'refusing to overwrite must be a failed host, not a silent skip');
+    assert.match(r.stdout, /refusing to overwrite/);
+    assert.equal(
+      fs.readFileSync(path.join(home, '.kiro', 'steering', 'ponytail.md'), 'utf8'),
+      mine,
+      "a user's own steering file must be left byte-for-byte intact",
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('an older ponytail file at the Kiro target is upgraded in place', () => {
+  const kiroHost = HOSTS.find((h) => h.id === 'kiro');
+  // An earlier version: same title, different body. The upgrade path must not
+  // be blocked by the ownership check.
+  const older = `---\n${kiroHost.owner}\ninclusion: always\n---\n\nold rules\n`;
+  const { home, cleanup } = tempHome((h) => {
+    fs.mkdirSync(path.join(h, '.kiro', 'steering'), { recursive: true });
+    fs.writeFileSync(path.join(h, '.kiro', 'steering', 'ponytail.md'), older);
+  });
+  try {
+    const r = run([], { home });
+    assert.equal(r.status, 0, r.stdout + r.stderr);
+    assert.equal(
+      fs.readFileSync(path.join(home, '.kiro', 'steering', 'ponytail.md'), 'utf8'),
+      fs.readFileSync(path.join(root, kiroHost.copy), 'utf8'),
+      'an older copy of our own file must be replaced with the current one',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+// Every command in `steps` has to pass. Swival runs two, and the first failing
+// must fail the host rather than being overwritten by the second's status.
+test('a host whose first step fails is reported failed, and the rest is skipped', (t) => {
+  if (process.platform === 'win32') return t.skip('fake CLI fixture is POSIX-only');
+
+  const cli = fakeCli('swival', [1, 0]);
+  const { home, cleanup } = tempHome();
+  try {
+    const r = run([], { home, binDir: cli.dir });
+    assert.equal(r.status, 1, 'a failed first step must fail the host');
+    assert.match(r.stdout, /0 ok, 1 failed/);
+    assert.equal(cli.calls().length, 1, 'the step after a failure should not run');
+  } finally {
+    cli.cleanup();
+    cleanup();
+  }
+});
+
+// The one measured exception: Copilot CLI exits 1 when its marketplace is
+// already registered, which is what a second run always looks like.
+test('a failing precondition does not fail the host', (t) => {
+  if (process.platform === 'win32') return t.skip('fake CLI fixture is POSIX-only');
+
+  const cli = fakeCli('copilot', [1, 0]);
+  const { home, cleanup } = tempHome();
+  try {
+    const r = run([], { home, binDir: cli.dir });
+    assert.equal(r.status, 0, `a precondition failure must not fail the host: ${r.stdout}`);
+    assert.match(r.stdout, /1 ok, 0 failed/);
+    assert.equal(cli.calls().length, 2, 'the install step must still run after a failed precondition');
+  } finally {
+    cli.cleanup();
+    cleanup();
+  }
+});
+
+// --dry-run is a preflight, not just an echo: a target it would refuse has to
+// say so before the real run, not after.
+test('--dry-run reports a refusal it would hit, and still writes nothing', () => {
+  const mine = '---\ntitle: my own steering\n---\n\nmy rules\n';
+  const { home, cleanup } = tempHome((h) => {
+    fs.mkdirSync(path.join(h, '.kiro', 'steering'), { recursive: true });
+    fs.writeFileSync(path.join(h, '.kiro', 'steering', 'ponytail.md'), mine);
+  });
+  try {
+    const r = run(['--dry-run'], { home });
+    assert.equal(r.status, 1, 'a refusal must be visible in the dry run');
+    assert.match(r.stdout, /refusing to overwrite/);
+    assert.equal(
+      fs.readFileSync(path.join(home, '.kiro', 'steering', 'ponytail.md'), 'utf8'),
+      mine,
+      'the dry run must not have touched the file',
+    );
+  } finally {
+    cleanup();
+  }
+});
+
+test('--dry-run says unchanged for a target that is already current', () => {
+  const { home, cleanup } = tempHome((h) => fs.mkdirSync(path.join(h, '.kiro'), { recursive: true }));
+  try {
+    assert.equal(run([], { home }).status, 0);
+    const r = run(['--dry-run'], { home });
+    assert.equal(r.status, 0, r.stderr);
+    assert.match(r.stdout, /unchanged/, 'a dry run over an up-to-date install should not claim it would write');
+  } finally {
+    cleanup();
+  }
+});
+
+// The shim's Node check has to fail closed. Keeping every digit in the output
+// would concatenate them, so a wrapper that prints its own banner ahead of an
+// old Node could read as a new one and pass a check meant to reject it.
+test('install.sh rejects a Node whose version cannot be read cleanly', (t) => {
+  if (process.platform === 'win32') return t.skip('bash shim is not the Windows path');
+
+  const cases = [
+    ['wrapper 2.0\n16', 'a banner ahead of Node 16 must not read as 2016'],
+    ['16', 'Node 16 must be rejected'],
+    ['not-a-number', 'unparseable output must be rejected'],
+  ];
+  for (const [stdout, why] of cases) {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-node-'));
+    try {
+      const fake = path.join(dir, 'node');
+      fs.writeFileSync(fake, `#!/bin/sh\nprintf '%s\\n' '${stdout.replace(/\n/g, "' '")}'\n`);
+      fs.chmodSync(fake, 0o755);
+      const r = spawnSync('bash', [path.join(root, 'install.sh'), '--dry-run'], {
+        env: { ...process.env, PATH: `${dir}:/usr/bin:/bin` },
+        encoding: 'utf8',
+      });
+      assert.equal(r.status, 1, `${why}: exited ${r.status}`);
+      assert.match(r.stderr, /need Node >=18/, why);
+    } finally {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  }
+});
+
+// `iex` runs in the caller's scope, and an `exit` there terminates a calling
+// script outright (measured on Windows PowerShell 5.1 and 7.6.5). What keeps
+// the piped form safe is that $PSCommandPath is empty under `iex` even when
+// the `iex` sits inside another .ps1 -- so the shim takes the branch that only
+// sets $LASTEXITCODE. A bad PONYTAIL_REF makes the function return before the
+// download, so this exercises the real file without touching the network.
+test('the shim never exits the script that pipes it into iex', (t) => {
+  const probe = spawnSync('pwsh', ['-NoProfile', '-Command', '$PSVersionTable.PSVersion.Major'], { encoding: 'utf8' });
+  if (probe.error) return t.skip('pwsh not installed (GitHub runners have it)');
+
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-iex-'));
+  try {
+    const shim = path.join(root, 'install.ps1').replace(/'/g, "''");
+    const wrapper = path.join(dir, 'wrapper.ps1');
+    fs.writeFileSync(wrapper, [
+      "$env:PONYTAIL_REF = 'not/../valid'",
+      `Invoke-Expression (Get-Content -Raw '${shim}')`,
+      "'WRAPPER-STILL-ALIVE'",
+      '',
+    ].join('\n'));
+
+    const r = spawnSync('pwsh', ['-NoProfile', '-File', wrapper], { encoding: 'utf8' });
+    assert.match(r.stdout, /refusing PONYTAIL_REF/, 'the shim should have refused the ref');
+    assert.match(
+      r.stdout, /WRAPPER-STILL-ALIVE/,
+      'the shim exited the calling script instead of only setting an exit code',
+    );
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/tests/uninstall.test.js
+++ b/tests/uninstall.test.js
@@ -106,6 +106,41 @@ assert.equal(
   'malformed settings.json must be left unchanged',
 );
 
+// The one-line installer writes the ruleset into global instruction files that
+// no host uninstall command knows about, so this script has to take them back
+// out: the block only, leaving whatever the user wrote around it.
+const BEGIN = '<!-- ponytail:begin -->';
+const END = '<!-- ponytail:end -->';
+
+function seed(relPath, content) {
+  const target = path.join(home, ...relPath.split('/'));
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, content);
+  return target;
+}
+
+const shared = seed('.config/amp/AGENTS.md', `# My own rules\n\nAlways use tabs.\n\n${BEGIN}\nRULES\n${END}\n`);
+const oursOnly = seed('.codex/AGENTS.md', `${BEGIN}\nRULES\n${END}\n`);
+const kiro = seed('.kiro/steering/ponytail.md', '---\ntitle: Ponytail, lazy senior dev mode\n---\n\nrules\n');
+
+result = runUninstall(env);
+assert.equal(result.status, 0, result.stderr);
+
+const sharedAfter = fs.readFileSync(shared, 'utf8');
+assert.ok(!sharedAfter.includes(BEGIN), 'the ponytail block must be removed from a shared file');
+assert.ok(sharedAfter.includes('Always use tabs.'), "a shared file's own content must survive");
+assert.equal(fs.existsSync(oursOnly), false, 'a file that held nothing but our block must be removed');
+assert.equal(fs.existsSync(kiro), false, "ponytail's own steering file must be removed");
+
+// A steering file the user replaced with their own rules is not ours to delete.
+// The same ownership string the installer checks before it writes, so the two
+// sides cannot disagree about which files belong to ponytail. A file that only
+// mentions the word somewhere is not enough.
+const mine = seed('.kiro/steering/ponytail.md', '---\ntitle: my own steering\n---\n\nI removed Ponytail from this file.\n');
+result = runUninstall(env);
+assert.equal(result.status, 0, result.stderr);
+assert.ok(fs.existsSync(mine), 'a steering file the user rewrote must be left alone');
+
 // Running on an already-clean machine must not throw.
 result = runUninstall({ HOME: path.join(temp, 'home-empty'), USERPROFILE: path.join(temp, 'home-empty') });
 assert.equal(result.status, 0, result.stderr);


### PR DESCRIPTION
Ponytail supports around twenty hosts and the README documents a separate install command for each. This adds one entry point that installs into every agent on the machine that can be installed machine-wide, without a prompt.

```bash
curl -fsSL https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.sh | bash
```

```powershell
irm https://raw.githubusercontent.com/DietrichGebert/ponytail/main/install.ps1 | iex
```

## How it works

`install.sh` and `install.ps1` are twins that only locate Node (>= 18) and hand off to `scripts/install.js`. Neither holds install logic, so there is nothing for the pair to drift apart on, and a test pins what they must agree about. From a clone they run the local installer; otherwise they unpack a source archive into a temp dir, which keeps `.agents/rules/ponytail.md` and `.kiro/steering/ponytail.md` available at runtime without mirroring anything into `package.json`.

`scripts/install.js` keeps every host in one table, so adding an ecosystem is a row rather than a branch:

- **CLI hosts** are detected on PATH and installed with the exact commands the README documents. A test asserts every command in the table appears verbatim in that host's README section, so the two copies cannot drift.
- **Instruction-tier hosts** (Amp, Kiro, plus Codex and Copilot when their CLI is absent) are detected by the config directory they create on first run. That directory is never created here, so an agent you do not have stays uninstalled. Kiro's steering file is the one ponytail replaces wholesale, and it is only overwritten when it carries ponytail's own title: `~/.kiro/steering` is the user's own directory of hand-written rules, so the filename alone does not make the file ours. Uninstall tests the same string, so install and removal agree on ownership.
- **Project-scoped hosts** (Cursor, Windsurf, Cline, OpenCode, Qoder) are deliberately left manual, because there is nothing machine-wide to install. The zero-host message points at the README rather than claiming you have no agents.

Rerunning is safe. Every command in a host's `steps` must succeed and the run stops at the first that does not; the one exception is an explicitly marked `precondition`, because re-adding an existing marketplace was measured to exit 1 on `copilot` while the same command exits 0 on `claude` and `codex`. Instruction files are rewritten only between `<!-- ponytail:begin -->` and `<!-- ponytail:end -->`, leaving whatever the user wrote around them intact; markers that are malformed (unterminated, reversed, or doubled) abort that host instead of guessing where the block ends, because guessing is how a rewrite loses user text.

The ruleset comes from `.agents/rules/ponytail.md`, not `AGENTS.md`, whose closing note is addressed to agents working on this repo and which `scripts/check-rule-copies.js` already strips for that reason.

`scripts/uninstall.js` learns to undo these writes: it strips the marker block and removes a file that held nothing else. Previously nothing could remove them, since the host CLIs do not know those files exist.

`--dry-run` prints the plan and changes nothing. It takes the same code path as a real install and stops before the write, so a target it would refuse is reported during the dry run rather than for the first time during the install. Any host that fails exits non-zero, so a caller piping this into a script cannot read a partial install as success. A `PONYTAIL_REF` older than the installer downloads a valid archive with no entry point in it, so both shims check for `scripts/install.js` before invoking Node and say so in one line rather than letting Node print a MODULE_NOT_FOUND stack.

## Windows

Three defects here only reproduce on real Windows, and each was found by running it there:

- Windows PowerShell 5.1 does not escape embedded double quotes in a native argument without spaces, so `node -p 'process.versions.node.split(".")[0]'` made a Node 24 machine report "Node 0 too old" and refuse to install. The quoting now puts double quotes outside and single quotes inside, the same nesting `install.sh` uses.
- 5.1 reads a BOM-less file as ANSI, and in CP1252 the bytes of an em dash decode to a smart quote, which its parser accepts as a string delimiter. One dash inside a string broke the whole script on the `-File` path while surviving `irm | iex`, which decodes UTF-8. Both shims are now pure ASCII, and a test reads their bytes to keep them that way.
- A PowerShell function shares its output stream with the native commands it runs, so returning the exit code swallowed every line the installer printed. The code now travels in a script-scoped variable.

Also: `exit` under `irm | iex` terminates the caller's session, so the piped form sets a code instead; the host CLIs install as `.cmd` shims that Node can only spawn through `cmd.exe`, and `cmd.exe` resolves a bare command name from the current directory before PATH, so the installer spawns the absolute path it resolved on PATH; and `.gitattributes` pins `*.sh` to LF, because a Windows clone under the default `core.autocrlf` turns `install.sh` into a CRLF script that fails on `set -euo pipefail` and then runs with `-e` silently not in effect.

## Things worth flagging

- **`.gitattributes` is new and repo-wide.** Concretely, a fresh checkout now gets `hooks/ponytail-statusline.ps1` with CRLF instead of LF, and `hooks/ponytail-statusline.sh` is pinned to LF alongside `install.sh`. The broad rule is deliberate: that shell script is also invoked as `bash <path>`, so it has the same latent CRLF failure. I verified a fresh clone honouring these attributes runs the full suite green. Happy to narrow it to just the two new files, at the cost of leaving that one exposed.
- **The default ref is `main`, not a pinned tag.** Pinning would add a ninth version-bearing file for `scripts/check-versions.js` to guard, and the shim itself is already fetched from `main`, so pinning only the archive would not add a real guarantee. `PONYTAIL_REF=<tag>` overrides it; the README shows the invocation that actually works, since `PONYTAIL_REF=... curl ... | bash` sets the variable for `curl` rather than for `bash`.
- **`--yes` was dropped from the Claude Code command.** It exists on newer Claude Code but not on older ones, where the install fails with `error: unknown option '--yes'`. This surfaced on a real Windows machine, not in review. The README's Claude Code section gains the CLI form the installer uses, which is also what lets the verbatim-command test bind the table to the docs.
- **The installer runs each host's own install command, trust flags and all** (`--trust`, `--enable`). Those are the documented commands; `--dry-run` prints the exact list first.
- **The Amp row uses a POSIX path.** Amp's Windows config location is unverified, so Windows simply does not detect Amp rather than writing to a guessed path. Marked with a `ponytail:` comment and an upgrade path.
- **`package.json` is untouched.** Both shims fetch a source archive rather than the npm package, so the installer is deliberately absent from `files`.

## Testing

`tests/install.test.js` covers the table shape, the merge on malformed markers, rerun idempotency end-to-end against a temp home, that an absent host is never written to, that `--dry-run` neither writes a file nor runs a host CLI, the exit-code matrix, and the CLI-host path through a stand-in binary on a temp PATH. Every spawn pins HOME and PATH so a test can never reach a real agent.

The suite was mutation-checked: reverting the dry-run guards, the idempotency short-circuit, the malformed-marker guard, `skipIfCli`, the `--help` short-circuit, the exit codes, the ruleset read, and `runStep`'s status handling each fails at least one test.

On Windows (PowerShell 5.1.26100 and 7.6.5, Node 20) the following were verified by hand, since CI is Linux-only: the clone path and the real `irm | iex` path end to end (shim over HTTP, archive unpacked to a temp dir, Node invoked, four hosts detected and planned), install then rerun reporting `unchanged`, uninstall stripping the block while keeping user content, exit codes 0/1/2, ASCII-only output by codepoint scan, a clone checking out `install.sh` with zero CR bytes, and the `cmd.exe` resolution fix using a decoy `clawhub.cmd` in the working directory against the real one on a PATH directory containing a space.