### PR TITLE
fix(uninstall): remove the mode flag from every host state dir

### DIFF
--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -6,6 +6,7 @@
 // can't see.
 
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 const { getConfigPath, getClaudeDir } = require('../hooks/ponytail-config');
 
@@ -20,7 +21,19 @@ function removeIfExists(filePath, label) {
   }
 }
 
-removeIfExists(path.join(getClaudeDir(), '.ponytail-active'), 'mode flag');
+// Not every host keeps the flag in ~/.claude — hooks/ponytail-runtime.js writes
+// it beside each host's own state: Codex $PLUGIN_DATA, Copilot
+// $COPILOT_PLUGIN_DATA, Qoder ~/.qoder. Uninstall runs from a plain shell where
+// those vars are usually unset, so sweep every location ponytail writes to.
+const stateDirs = new Set([
+  getClaudeDir(),
+  path.join(os.homedir(), '.qoder'),
+  process.env.PLUGIN_DATA,
+  process.env.COPILOT_PLUGIN_DATA,
+].filter(Boolean));
+for (const dir of stateDirs) {
+  removeIfExists(path.join(dir, '.ponytail-active'), 'mode flag');
+}
 removeIfExists(getConfigPath(), 'config file');
 
 const settingsPath = path.join(getClaudeDir(), 'settings.json');

--- a/tests/uninstall.test.js
+++ b/tests/uninstall.test.js
@@ -27,6 +27,17 @@ fs.mkdirSync(claudeDir, { recursive: true });
 const flagPath = path.join(claudeDir, '.ponytail-active');
 fs.writeFileSync(flagPath, 'full');
 
+// Codex, Copilot and Qoder keep the flag beside their own state, not in
+// ~/.claude (hooks/ponytail-runtime.js). Uninstall must sweep those too.
+const qoderFlagPath = path.join(home, '.qoder', '.ponytail-active');
+fs.mkdirSync(path.dirname(qoderFlagPath), { recursive: true });
+fs.writeFileSync(qoderFlagPath, 'ultra');
+
+const codexDir = path.join(temp, 'codex-plugin-data');
+fs.mkdirSync(codexDir, { recursive: true });
+const codexFlagPath = path.join(codexDir, '.ponytail-active');
+fs.writeFileSync(codexFlagPath, 'lite');
+
 const configDir = path.join(temp, 'config-home', 'ponytail');
 fs.mkdirSync(configDir, { recursive: true });
 const configPath = path.join(configDir, 'config.json');
@@ -41,11 +52,14 @@ const env = {
   HOME: home,
   USERPROFILE: home,
   XDG_CONFIG_HOME: path.join(temp, 'config-home'),
+  PLUGIN_DATA: codexDir,
 };
 
 let result = runUninstall(env);
 assert.equal(result.status, 0, result.stderr);
 assert.equal(fs.existsSync(flagPath), false, 'mode flag must be removed');
+assert.equal(fs.existsSync(qoderFlagPath), false, 'Qoder mode flag must be removed');
+assert.equal(fs.existsSync(codexFlagPath), false, 'Codex mode flag must be removed');
 assert.equal(fs.existsSync(configPath), false, 'config file must be removed');
 
 const settingsAfter = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));


### PR DESCRIPTION
## Summary

`scripts/uninstall.js` only deletes `~/.claude/.ponytail-active`, but that is not where most hosts keep it. `hooks/ponytail-runtime.js` writes the flag beside each host's own state:

| host | state dir |
|---|---|
| Claude Code | `getClaudeDir()` (`~/.claude`) |
| Codex | `$PLUGIN_DATA` |
| VS Code Copilot | `$COPILOT_PLUGIN_DATA` |
| Qoder | `~/.qoder` |

On Codex, Copilot and Qoder the mode flag therefore survives uninstall. The statusline still reads it, and a later reinstall picks up a stale mode instead of starting from the configured default.

## Repro (before this change)

```console
$ QODER_SESSION_ID=x node hooks/ponytail-activate.js   # writes ~/.qoder/.ponytail-active
$ node scripts/uninstall.js
Removed config file: ~/.config/ponytail/config.json
$ ls ~/.qoder/.ponytail-active
~/.qoder/.ponytail-active                              # still there
```

Same result with `PLUGIN_DATA` (Codex) and `COPILOT_PLUGIN_DATA` (Copilot).

## Fix

Sweep every location ponytail writes to, instead of resolving one.

Uninstall runs from a plain shell where `PLUGIN_DATA` / `COPILOT_PLUGIN_DATA` / `QODER_SESSION_ID` are usually unset, so importing the runtime's already-resolved `statePath` would just resolve back to `~/.claude` — it has to check all four. `removeIfExists` already swallows `ENOENT`, so dirs that don't exist cost nothing.

Scope kept deliberately narrow: only `.ponytail-active`. The `.ponytail-statusline-nudged` flag is the same class of leak but is already covered by #680, so this doesn't touch it.

## Verification

```console
$ node --test tests/uninstall.test.js
uninstall script checks passed
✔ tests/uninstall.test.js
```

Full suite is unchanged (`node --test tests/*.test.js`): 83 pass, 1 pre-existing failure in `csv: correct pandas one-liner passes`, which is a local pandas/numpy install issue and is unrelated to this change.

The existing test now also seeds a Qoder flag (`~/.qoder`) and a Codex flag (`$PLUGIN_DATA`) and asserts both are gone.
