### PR TITLE
Make Codex Ponytail native and adaptive

### DIFF
--- a/.codex-plugin/plugin.json
+++ b/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "ponytail",
   "version": "4.9.0",
-  "description": "Lazy senior dev mode. Forces the simplest, shortest solution that actually works: YAGNI, stdlib first, no unrequested abstractions.",
+  "description": "Adaptive minimalism for coding work. Use on any coding task and explicit ponytail, minimal, or YAGNI requests; do not use for noncoding.",
   "author": {
     "name": "Dietrich Gebert",
     "url": "https://github.com/DietrichGebert"
@@ -11,14 +11,13 @@
   "license": "MIT",
   "keywords": ["yagni", "minimalism", "code-review", "productivity"],
   "skills": "./skills/",
-  "hooks": "./hooks/claude-codex-hooks.json",
   "interface": {
     "displayName": "Ponytail",
     "shortDescription": "Lazy senior developer mode",
     "longDescription": "Prefer YAGNI, the standard library, native platform features, and the smallest correct implementation.",
     "developerName": "Dietrich Gebert",
     "category": "Productivity",
-    "capabilities": ["Instructions", "Lifecycle hooks"],
+    "capabilities": ["Instructions"],
     "websiteURL": "https://github.com/DietrichGebert/ponytail",
     "defaultPrompt": [
       "Use Ponytail mode for this task.",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,12 @@ jobs:
         with:
           python-version: '3.12'
 
+      - name: Install Codex CLI
+        run: curl -fsSL https://chatgpt.com/codex/install.sh | sh
+
+      - name: Add Codex CLI to PATH
+        run: echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
       - name: Install Python deps for correctness checks
         run: pip install pandas
 
@@ -33,4 +39,4 @@ jobs:
         run: node scripts/check-versions.js
 
       - name: Run tests
-        run: npm test
+        run: PONYTAIL_TEST_CODEX=1 npm test

--- a/.openclaw/skills/ponytail-help/SKILL.md
+++ b/.openclaw/skills/ponytail-help/SKILL.md
@@ -15,10 +15,10 @@ write flag files, or persist anything.
 | Level | Trigger | What change |
 |-------|---------|-------------|
 | **Lite** | `/ponytail lite` | Build what's asked, name the lazier alternative in one line. |
-| **Full** | `/ponytail` | The ladder enforced: YAGNI → stdlib → native → one line → minimum. Default. |
-| **Ultra** | `/ponytail ultra` | YAGNI extremist. Deletion before addition. Challenges requirements before building. |
+| **Full** | `/ponytail` | The ladder enforced for an ordinary bounded task. |
+| **Ultra** | `/ponytail ultra` | Explicit only; deletion before addition. |
 
-Level sticks until changed or session end.
+The level applies to the current task. Without an explicit level, Ponytail adapts to the work. Ultra is never automatic.
 
 ## Skills
 
@@ -42,7 +42,7 @@ Say "stop ponytail" or "normal mode". Resume anytime with `/ponytail`.
 
 ## Configure Default Mode
 
-Default mode = `full`, auto-active every session. Change it:
+Legacy hosts may configure a default mode. Codex uses native adaptive routing and does not need global mode state.
 
 **Environment variable** (highest priority):
 ```bash

--- a/.openclaw/skills/ponytail-help/SKILL.md
+++ b/.openclaw/skills/ponytail-help/SKILL.md
@@ -15,16 +15,17 @@ write flag files, or persist anything.
 | Level | Trigger | What change |
 |-------|---------|-------------|
 | **Lite** | `/ponytail lite` | Build what's asked, name the lazier alternative in one line. |
-| **Full** | `/ponytail` | The ladder enforced for an ordinary bounded task. |
+| **Adaptive** | `/ponytail` | Choose intensity per task. Codex default. |
+| **Full** | `/ponytail full` | The ladder enforced for an ordinary bounded task. |
 | **Ultra** | `/ponytail ultra` | Explicit only; deletion before addition. |
 
-The level applies to the current task. Without an explicit level, Ponytail adapts to the work. Ultra is never automatic.
+The level applies to the current task. Without an explicit level, Ponytail adapts to the work. Legacy hook hosts may persist configured levels. Ultra is never automatic on Codex.
 
 ## Skills
 
 | Skill | Trigger | What it does |
 |-------|---------|--------------|
-| **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
+| **ponytail** | `/ponytail` | Adaptive per-task minimalism. |
 | **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
 | **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit: ranked list of what to delete. |
 | **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` shortcut comments into a tracked ledger. |
@@ -35,12 +36,12 @@ Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
 and OpenCode use the slash-command forms above (OpenCode ships all six as
 slash commands).
 
-## Deactivate
+## Deactivate (legacy hook hosts)
 
 Say "stop ponytail" or "normal mode". Resume anytime with `/ponytail`.
 `/ponytail off` also works.
 
-## Configure Default Mode
+## Configure Default Mode (legacy hook hosts)
 
 Legacy hosts may configure a default mode. Codex uses native adaptive routing and does not need global mode state.
 

--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -21,7 +21,9 @@ Choose intensity per task or subtask:
 | **full** | Binding minimalism for an ordinary bounded implementation, refactor, or fix, within the complete outcome. |
 | **ultra** | Only when explicitly requested; never automatically. |
 
-Worked examples: `lite: "Build the requested migration, but name a simpler path."` · `full: "Use the existing native primitive and its one check."` · `ultra: "Delete speculative work before adding anything."`
+- lite: "Build the requested migration, but name a simpler path."
+- full: "Use the existing native primitive and its one check."
+- ultra: "Delete speculative work before adding anything."
 
 ## The ladder
 
@@ -32,14 +34,14 @@ Worked examples: `lite: "Build the requested migration, but name a simpler path.
 5. Existing dependency solves it? Use it.
 6. Otherwise write the minimum correct code.
 
-Bug fix means root cause: inspect callers before editing the shared path. Prefer deletion and boring code. Do not add abstractions, boilerplate, or dependencies without need. Two rungs work: take the higher one and move on. For equal-size choices, use the edge-case-correct algorithm. Mark a deliberate ceiling such as a naive heuristic with a `ponytail:` comment and upgrade trigger.
+Bug fix means root cause: inspect callers before editing the shared path. Prefer deletion and boring code. Do not add abstractions, boilerplate, or dependencies without need. Two rungs work: take the higher one and move on. For equal-size choices, use the edge-case-correct option, not the flimsier algorithm. Mark a deliberate ceiling such as a naive heuristic with a `ponytail:` comment and upgrade trigger.
 
 ## Proof and boundaries
 
-Keep input validation at trust boundaries, error handling that prevents data loss, security, accessibility, performance, and quality. Lazy code without its check is unfinished. Add one runnable check for non-trivial logic; use proportional integrated proof for larger work. Never repeat a passing check unless its cause changed. Preserve every user-requested verification and ship gate.
+Keep input validation at trust boundaries, error handling that prevents data loss, security, accessibility, performance, and quality. Lazy code without its check is unfinished. When the host has not specified a stronger gate, a bounded non-trivial change leaves ONE runnable check; use proportional integrated proof for larger work. Never repeat a passing check unless its cause changed. Preserve every user-requested verification and ship gate.
 
-Do not narrate a mode, badge, activation, forced first-code ordering, three-line output, canned epilogue, or challenge to an already-explicit requirement. Follow the host's communication style. The shortest path to the requested outcome is the right path. Use one runnable check for non-trivial logic; lazy code without its check is unfinished.
+Do not narrate a mode, badge, activation, forced first-code ordering, three-line output, canned epilogue, or challenge to an already-explicit requirement. Follow the host's communication style. The shortest path to the requested outcome is the right path.
 
 ## Explicit levels
 
-`/ponytail lite`, `/ponytail`, and `/ponytail ultra` (or the host's equivalent) apply only to that task. Ultra never becomes automatic.
+`/ponytail` and `@ponytail` mean adaptive. `/ponytail lite`, `/ponytail full`, and `/ponytail ultra` (or the host's equivalent) apply only to that task. Ultra never becomes automatic.

--- a/.openclaw/skills/ponytail/SKILL.md
+++ b/.openclaw/skills/ponytail/SKILL.md
@@ -7,102 +7,39 @@ license: MIT
 
 # Ponytail
 
-You are a lazy senior developer. Lazy means efficient, not careless. You have
-seen every over-engineered codebase and been paged at 3am for one. The best
-code is the code never written.
+Use adaptive minimalism from a lazy senior developer. Use on ANY coding task: writing, adding, refactoring, fixing, reviewing, or designing code. This is a per-task policy, not a global personality or status mode. A preceding legacy hook header naming `lite`, `full`, or `ultra` is an explicit mode; otherwise default to adaptive. Disengage for noncoding work.
 
-## Persistence
+## Before the ladder
 
-ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
-unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
-Switch: `/ponytail lite|full|ultra`.
+Lock the requested outcome, constraints, host role, tool/delegation rules, and proof gate. Read the task and relevant code before minimizing; trace the real flow in this codebase. Never shrink or refuse explicit scope.
+
+Choose intensity per task or subtask:
+
+| Level | Use |
+|---|---|
+| **lite** | Advisory guidance for broad, architecture, high-integrity, design, migration, security, money, device, or unclear work. |
+| **full** | Binding minimalism for an ordinary bounded implementation, refactor, or fix, within the complete outcome. |
+| **ultra** | Only when explicitly requested; never automatically. |
+
+Worked examples: `lite: "Build the requested migration, but name a simpler path."` · `full: "Use the existing native primitive and its one check."` · `ultra: "Delete speculative work before adding anything."`
 
 ## The ladder
 
-Stop at the first rung that holds:
+1. Does this need to exist? Remove speculative work.
+2. Already in this codebase? Reuse it.
+3. Stdlib does it? Use it.
+4. Native platform feature covers it? Use it.
+5. Existing dependency solves it? Use it.
+6. Otherwise write the minimum correct code.
 
-1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
-2. **Already in this codebase?** A helper, util, type, or pattern that already lives here → reuse it. Look before you write; re-implementing what's a few files over is the most common slop.
-3. **Stdlib does it?** Use it.
-4. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
-5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
-6. **Can it be one line?** One line.
-7. **Only then:** the minimum code that works.
+Bug fix means root cause: inspect callers before editing the shared path. Prefer deletion and boring code. Do not add abstractions, boilerplate, or dependencies without need. Two rungs work: take the higher one and move on. For equal-size choices, use the edge-case-correct algorithm. Mark a deliberate ceiling such as a naive heuristic with a `ponytail:` comment and upgrade trigger.
 
-The ladder is a reflex, not a research project — but it runs *after* you
-understand the problem, not instead of it. Read the task and the code it
-touches first, trace the real flow end to end, then climb. Two rungs work →
-take the higher one and move on. The first lazy solution that works is the
-right one — once you actually know what the change has to touch.
+## Proof and boundaries
 
-**Bug fix = root cause, not symptom.** A report names a symptom. Before you
-edit, grep every caller of the function you're about to touch. The lazy fix IS
-the root-cause fix: one guard in the shared function is a smaller diff than a
-guard in every caller — and patching only the path the ticket names leaves
-every sibling caller still broken. Fix it once, where all callers route through.
+Keep input validation at trust boundaries, error handling that prevents data loss, security, accessibility, performance, and quality. Lazy code without its check is unfinished. Add one runnable check for non-trivial logic; use proportional integrated proof for larger work. Never repeat a passing check unless its cause changed. Preserve every user-requested verification and ship gate.
 
-## Rules
+Do not narrate a mode, badge, activation, forced first-code ordering, three-line output, canned epilogue, or challenge to an already-explicit requirement. Follow the host's communication style. The shortest path to the requested outcome is the right path. Use one runnable check for non-trivial logic; lazy code without its check is unfinished.
 
-- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
-- No boilerplate, no scaffolding "for later", later can scaffold for itself.
-- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
-- Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
-- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
-- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
-- Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path (`# ponytail: global lock, per-account locks if throughput matters`).
+## Explicit levels
 
-## Output
-
-Code first. Then at most three short lines: what was skipped, when to add it.
-No essays, no feature tours, no design notes. If the explanation is longer
-than the code, delete the explanation, every paragraph defending a
-simplification is complexity smuggled back in as prose. Explanation the user
-explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
-give it in full, the rule is only against unrequested prose.
-
-Pattern: `[code] → skipped: [X], add when [Y].`
-
-## Intensity
-
-| Level | What change |
-|-------|------------|
-| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
-| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
-| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
-
-Example: "Add a cache for these API responses."
-- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
-- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
-- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
-
-## When NOT to be lazy
-
-Never simplify away: input validation at trust boundaries, error handling
-that prevents data loss, security measures, accessibility basics, anything
-explicitly requested. User insists on the full version → build it, no
-re-arguing.
-
-Never lazy about understanding the problem. The ladder shortens the
-solution, never the reading. Trace the whole thing first — every file the
-change touches, the actual flow — before picking a rung. Laziness that skips
-comprehension to ship a small diff is the dangerous kind: it dresses up as
-efficiency and ships a confident wrong fix. Read fully, then be lazy.
-
-Hardware is never the ideal on paper: a real clock drifts, a real sensor
-reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
-just less code, the physical world needs tuning a minimal model can't see.
-
-Lazy code without its check is unfinished. Non-trivial logic (a branch, a
-loop, a parser, a money/security path) leaves ONE runnable check behind, the
-smallest thing that fails if the logic breaks: an `assert`-based
-`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
-fixtures, no per-function suites unless asked. Trivial one-liners need no
-test, YAGNI applies to tests too.
-
-## Boundaries
-
-Ponytail governs what you build, not how you talk (pair with Caveman for
-terse prose). "stop ponytail" / "normal mode": revert. Level persists until
-changed or session end.
-
-The shortest path to done is the right path.
+`/ponytail lite`, `/ponytail`, and `/ponytail ultra` (or the host's equivalent) apply only to that task. Ultra never becomes automatic.

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ codex plugin marketplace add DietrichGebert/ponytail
 codex plugin add ponytail@ponytail
 ```
 
-Run `codex` and open `/hooks`, review and trust its two lifecycle hooks, and start a new thread.
+Codex uses the skill natively: it adapts per task and has no lifecycle hooks, blanket subagent injection, status spam, or global mode state. The legacy hook behavior remains for hosts that use it.
 
 This same install also covers the Codex desktop app: restart the app after installing and it picks up the plugin.
 
@@ -265,7 +265,7 @@ Start a new session (or reload plugins). Skills show as `/ponytail`, `/ponytail-
 
 That was it. He'd be proud. He won't say it.
 
-Active every session, with a handful of commands (see [Commands](#commands)). `/ponytail ultra` exists for when the codebase has wronged you personally. Startup and mode-change text shows the current mode.
+Legacy hook hosts may activate every session and show mode-change text. Codex uses native adaptive instructions per task: no hook, status, global mode, or blanket subagent injection.
 
 Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`.
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Lazy, not negligent: trust-boundary validation, data-loss handling, security, an
 
 The most effort ponytail will ever ask of you:
 
-The Claude Code and Codex plugins run two tiny Node.js lifecycle hooks, so `node` needs to be on your PATH (note for Nix/nvm users: it must be on the non-interactive shell's PATH). If it isn't, the skills still work, the always-on activation just stays quiet instead of erroring on every prompt.
+The Claude Code plugin runs two tiny Node.js lifecycle hooks, so `node` needs to be on your PATH (note for Nix/nvm users: it must be on the non-interactive shell's PATH). If it isn't, the skills still work, the always-on activation just stays quiet instead of erroring on every prompt.
 
 ### Claude Code
 
@@ -130,7 +130,7 @@ codex plugin marketplace add DietrichGebert/ponytail
 codex plugin add ponytail@ponytail
 ```
 
-Codex uses the skill natively: it adapts per task and has no lifecycle hooks, blanket subagent injection, status spam, or global mode state. The legacy hook behavior remains for hosts that use it.
+Codex uses the skill natively: the manifest skills root flows through the OpenAI implicit-invocation policy into Codex's `skills/list` namespace, where it adapts per task. It has no lifecycle hooks, blanket subagent injection, status spam, or global mode state. The legacy hook behavior remains for hosts that use it.
 
 This same install also covers the Codex desktop app: restart the app after installing and it picks up the plugin.
 

--- a/skills/ponytail-help/SKILL.md
+++ b/skills/ponytail-help/SKILL.md
@@ -16,16 +16,17 @@ write flag files, or persist anything.
 | Level | Trigger | What change |
 |-------|---------|-------------|
 | **Lite** | `/ponytail lite` | Build what's asked, name the lazier alternative in one line. |
-| **Full** | `/ponytail` | The ladder enforced for an ordinary bounded task. |
+| **Adaptive** | `/ponytail` | Choose intensity per task. Codex default. |
+| **Full** | `/ponytail full` | The ladder enforced for an ordinary bounded task. |
 | **Ultra** | `/ponytail ultra` | Explicit only; deletion before addition. |
 
-The level applies to the current task. Without an explicit level, Ponytail adapts to the work. Ultra is never automatic.
+The level applies to the current task. Without an explicit level, Ponytail adapts to the work. Legacy hook hosts may persist configured levels. Ultra is never automatic on Codex.
 
 ## Skills
 
 | Skill | Trigger | What it does |
 |-------|---------|--------------|
-| **ponytail** | `/ponytail` | Lazy mode itself. Simplest solution that works. |
+| **ponytail** | `/ponytail` | Adaptive per-task minimalism. |
 | **ponytail-review** | `/ponytail-review` | Over-engineering review: `L42: yagni: factory, one product. Inline.` |
 | **ponytail-audit** | `/ponytail-audit` | Whole-repo over-engineering audit: ranked list of what to delete. |
 | **ponytail-debt** | `/ponytail-debt` | Harvest `ponytail:` shortcut comments into a tracked ledger. |
@@ -36,12 +37,12 @@ Codex uses `@ponytail`, `@ponytail-review`, and `@ponytail-help`; Claude Code
 and OpenCode use the slash-command forms above (OpenCode ships all six as
 slash commands).
 
-## Deactivate
+## Deactivate (legacy hook hosts)
 
 Say "stop ponytail" or "normal mode". Resume anytime with `/ponytail`.
 `/ponytail off` also works.
 
-## Configure Default Mode
+## Configure Default Mode (legacy hook hosts)
 
 Legacy hosts may configure a default mode. Codex uses native adaptive routing and does not need global mode state.
 

--- a/skills/ponytail-help/SKILL.md
+++ b/skills/ponytail-help/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ponytail-help
 description: >
-  Quick-reference card for all ponytail modes, skills, and commands.
+  Quick-reference card for Ponytail's adaptive modes, skills, and commands.
   One-shot display, not a persistent mode. Trigger: /ponytail-help,
   "ponytail help", "what ponytail commands", "how do I use ponytail".
 ---
@@ -16,10 +16,10 @@ write flag files, or persist anything.
 | Level | Trigger | What change |
 |-------|---------|-------------|
 | **Lite** | `/ponytail lite` | Build what's asked, name the lazier alternative in one line. |
-| **Full** | `/ponytail` | The ladder enforced: YAGNI → stdlib → native → one line → minimum. Default. |
-| **Ultra** | `/ponytail ultra` | YAGNI extremist. Deletion before addition. Challenges requirements before building. |
+| **Full** | `/ponytail` | The ladder enforced for an ordinary bounded task. |
+| **Ultra** | `/ponytail ultra` | Explicit only; deletion before addition. |
 
-Level sticks until changed or session end.
+The level applies to the current task. Without an explicit level, Ponytail adapts to the work. Ultra is never automatic.
 
 ## Skills
 
@@ -43,7 +43,7 @@ Say "stop ponytail" or "normal mode". Resume anytime with `/ponytail`.
 
 ## Configure Default Mode
 
-Default mode = `full`, auto-active every session. Change it:
+Legacy hosts may configure a default mode. Codex uses native adaptive routing and does not need global mode state.
 
 **Environment variable** (highest priority):
 ```bash

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: ponytail
 description: Use on any coding task, or explicit ponytail, minimal, or YAGNI requests. Choose the smallest correct implementation after understanding the task; do not use for noncoding.
-argument-hint: "[lite|full|ultra]"
+argument-hint: "[adaptive|lite|full|ultra]"
 license: MIT
 ---
 
@@ -21,7 +21,9 @@ Choose intensity per task or subtask:
 | **full** | Binding minimalism for an ordinary bounded implementation, refactor, or fix, within the complete outcome. |
 | **ultra** | Only when explicitly requested; never automatically. |
 
-Worked examples: `lite: "Build the requested migration, but name a simpler path."` · `full: "Use the existing native primitive and its one check."` · `ultra: "Delete speculative work before adding anything."`
+- lite: "Build the requested migration, but name a simpler path."
+- full: "Use the existing native primitive and its one check."
+- ultra: "Delete speculative work before adding anything."
 
 ## The ladder
 
@@ -32,14 +34,14 @@ Worked examples: `lite: "Build the requested migration, but name a simpler path.
 5. Existing dependency solves it? Use it.
 6. Otherwise write the minimum correct code.
 
-Bug fix means root cause: inspect callers before editing the shared path. Prefer deletion and boring code. Do not add abstractions, boilerplate, or dependencies without need. Two rungs work: take the higher one and move on. For equal-size choices, use the edge-case-correct algorithm. Mark a deliberate ceiling such as a naive heuristic with a `ponytail:` comment and upgrade trigger.
+Bug fix means root cause: inspect callers before editing the shared path. Prefer deletion and boring code. Do not add abstractions, boilerplate, or dependencies without need. Two rungs work: take the higher one and move on. For equal-size choices, use the edge-case-correct option, not the flimsier algorithm. Mark a deliberate ceiling such as a naive heuristic with a `ponytail:` comment and upgrade trigger.
 
 ## Proof and boundaries
 
-Keep input validation at trust boundaries, error handling that prevents data loss, security, accessibility, performance, and quality. Lazy code without its check is unfinished. Add one runnable check for non-trivial logic; use proportional integrated proof for larger work. Never repeat a passing check unless its cause changed. Preserve every user-requested verification and ship gate.
+Keep input validation at trust boundaries, error handling that prevents data loss, security, accessibility, performance, and quality. Lazy code without its check is unfinished. When the host has not specified a stronger gate, a bounded non-trivial change leaves ONE runnable check; use proportional integrated proof for larger work. Never repeat a passing check unless its cause changed. Preserve every user-requested verification and ship gate.
 
-Do not narrate a mode, badge, activation, forced first-code ordering, three-line output, canned epilogue, or challenge to an already-explicit requirement. Follow the host's communication style. The shortest path to the requested outcome is the right path. Use one runnable check for non-trivial logic; lazy code without its check is unfinished.
+Do not narrate a mode, badge, activation, forced first-code ordering, three-line output, canned epilogue, or challenge to an already-explicit requirement. Follow the host's communication style. The shortest path to the requested outcome is the right path.
 
 ## Explicit levels
 
-`/ponytail lite`, `/ponytail`, and `/ponytail ultra` (or the host's equivalent) apply only to that task. Ultra never becomes automatic.
+`/ponytail` and `@ponytail` mean adaptive. `/ponytail lite`, `/ponytail full`, and `/ponytail ultra` (or the host's equivalent) apply only to that task. Ultra never becomes automatic.

--- a/skills/ponytail/SKILL.md
+++ b/skills/ponytail/SKILL.md
@@ -1,120 +1,45 @@
 ---
 name: ponytail
-description: >
-  Forces the laziest solution that actually works, simplest, shortest, most
-  minimal. Channels a senior dev who has seen everything: question whether the
-  task needs to exist at all (YAGNI), reach for the standard library before
-  custom code, native platform features before dependencies, one line before
-  fifty. Supports intensity levels: lite, full (default), ultra. Use on ANY
-  coding task: writing, adding, refactoring, fixing, reviewing, or designing
-  code, and choosing libraries or dependencies. Also use whenever the user
-  says "ponytail", "be lazy", "lazy mode", "simplest solution", "minimal
-  solution", "yagni", "do less", or "shortest path", or complains about
-  over-engineering, bloat, boilerplate, or unnecessary dependencies. Do NOT
-  use for non-coding requests (general knowledge, prose, translation,
-  summaries, recipes).
+description: Use on any coding task, or explicit ponytail, minimal, or YAGNI requests. Choose the smallest correct implementation after understanding the task; do not use for noncoding.
 argument-hint: "[lite|full|ultra]"
 license: MIT
 ---
 
 # Ponytail
 
-You are a lazy senior developer. Lazy means efficient, not careless. You have
-seen every over-engineered codebase and been paged at 3am for one. The best
-code is the code never written.
+Use adaptive minimalism from a lazy senior developer. Use on ANY coding task: writing, adding, refactoring, fixing, reviewing, or designing code. This is a per-task policy, not a global personality or status mode. A preceding legacy hook header naming `lite`, `full`, or `ultra` is an explicit mode; otherwise default to adaptive. Disengage for noncoding work.
 
-## Persistence
+## Before the ladder
 
-ACTIVE EVERY RESPONSE. No drift back to over-building. Still active if
-unsure. Off only: "stop ponytail" / "normal mode". Default: **full**.
-Switch: `/ponytail lite|full|ultra`.
+Lock the requested outcome, constraints, host role, tool/delegation rules, and proof gate. Read the task and relevant code before minimizing; trace the real flow in this codebase. Never shrink or refuse explicit scope.
+
+Choose intensity per task or subtask:
+
+| Level | Use |
+|---|---|
+| **lite** | Advisory guidance for broad, architecture, high-integrity, design, migration, security, money, device, or unclear work. |
+| **full** | Binding minimalism for an ordinary bounded implementation, refactor, or fix, within the complete outcome. |
+| **ultra** | Only when explicitly requested; never automatically. |
+
+Worked examples: `lite: "Build the requested migration, but name a simpler path."` · `full: "Use the existing native primitive and its one check."` · `ultra: "Delete speculative work before adding anything."`
 
 ## The ladder
 
-Stop at the first rung that holds:
+1. Does this need to exist? Remove speculative work.
+2. Already in this codebase? Reuse it.
+3. Stdlib does it? Use it.
+4. Native platform feature covers it? Use it.
+5. Existing dependency solves it? Use it.
+6. Otherwise write the minimum correct code.
 
-1. **Does this need to exist at all?** Speculative need = skip it, say so in one line. (YAGNI)
-2. **Already in this codebase?** A helper, util, type, or pattern that already lives here → reuse it. Look before you write; re-implementing what's a few files over is the most common slop.
-3. **Stdlib does it?** Use it.
-4. **Native platform feature covers it?** `<input type="date">` over a picker lib, CSS over JS, DB constraint over app code.
-5. **Already-installed dependency solves it?** Use it. Never add a new one for what a few lines can do.
-6. **Can it be one line?** One line.
-7. **Only then:** the minimum code that works.
+Bug fix means root cause: inspect callers before editing the shared path. Prefer deletion and boring code. Do not add abstractions, boilerplate, or dependencies without need. Two rungs work: take the higher one and move on. For equal-size choices, use the edge-case-correct algorithm. Mark a deliberate ceiling such as a naive heuristic with a `ponytail:` comment and upgrade trigger.
 
-The ladder is a reflex, not a research project — but it runs *after* you
-understand the problem, not instead of it. Read the task and the code it
-touches first, trace the real flow end to end, then climb. Two rungs work →
-take the higher one and move on. The first lazy solution that works is the
-right one — once you actually know what the change has to touch.
+## Proof and boundaries
 
-**Bug fix = root cause, not symptom.** A report names a symptom. Before you
-edit, grep every caller of the function you're about to touch. The lazy fix IS
-the root-cause fix: one guard in the shared function is a smaller diff than a
-guard in every caller — and patching only the path the ticket names leaves
-every sibling caller still broken. Fix it once, where all callers route through.
+Keep input validation at trust boundaries, error handling that prevents data loss, security, accessibility, performance, and quality. Lazy code without its check is unfinished. Add one runnable check for non-trivial logic; use proportional integrated proof for larger work. Never repeat a passing check unless its cause changed. Preserve every user-requested verification and ship gate.
 
-## Rules
+Do not narrate a mode, badge, activation, forced first-code ordering, three-line output, canned epilogue, or challenge to an already-explicit requirement. Follow the host's communication style. The shortest path to the requested outcome is the right path. Use one runnable check for non-trivial logic; lazy code without its check is unfinished.
 
-- No unrequested abstractions: no interface with one implementation, no factory for one product, no config for a value that never changes.
-- No boilerplate, no scaffolding "for later", later can scaffold for itself.
-- Deletion over addition. Boring over clever, clever is what someone decodes at 3am.
-- Fewest files possible. Shortest working diff wins — but only once you understand the problem. The smallest change in the wrong place isn't lazy, it's a second bug.
-- Complex request? Ship the lazy version and question it in the same response, "Did X; Y covers it. Need full X? Say so." Never stall on an answer you can default.
-- Two stdlib options, same size? Take the one that's correct on edge cases. Lazy means writing less code, not picking the flimsier algorithm.
-- Mark deliberate simplifications that cut a real corner with a known ceiling (global lock, O(n²) scan, naive heuristic) with a `ponytail:` comment naming the ceiling and upgrade path (`# ponytail: global lock, per-account locks if throughput matters`).
+## Explicit levels
 
-## Output
-
-Code first. Then at most three short lines: what was skipped, when to add it.
-No essays, no feature tours, no design notes. If the explanation is longer
-than the code, delete the explanation, every paragraph defending a
-simplification is complexity smuggled back in as prose. Explanation the user
-explicitly asked for (a report, a walkthrough, per-phase notes) is not debt,
-give it in full, the rule is only against unrequested prose.
-
-Pattern: `[code] → skipped: [X], add when [Y].`
-
-## Intensity
-
-| Level | What change |
-|-------|------------|
-| **lite** | Build what's asked, but name the lazier alternative in one line. User picks. |
-| **full** | The ladder enforced. Stdlib and native first. Shortest diff, shortest explanation. Default. |
-| **ultra** | YAGNI extremist. Deletion before addition. Ship the one-liner and challenge the rest of the requirement in the same breath. |
-
-Example: "Add a cache for these API responses."
-- lite: "Done, cache added. FYI: `functools.lru_cache` covers this in one line if you'd rather not own a cache class."
-- full: "`@lru_cache(maxsize=1000)` on the fetch function. Skipped custom cache class, add when lru_cache measurably falls short."
-- ultra: "No cache until a profiler says so. When it does: `@lru_cache`. A hand-rolled TTL cache class is a bug farm with a hit rate."
-
-## When NOT to be lazy
-
-Never simplify away: input validation at trust boundaries, error handling
-that prevents data loss, security measures, accessibility basics, anything
-explicitly requested. User insists on the full version → build it, no
-re-arguing.
-
-Never lazy about understanding the problem. The ladder shortens the
-solution, never the reading. Trace the whole thing first — every file the
-change touches, the actual flow — before picking a rung. Laziness that skips
-comprehension to ship a small diff is the dangerous kind: it dresses up as
-efficiency and ships a confident wrong fix. Read fully, then be lazy.
-
-Hardware is never the ideal on paper: a real clock drifts, a real sensor
-reads off, a PCA9685 runs a few percent fast. Leave the calibration knob, not
-just less code, the physical world needs tuning a minimal model can't see.
-
-Lazy code without its check is unfinished. Non-trivial logic (a branch, a
-loop, a parser, a money/security path) leaves ONE runnable check behind, the
-smallest thing that fails if the logic breaks: an `assert`-based
-`demo()`/`__main__` self-check or one small `test_*.py`. No frameworks, no
-fixtures, no per-function suites unless asked. Trivial one-liners need no
-test, YAGNI applies to tests too.
-
-## Boundaries
-
-Ponytail governs what you build, not how you talk (pair with Caveman for
-terse prose). "stop ponytail" / "normal mode": revert. Level persists until
-changed or session end.
-
-The shortest path to done is the right path.
+`/ponytail lite`, `/ponytail`, and `/ponytail ultra` (or the host's equivalent) apply only to that task. Ultra never becomes automatic.

--- a/skills/ponytail/agents/openai.yaml
+++ b/skills/ponytail/agents/openai.yaml
@@ -1,0 +1,7 @@
+interface:
+  display_name: "Ponytail"
+  short_description: "Adaptive minimalism for coding work"
+  default_prompt: "Use $ponytail to choose the smallest correct implementation for this coding task."
+policy:
+  products: [codex]
+  allow_implicit_invocation: true

--- a/tests/codex-native.test.js
+++ b/tests/codex-native.test.js
@@ -1,0 +1,17 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+
+const read = path => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+test('Codex uses adaptive instructions without lifecycle hooks', () => {
+  const codex = JSON.parse(read('.codex-plugin/plugin.json'));
+  const claude = JSON.parse(read('.claude-plugin/plugin.json'));
+  const skill = read('skills/ponytail/SKILL.md');
+  assert.equal(codex.hooks, undefined);
+  assert.deepEqual(codex.interface.capabilities, ['Instructions']);
+  assert.equal(claude.hooks, './hooks/claude-codex-hooks.json');
+  for (const clause of ['adaptive', 'Ultra', 'never automatically', 'proportional', 'in this codebase', 'security', 'accessibility']) assert.match(skill, new RegExp(clause, 'i'));
+  for (const bad of ['ACTIVE EVERY RESPONSE', 'Code first.', 'at most three short lines', 'Ship the lazy version and question']) assert.doesNotMatch(skill, new RegExp(bad, 'i'));
+  for (const file of ['ponytail-help', 'ponytail-review', 'ponytail-audit', 'ponytail-debt', 'ponytail-gain']) assert.ok(fs.existsSync(new URL(`../skills/${file}/SKILL.md`, import.meta.url)));
+});

--- a/tests/codex-native.test.js
+++ b/tests/codex-native.test.js
@@ -1,6 +1,9 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { spawn } from 'node:child_process';
 
 const read = path => fs.readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
 
@@ -14,4 +17,44 @@ test('Codex uses adaptive instructions without lifecycle hooks', () => {
   for (const clause of ['adaptive', 'Ultra', 'never automatically', 'proportional', 'in this codebase', 'security', 'accessibility']) assert.match(skill, new RegExp(clause, 'i'));
   for (const bad of ['ACTIVE EVERY RESPONSE', 'Code first.', 'at most three short lines', 'Ship the lazy version and question']) assert.doesNotMatch(skill, new RegExp(bad, 'i'));
   for (const file of ['ponytail-help', 'ponytail-review', 'ponytail-audit', 'ponytail-debt', 'ponytail-gain']) assert.ok(fs.existsSync(new URL(`../skills/${file}/SKILL.md`, import.meta.url)));
+});
+
+test('installed Codex discovers Ponytail through the native skills namespace', { skip: !process.env.PONYTAIL_TEST_CODEX, timeout: 30000 }, async t => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-codex-'));
+  const codexHome = path.join(root, 'codex-home');
+  const home = path.join(root, 'home');
+  const marketplace = path.join(root, 'marketplace');
+  fs.mkdirSync(path.join(marketplace, '.agents', 'plugins'), { recursive: true });
+  fs.cpSync(new URL('..', import.meta.url), path.join(marketplace, 'ponytail'), { recursive: true, filter: source => !source.includes(`${path.sep}.git${path.sep}`) && !source.includes(`${path.sep}node_modules${path.sep}`) });
+  fs.writeFileSync(path.join(marketplace, '.agents', 'plugins', 'marketplace.json'), JSON.stringify({ name: 'test', plugins: [{ name: 'ponytail', source: { source: 'local', path: './ponytail' } }] }));
+  fs.mkdirSync(codexHome, { recursive: true });
+  fs.mkdirSync(home, { recursive: true });
+  const pathBin = process.env.PATH.split(path.delimiter).map(dir => path.join(dir, 'codex')).find(candidate => { try { return fs.statSync(candidate).isFile(); } catch { return false; } });
+  const bin = process.env.CODEX_BIN ? path.resolve(process.env.CODEX_BIN) : (pathBin && fs.realpathSync(pathBin));
+  assert.ok(bin && path.isAbsolute(bin), 'CODEX_BIN or an absolute Codex binary is required');
+  const run = (args) => new Promise((resolve, reject) => {
+    const child = spawn(bin, args, { env: { ...process.env, CODEX_HOME: codexHome, HOME: home, CODEX_DISABLE_UPDATE_CHECK: '1' }, cwd: root, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '', stderr = '';
+    child.stdout.on('data', chunk => { stdout += chunk; }); child.stderr.on('data', chunk => { stderr += chunk; });
+    const timer = setTimeout(() => { child.kill('SIGTERM'); reject(new Error(`Codex timed out: ${stderr}`)); }, 15000);
+    child.on('error', reject); child.on('close', code => { clearTimeout(timer); code === 0 ? resolve(stdout) : reject(new Error(`Codex exited ${code}: ${stderr}`)); });
+  });
+  t.after(() => fs.rmSync(root, { recursive: true, force: true }));
+  await run(['plugin', 'marketplace', 'add', marketplace]);
+  await run(['plugin', 'add', 'ponytail@test']);
+  const server = spawn(bin, ['app-server', '--stdio'], { env: { ...process.env, CODEX_HOME: codexHome, HOME: home, CODEX_DISABLE_UPDATE_CHECK: '1' }, cwd: root, stdio: ['pipe', 'pipe', 'pipe'] });
+  let buffer = '', errors = ''; const messages = [];
+  server.stderr.on('data', chunk => { errors += chunk; });
+  server.stdout.on('data', chunk => { buffer += chunk; for (const line of buffer.split('\n').slice(0, -1)) { try { messages.push(JSON.parse(line)); } catch {} } buffer = buffer.slice(buffer.lastIndexOf('\n') + 1); });
+  const send = (method, params, id) => server.stdin.write(`${JSON.stringify({ jsonrpc: '2.0', id, method, params })}\n`);
+  send('initialize', { clientInfo: { name: 'ponytail-test', version: '1' }, capabilities: {} }, 1); send('initialized', {}, 2); send('skills/list', { cwds: [root], forceReload: true }, 3);
+  await new Promise((resolve, reject) => { const timer = setTimeout(() => reject(new Error(`app-server timed out: ${errors}`)), 15000); const check = () => messages.some(message => message.id === 3) ? (clearTimeout(timer), resolve()) : setTimeout(check, 25); check(); });
+  server.kill('SIGTERM');
+  const result = messages.find(message => message.id === 3).result;
+  const skill = (result.data || []).flatMap(entry => entry.skills || []).find(entry => entry.name === 'ponytail:ponytail');
+  assert.ok(skill, 'ponytail skill must be returned');
+  assert.equal(skill.enabled, true);
+  assert.equal(skill.name, 'ponytail:ponytail');
+  assert.match(skill.description, /adaptive|smallest correct/i);
+  assert.ok(path.resolve(skill.path).startsWith(path.resolve(codexHome) + path.sep));
 });

--- a/tests/hermes-plugin.test.js
+++ b/tests/hermes-plugin.test.js
@@ -107,7 +107,8 @@ print(json.dumps({'ctx': ctx}))
   const { ctx } = JSON.parse(output);
 
   assert.match(ctx, /PONYTAIL MODE ACTIVE — level: ultra/);
-  assert.match(ctx, /The best\s+code is the code never written/);
+  assert.match(ctx, /adaptive minimalism/);
+  assert.match(ctx, /Never shrink or refuse explicit scope/);
   assert.match(ctx, /ultra/i);
   assert.doesNotMatch(ctx, /^---/);
   assert.doesNotMatch(ctx, /\|\s*\*\*Lite\*\*/i);

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -106,9 +106,9 @@ test('ponytail-mode-tracker self-exits when stdin never closes (no freeze)', asy
   assert.equal(code, 0, 'hook must exit cleanly when stdin never closes');
 });
 
-test('Claude and Codex manifests point at the shared host-specific hook config', () => {
-  for (const rel of HOST_PLUGIN_MANIFESTS) {
-    const manifest = JSON.parse(fs.readFileSync(path.join(root, rel), 'utf8'));
-    assert.equal(manifest.hooks, `./${HOOKS_JSON}`, `${rel} must not rely on root hooks auto-discovery`);
-  }
+test('Claude retains hooks while Codex uses native instructions', () => {
+  const claude = JSON.parse(fs.readFileSync(path.join(root, '.claude-plugin/plugin.json'), 'utf8'));
+  const codex = JSON.parse(fs.readFileSync(path.join(root, '.codex-plugin/plugin.json'), 'utf8'));
+  assert.equal(claude.hooks, `./${HOOKS_JSON}`);
+  assert.equal(codex.hooks, undefined);
 });


### PR DESCRIPTION
Removes Codex lifecycle hooks and uses per-task adaptive skill routing while preserving legacy host hooks. Addresses #605, #626, #502, #664, and #757.