### PR TITLE
feat: opt-in compact ruleset for subagents (PONYTAIL_SUBAGENT_RULESET=compact)

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,6 +271,8 @@ Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`l
 
 While active, the ruleset is also injected into every subagent spawned via the Agent tool. To scope that to specific agent types (say, keep it off read-only search agents), set the `PONYTAIL_SUBAGENT_MATCHER` env var to a regex tested against the subagent's `agent_type`. It is unanchored and case-insensitive: `explore|general` matches either, `^general$` is exact, and plugin agent types look like `plugin:name`. Unset means inject into every subagent (the default); an invalid regex, or a subagent whose type the platform doesn't report, also falls back to injecting.
 
+To shrink what each subagent receives, set `PONYTAIL_SUBAGENT_RULESET=compact`: the hook then injects the `AGENTS.md` body (the same compact ruleset the instruction-only adapters use, about half the size of the full skill) instead of the full skill text. The level header is kept; the intensity table and worked examples are what gets dropped. Unset keeps the full ruleset.
+
 Cursor, Windsurf, Cline, GitHub Copilot Chat (the VS Code, JetBrains, and Visual Studio editor extension, not the standalone Copilot CLI covered under [Install](#install)), Aider, Kiro, Zed, CodeWhale, Swival, Qoder: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/), [`.qoder/rules/`](.qoder/rules/)).
 
 Kiro: copy `.kiro/steering/ponytail.md` to `~/.kiro/steering/` (global) or `.kiro/steering/` in your project.

--- a/hooks/ponytail-instructions.js
+++ b/hooks/ponytail-instructions.js
@@ -7,6 +7,9 @@ const { DEFAULT_MODE, normalizeMode, normalizePersistedMode } = require('./ponyt
 
 const INDEPENDENT_MODES = new Set(['review']);
 const SKILL_PATH = path.join(__dirname, '..', 'skills', 'ponytail', 'SKILL.md');
+// AGENTS.md is the canonical compact body (scripts/check-rule-copies.js keeps
+// the instruction-only adapters aligned with it). About half the size of SKILL.md.
+const COMPACT_PATH = path.join(__dirname, '..', 'AGENTS.md');
 
 function filterSkillBodyForMode(body, mode) {
   const effectiveMode = normalizeMode(mode) || DEFAULT_MODE;
@@ -91,8 +94,31 @@ function getPonytailInstructions(mode) {
   }
 }
 
+// Compact variant for subagents (PONYTAIL_SUBAGENT_RULESET=compact): the
+// AGENTS.md body instead of the full skill. The level header stays so a
+// subagent still knows which mode its parent is in; the intensity table and
+// worked examples are the part that is dropped. Falls back to the built-in
+// text if AGENTS.md is missing, same as the full path.
+function getCompactInstructions(mode) {
+  const configuredMode = normalizePersistedMode(mode) || DEFAULT_MODE;
+
+  if (INDEPENDENT_MODES.has(configuredMode)) {
+    return getPonytailInstructions(configuredMode);
+  }
+
+  const effectiveMode = normalizeMode(configuredMode) || DEFAULT_MODE;
+
+  try {
+    const body = fs.readFileSync(COMPACT_PATH, 'utf8').replace(/^---[\s\S]*?---\s*/, '').trim();
+    return 'PONYTAIL MODE ACTIVE — level: ' + effectiveMode + '\n\n' + body;
+  } catch (e) {
+    return getFallbackInstructions(effectiveMode);
+  }
+}
+
 module.exports = {
   filterSkillBodyForMode,
+  getCompactInstructions,
   getFallbackInstructions,
   getPonytailInstructions,
 };

--- a/hooks/ponytail-subagent.js
+++ b/hooks/ponytail-subagent.js
@@ -10,7 +10,7 @@
 // regex is unanchored and case-insensitive — "explore|general" matches either,
 // "^general$" is exact. Unset means inject into every subagent, as before.
 
-const { getPonytailInstructions } = require('./ponytail-instructions');
+const { getCompactInstructions, getPonytailInstructions } = require('./ponytail-instructions');
 const { readMode, writeHookOutput } = require('./ponytail-runtime');
 
 const mode = readMode();
@@ -20,9 +20,16 @@ if (!mode || mode === 'off') {
   process.exit(0);
 }
 
+// Payload size (opt-in): PONYTAIL_SUBAGENT_RULESET=compact injects the AGENTS.md
+// body (about half the size of the full skill) into each subagent. A parent that
+// spawns many short subagents pays the full ruleset once per spawn otherwise.
+// Unset, or any other value, keeps the full ruleset, as before.
+const compact = String(process.env.PONYTAIL_SUBAGENT_RULESET || '').trim().toLowerCase() === 'compact';
+
 function inject() {
   try {
-    writeHookOutput('SubagentStart', mode, getPonytailInstructions(mode));
+    const context = compact ? getCompactInstructions(mode) : getPonytailInstructions(mode);
+    writeHookOutput('SubagentStart', mode, context);
   } catch (e) {
     // Silent fail — a stdout error at hook exit must not surface as a hook failure.
   }

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -266,6 +266,27 @@ assert.match(
   /PONYTAIL MODE ACTIVE — level: full/,
 );
 
+// PONYTAIL_SUBAGENT_RULESET=compact → the AGENTS.md body instead of the full
+// skill: same level header, no intensity table or worked examples, and
+// measurably smaller. Any other value keeps the full ruleset.
+const fullContext = output.hookSpecificOutput.additionalContext;
+result = run('ponytail-subagent.js', { ...subEnv, PONYTAIL_SUBAGENT_RULESET: 'compact' });
+assert.equal(result.status, 0, result.stderr);
+output = JSON.parse(result.stdout);
+assert.equal(output.hookSpecificOutput.hookEventName, 'SubagentStart');
+const compactContext = output.hookSpecificOutput.additionalContext;
+assert.match(compactContext, /PONYTAIL MODE ACTIVE — level: full/);
+assert.match(compactContext, /lazy senior developer/);
+assert.doesNotMatch(compactContext, /## Intensity/, 'compact ruleset must not carry the intensity table');
+assert.ok(
+  compactContext.length < fullContext.length * 0.6,
+  `compact ruleset (${compactContext.length}) should be well under the full one (${fullContext.length})`,
+);
+result = run('ponytail-subagent.js', { ...subEnv, PONYTAIL_SUBAGENT_RULESET: 'verbose' });
+assert.equal(result.status, 0, result.stderr);
+output = JSON.parse(result.stdout);
+assert.equal(output.hookSpecificOutput.additionalContext, fullContext, 'unknown value keeps the full ruleset');
+
 // No flag → ponytail off → inject nothing (empty stdout, no failure).
 fs.unlinkSync(subFlag);
 result = run('ponytail-subagent.js', subEnv);


### PR DESCRIPTION
## What

Opt-in compact ruleset for subagents: `PONYTAIL_SUBAGENT_RULESET=compact` makes the `SubagentStart` hook inject the `AGENTS.md` body (the compact ruleset the instruction-only adapters already ship, kept aligned by `scripts/check-rule-copies.js`) instead of the full `SKILL.md` text.

Unset, or any other value, keeps today's behaviour byte for byte.

## Why

A parent session that spawns many short subagents pays the full skill (about 5.2 KB after mode filtering) on every spawn. The compact body is about 2.6 KB and carries the same rules; what it drops is the intensity table and the worked examples, which a subagent does not switch between. The level header is kept so the subagent still knows which mode its parent runs.

## How

- `hooks/ponytail-instructions.js`: `getCompactInstructions(mode)` reads `AGENTS.md`, strips any frontmatter, prefixes the same `PONYTAIL MODE ACTIVE — level: <mode>` header. Independent modes (`review`) and a missing file fall back exactly like the full path.
- `hooks/ponytail-subagent.js`: picks compact or full once at startup; the matcher logic is untouched.
- `tests/hooks.test.js`: compact output carries the header and the rules, has no `## Intensity` section, is under 60 percent of the full payload; an unknown value returns the full payload unchanged.
- `README.md`: one paragraph after the `PONYTAIL_SUBAGENT_MATCHER` note.

`node --test tests/hooks.test.js` and the adapter tests pass; `scripts/check-rule-copies.js` unchanged and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
