### PR TITLE
fix: emit hookSpecificOutput JSON on ZCode so rules reach the model

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -14,6 +14,7 @@ const {
   clearMode,
   isCodex,
   isCopilot,
+  isZcode,
   setMode,
   writeHookOutput,
 } = require('./ponytail-runtime');
@@ -26,7 +27,7 @@ const mode = getDefaultMode();
 // "off" mode — skip activation entirely, don't write flag or emit rules
 if (mode === 'off') {
   clearMode();
-  const hookOutput = (isCodex || isCopilot) ? '' : 'OK';
+  const hookOutput = (isCodex || isCopilot || isZcode) ? '' : 'OK';
   writeHookOutput('SessionStart', 'off', hookOutput);
   process.exit(0);
 }
@@ -42,7 +43,9 @@ try {
 let output = getPonytailInstructions(mode);
 
 // 3. Detect missing statusline config — nudge Claude to help set it up
-if (!isCodex && !isCopilot) try {
+// Skipped on ZCode: its statusline configuration story is unverified, and a
+// wrong pointer at Claude's settings.json would just mislead the agent.
+if (!isCodex && !isCopilot && !isZcode) try {
   let hasStatusline = false;
   if (fs.existsSync(settingsPath)) {
     // Strip UTF-8 BOM some editors prepend on Windows (breaks JSON.parse)

--- a/hooks/ponytail-runtime.js
+++ b/hooks/ponytail-runtime.js
@@ -20,6 +20,9 @@ const isCopilot = Boolean(process.env.COPILOT_PLUGIN_DATA) ||
   isVsCodeCopilotRoot(process.env.CLAUDE_PLUGIN_ROOT);
 const isCodex = !isCopilot && Boolean(process.env.PLUGIN_DATA);
 const isQoder = !isCopilot && !isCodex && Boolean(process.env.QODER_SESSION_ID);
+// ZCode injects ZCODE_APP_VERSION into every child process, hooks included.
+const isZcode = !isCopilot && !isCodex && !isQoder &&
+  Boolean(process.env.ZCODE_APP_VERSION);
 
 let stateDir = getClaudeDir();
 if (isCodex) stateDir = process.env.PLUGIN_DATA;
@@ -66,9 +69,13 @@ function writeHookOutput(event, mode, context = '') {
     process.stdout.write(JSON.stringify(output));
     return;
   }
-  if (isQoder) {
+  if (isQoder || isZcode) {
     // Qoder: hookSpecificOutput JSON, same shape as Codex minus systemMessage.
     // UserPromptSubmit additionalContext is injected into the Agent's conversation.
+    // ZCode parses hook stdout as strict JSON too — raw text fails validation
+    // and is silently discarded (#798). Unlike Qoder it has SessionStart, so
+    // activate.js handles startup injection and only the output shape differs
+    // from Claude Code.
     const output = {};
     if (context) {
       output.hookSpecificOutput = {
@@ -94,6 +101,7 @@ module.exports = {
   isCodex,
   isCopilot,
   isQoder,
+  isZcode,
   readMode,
   setMode,
   writeHookOutput,

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -37,6 +37,7 @@ delete process.env.COPILOT_PLUGIN_DATA;
 // A leaked subagent matcher would scope the inject-into-every-subagent assertions.
 delete process.env.PONYTAIL_SUBAGENT_MATCHER;
 delete process.env.QODER_SESSION_ID;
+delete process.env.ZCODE_APP_VERSION;
 
 const temp = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-hooks-'));
 // Runs on normal exit and on assertion-throw exit; force makes it idempotent.
@@ -422,6 +423,59 @@ assert.match(
   output.hookSpecificOutput.additionalContext,
   /PONYTAIL MODE ACTIVE — level: full/,
 );
+
+// Zcode: parses hook stdout as strict JSON, so the native-Claude raw-text
+// SessionStart output is silently discarded (#798). Same hookSpecificOutput
+// shape as Qoder, but Zcode does have SessionStart — activate.js injects the
+// ruleset at startup and the mode-tracker only speaks up on mode switches.
+const zcodeHome = path.join(temp, 'zcode-home');
+const zcodeState = path.join(zcodeHome, '.claude', '.ponytail-active');
+fs.mkdirSync(zcodeHome, { recursive: true });
+
+const zcodeEnv = {
+  HOME: zcodeHome,
+  USERPROFILE: zcodeHome,
+  ZCODE_APP_VERSION: '3.10.2',
+  PONYTAIL_DEFAULT_MODE: 'full',
+};
+
+// SessionStart: flag written, ruleset emitted as hookSpecificOutput JSON.
+result = run('ponytail-activate.js', zcodeEnv);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.readFileSync(zcodeState, 'utf8'), 'full');
+output = JSON.parse(result.stdout);
+assert.equal(output.systemMessage, undefined, 'Zcode must not emit systemMessage');
+assert.equal(output.hookSpecificOutput.hookEventName, 'SessionStart');
+assert.match(
+  output.hookSpecificOutput.additionalContext,
+  /PONYTAIL MODE ACTIVE — level: full/,
+);
+
+// '@ponytail lite': mode tracker updates the flag and confirms via JSON.
+result = run(
+  'ponytail-mode-tracker.js',
+  zcodeEnv,
+  JSON.stringify({ prompt: '@ponytail lite' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.readFileSync(zcodeState, 'utf8'), 'lite');
+output = JSON.parse(result.stdout);
+assert.equal(output.hookSpecificOutput.hookEventName, 'UserPromptSubmit');
+assert.match(
+  output.hookSpecificOutput.additionalContext,
+  /PONYTAIL MODE CHANGED — level: lite/,
+);
+
+// "stop ponytail": deactivates, clears flag, short confirmation as JSON.
+result = run(
+  'ponytail-mode-tracker.js',
+  zcodeEnv,
+  JSON.stringify({ prompt: 'stop ponytail' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.existsSync(zcodeState), false, 'flag must be cleared after stop ponytail');
+output = JSON.parse(result.stdout);
+assert.equal(output.hookSpecificOutput.additionalContext, 'PONYTAIL MODE OFF');
 // writeDefaultMode must merge into existing config, not overwrite it (#490).
 const mergeHome = path.join(temp, 'merge-home');
 const mergeConfigDir = path.join(mergeHome, '.config', 'ponytail');


### PR DESCRIPTION
Fixes #798

ZCode parses hook stdout as strict JSON and injects only `additionalContext`; the native-Claude raw-text output fails validation and is silently discarded, so the ponytail ruleset never reaches the model there. The hook itself runs fine — the state flag is written at session start — which is what makes the failure so quiet.

## Changes

- Detect ZCode via `ZCODE_APP_VERSION`, which ZCode injects into every child process, hooks included. A Claude-compat variable alone (`CLAUDE_PLUGIN_ROOT`) can't distinguish the two.
- Reuse the Qoder `hookSpecificOutput` shape for ZCode in `writeHookOutput`. Unlike Qoder, ZCode has SessionStart, so `ponytail-activate.js` keeps handling startup injection — only the output shape differs from Claude Code.
- Same treatment for the `off`-mode early exit in `ponytail-activate.js`, where the bare `OK` text would also fail ZCode's strict JSON parse.
- Skip the statusline nudge on ZCode: its statusline configuration story is unverified, and the nudge points the agent at Claude's `settings.json`.
- No `SubagentStart` change: ZCode drops that event at registration time, which is already the desired behavior there.
- Tests mirror the Qoder block in `tests/hooks.test.js`: SessionStart injection, mode switch, deactivation.

## Verification

- `node --test tests/hooks.test.js` and `tests/hooks-windows.test.js` pass; `scripts/check-rule-copies.js` and `scripts/check-versions.js` pass.
- Output shape follows ZCode's documented hook contract (strict-JSON stdout, `hookSpecificOutput.hookEventName` + `additionalContext`, cf. #798 diagnostics: an event-specific output naming the wrong event fails validation).
- End-to-end injection on a live ZCode 3.10.2 session: reported in a follow-up comment once confirmed (the patch is running on the reporter's install).
