### PR TITLE
fix: avoid shell execution when publishing OpenClaw skills

### DIFF
--- a/scripts/publish-openclaw-skills.js
+++ b/scripts/publish-openclaw-skills.js
@@ -42,26 +42,21 @@ if (slugs.length === 0) {
 const displayName = (slug) =>
   slug.split('-').map((w) => w.charAt(0).toUpperCase() + w.slice(1)).join(' ');
 
-// Minimal quoting that satisfies both POSIX sh and cmd.exe: only display names
-// (which contain a space) need wrapping; slugs, versions, paths, and flags don't.
-const quote = (a) => (/[^\w./-]/.test(a) ? `"${a}"` : a);
-
 const passthrough = process.argv.slice(2);
-const extra = passthrough.length ? ` (${passthrough.join(' ')})` : '';
+const extra = passthrough.length ? ` with arguments ${JSON.stringify(passthrough)}` : '';
 console.log(`Publishing ${slugs.length} skills to ClawHub at version ${version}${extra}:`);
 
 for (const slug of slugs) {
   const args = [
-    'clawhub', 'skill', 'publish', `.openclaw/skills/${slug}`,
+    'skill', 'publish', `.openclaw/skills/${slug}`,
     '--slug', slug,
     '--name', displayName(slug),
     '--version', version,
     '--tags', 'latest',
     ...passthrough,
   ];
-  const cmdline = args.map(quote).join(' ');
-  console.log(`\n$ ${cmdline}`);
-  const res = spawnSync(cmdline, { stdio: 'inherit', cwd: root, shell: true });
+  console.log(`\nRunning clawhub with arguments: ${JSON.stringify(args)}`);
+  const res = spawnSync('clawhub', args, { stdio: 'inherit', cwd: root });
   if (res.status !== 0) {
     console.error(
       `\nPublish failed for "${slug}" (exit ${res.status}). ` +

--- a/tests/publish-openclaw-skills.test.js
+++ b/tests/publish-openclaw-skills.test.js
@@ -1,0 +1,70 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const os = require('node:os');
+const path = require('node:path');
+const { spawnSync } = require('node:child_process');
+
+const root = path.join(__dirname, '..');
+
+test('publishes a literal shell-substitution skill slug without executing it', () => {
+  const markerName = `ponytail-openclaw-shell-injection-${process.pid}`;
+  const markerPath = path.join(root, markerName);
+  const maliciousSlug = `test-shell-$(touch ${markerName})`;
+  const skillPath = path.join(root, '.openclaw', 'skills', maliciousSlug);
+  const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-clawhub-'));
+  const binDir = path.join(tempDir, 'bin');
+  const capturePath = path.join(tempDir, 'clawhub-argv.jsonl');
+  const markerExisted = fs.existsSync(markerPath);
+
+  fs.mkdirSync(binDir);
+  fs.mkdirSync(skillPath);
+  fs.writeFileSync(path.join(skillPath, 'SKILL.md'), '---\nname: test-shell\n---\n');
+  fs.writeFileSync(
+    path.join(binDir, 'clawhub'),
+    `#!/usr/bin/env node
+const fs = require('node:fs');
+fs.appendFileSync(process.env.CLAWHUB_CAPTURE, JSON.stringify(process.argv.slice(2)) + '\\n');
+`,
+    { mode: 0o755 },
+  );
+
+  try {
+    assert.equal(markerExisted, false, 'test marker must not already exist');
+
+    for (const passthrough of [[], ['--dry-run']]) {
+      const result = spawnSync(
+        process.execPath,
+        [path.join(root, 'scripts', 'publish-openclaw-skills.js'), ...passthrough],
+        {
+          cwd: root,
+          encoding: 'utf8',
+          env: {
+            ...process.env,
+            PATH: `${binDir}${path.delimiter}${process.env.PATH}`,
+            CLAWHUB_CAPTURE: capturePath,
+          },
+        },
+      );
+      assert.equal(result.status, 0, result.stderr);
+    }
+    assert.equal(fs.existsSync(markerPath), false, 'shell substitution must not execute');
+
+    const calls = fs.readFileSync(capturePath, 'utf8')
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+    assert.ok(
+      calls.some((args) => args.includes(maliciousSlug) && !args.includes('--dry-run')),
+      'clawhub must receive the literal slug during a normal publish',
+    );
+    assert.ok(
+      calls.some((args) => args.includes(maliciousSlug) && args.includes('--dry-run')),
+      'clawhub must receive the literal slug and dry-run argument',
+    );
+  } finally {
+    fs.rmSync(skillPath, { recursive: true, force: true });
+    if (!markerExisted) fs.rmSync(markerPath, { force: true });
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- invoke `clawhub` with an argument vector instead of a shell command
- preserve normal publishing and `--dry-run` passthrough behavior
- add a regression test for repository-derived skill names containing shell syntax

## Security impact
The publishing helper previously constructed a shell command from generated skill directory names. Shell interpretation could execute content embedded in an untrusted name when a maintainer ran the release helper. Direct argument-vector execution keeps those names as literal `clawhub` arguments.

## Validation
- focused security regression
- OpenClaw publishing subsystem tests
- static syntax and patch-integrity checks
- rule-copy and version-consistency checks
- CI-equivalent root, Pi-extension, and MCP test suites
- post-validation mock trial for normal and `--dry-run` publishing