### PR TITLE
fix(hermes): avoid repeated context injection

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -122,10 +122,28 @@ def build_injected_context(mode: str | None = None) -> str:
         return _fallback_instructions(effective)
 
 
-def _pre_llm_call(session_id: str = "", **_: Any) -> dict[str, str] | None:
+def _pre_llm_call(
+    session_id: str = "", conversation_history: Any = None, **_: Any
+) -> dict[str, str] | None:
     mode = _current_mode or _default_mode()
     context = build_injected_context(mode)
-    return {"context": context} if context else None
+    if not context:
+        return None
+
+    # Hermes persists hook context in api_content for cache-stable replay.
+    # Re-inject only when the active mode changed or compaction removed it.
+    marker = "PONYTAIL MODE ACTIVE — level: "
+    for message in reversed(conversation_history or []):
+        if not isinstance(message, dict):
+            continue
+        api_content = message.get("api_content")
+        if not isinstance(api_content, str):
+            continue
+        matches = re.findall(rf"{re.escape(marker)}([a-z]+)", api_content)
+        if matches:
+            return None if matches[-1] == mode else {"context": context}
+
+    return {"context": context}
 
 
 def _skill_prompt(command: str, args: str = "") -> str:

--- a/tests/hermes-plugin.test.js
+++ b/tests/hermes-plugin.test.js
@@ -190,6 +190,36 @@ print(json.dumps({'message': message, 'context': injected['context']}))
   assert.match(data.context, /PONYTAIL MODE ACTIVE — level: ultra/);
 });
 
+test('Hermes pre_llm_call does not append the same ruleset to every persisted turn', () => {
+  const output = python(String.raw`
+import importlib.util, json
+spec = importlib.util.spec_from_file_location('ponytail_hermes_plugin', '__init__.py')
+mod = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(mod)
+first = mod._pre_llm_call(conversation_history=[])
+history = [{
+    'role': 'user',
+    'content': 'first task',
+    'api_content': 'first task\\n\\n' + first['context'],
+}]
+second = mod._pre_llm_call(conversation_history=history)
+mod._current_mode = 'ultra'
+switched = mod._pre_llm_call(conversation_history=history)
+history.append({
+    'role': 'user',
+    'content': 'second task',
+    'api_content': 'second task\\n\\n' + switched['context'],
+})
+after_switch = mod._pre_llm_call(conversation_history=history)
+print(json.dumps({'first': first, 'second': second, 'switched': switched, 'after_switch': after_switch}))
+`);
+  const data = JSON.parse(output);
+  assert.match(data.first.context, /PONYTAIL MODE ACTIVE — level: full/);
+  assert.equal(data.second, null);
+  assert.match(data.switched.context, /PONYTAIL MODE ACTIVE — level: ultra/);
+  assert.equal(data.after_switch, null);
+});
+
 test('Hermes gateway rewrite respects slash access denial', () => {
   const output = python(String.raw`
 import importlib.util, json


### PR DESCRIPTION
## Bug Description

The Hermes adapter injects the full Ponytail ruleset from `pre_llm_call` on every user turn. Hermes persists hook-injected user context in each message's `api_content` sidecar for cache-stable replay, so an N-turn session retains N copies of the ruleset instead of one.

A direct hook check measured about 5.4 KB for the first `full` injection and another 5.4 KB on every unchanged turn.

This is Hermes-specific repeated accumulation, not the Claude `SessionStart` resident-context cost described in #685.

## Root Cause

The adapter treated `pre_llm_call` context as ephemeral. Current Hermes appends that context to the API copy of the user message, persists the exact copy in `api_content`, and replays it on later turns.

#337 proposed a process-local `set(session_id)` guard, but it mixed in unrelated timeout changes and was closed after the surrounding hooks changed. A process-local guard would also miss persisted/resumed history and compaction semantics.

## Fix

- Read the latest persisted Ponytail mode marker from `conversation_history[*].api_content`.
- Skip injection when the latest persisted mode matches the active mode.
- Re-inject when the mode changes.
- Re-inject after compaction removes the persisted marker.
- Avoid new process-global session state.

## How to Verify

1. Call `_pre_llm_call` with empty history: it returns the active ruleset.
2. Persist that context in a user message's `api_content` and call again with the same mode: it returns `None`.
3. Change the mode: it returns the new ruleset once, then returns `None` again after that context is persisted.

## Test Plan

- [x] Added a Hermes regression test covering same-mode deduplication and mode changes.
- [x] `npm run test` passes.
- [x] Direct measurement: first injection 5,398 bytes; unchanged second turn 0 bytes; mode switch re-injects once.

## Risk Assessment

Low — the change is isolated to the Hermes `pre_llm_call` adapter. If no persisted marker exists, behavior remains unchanged and the ruleset is injected.
