### PR TITLE
fix(hooks): ref the stdin fallback timer so it actually fires

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -117,14 +117,21 @@ function finish() {
 }
 
 process.stdin.on('data', chunk => { input += chunk; });
-process.stdin.on('end', finish);
+// Exit on 'end', not just finish(): the fallback timer below must stay ref'd
+// (see #790) so it can actually fire when stdin is stuck, and a ref'd timer
+// would otherwise keep the process alive for its full 1000ms on this normal
+// fast path.
+process.stdin.on('end', () => { finish(); process.exit(0); });
 
 // Never hang the session. On Windows, Claude Code runs this hook through a
 // PowerShell `if {}` wrapper that can swallow the piped prompt JSON, so stdin
 // 'end' never fires and the hook blocks forever — freezing the session (#443).
 // On error, or after a short fallback, process whatever arrived (recovering the
-// mode if data came without EOF) and exit. unref() keeps the timer from adding
-// latency to the normal path, where 'end' fires first. Mirrors the best-effort,
-// never-block contract the other lifecycle hooks already follow.
+// mode if data came without EOF) and exit. The fallback timer MUST stay ref'd:
+// on Windows a stuck ref'd stdin handle keeps the event loop alive, and an
+// unref'd timer competing with it is never scheduled — so the fallback was
+// dead code in exactly the #443/#790 case it exists for, and the hook hung
+// until Claude Code's external 5s watchdog killed it (#790). Mirrors the
+// best-effort, never-block contract the other lifecycle hooks already follow.
 process.stdin.on('error', () => { finish(); process.exit(0); });
-setTimeout(() => { finish(); process.exit(0); }, 1000).unref();
+setTimeout(() => { finish(); process.exit(0); }, 1000);

--- a/hooks/ponytail-subagent.js
+++ b/hooks/ponytail-subagent.js
@@ -71,7 +71,12 @@ function finish() {
 }
 
 process.stdin.on('data', chunk => { input += chunk; });
-process.stdin.on('end', finish);
+// Exit on 'end' (not just finish()) so the ref'd fallback timer below can't
+// add its full 1000ms to the normal fast path.
+process.stdin.on('end', () => { finish(); process.exit(0); });
 // Never block the session (#443): recover on stdin error or a short fallback.
+// The fallback stays ref'd: on Windows a stuck ref'd stdin keeps the loop
+// alive and an unref'd timer is never scheduled, so the hook hung to the
+// external watchdog instead of exiting at 1s (#790).
 process.stdin.on('error', () => { finish(); process.exit(0); });
-setTimeout(() => { finish(); process.exit(0); }, 1000).unref();
+setTimeout(() => { finish(); process.exit(0); }, 1000);

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -489,4 +489,48 @@ try {
   if (prevEnvModeRev === undefined) delete process.env.PONYTAIL_DEFAULT_MODE; else process.env.PONYTAIL_DEFAULT_MODE = prevEnvModeRev;
 }
 
+// Normal path stays fast: 'end' exits explicitly, so the (now ref'd) fallback
+// timer never adds its full 1000ms to a prompt that does reach EOF.
+{
+  const t0 = Date.now();
+  const r = run('ponytail-mode-tracker.js', codexEnv, JSON.stringify({ prompt: 'hi' }));
+  assert.equal(r.status, 0, r.stderr);
+  const elapsed = Date.now() - t0;
+  assert.ok(elapsed < 800, `normal path took ${elapsed}ms; ref'd fallback timer is delaying EOF exits`);
+}
+
+// #790: when stdin never emits 'end' (the Windows PowerShell wrapper can
+// swallow the piped JSON, #443), the hook must still exit on its own via the
+// 1000ms fallback timer — not hang until the host's external watchdog kills
+// it. An unref'd timer never fired in that state on Windows (a ref'd stdin
+// keeps the loop alive and the unref'd timer is never scheduled), so the
+// fallback was dead code exactly where it was needed. The timer is now ref'd;
+// the normal 'end' path exits explicitly (checked above) so the ref'd timer
+// adds no latency. spawnSync's timeout acts as the watchdog: status null /
+// SIGTERM means the hook hung past 2500ms instead of exiting on its 1s
+// fallback. The unref starvation itself is Windows-only (a POSIX pipe lets the
+// unref'd timer fire), so the ref'd-timer contract is also asserted
+// statically below.
+{
+  const hangHome = path.join(temp, 'hang-home');
+  fs.mkdirSync(hangHome, { recursive: true });
+  const hangEnv = { HOME: hangHome, USERPROFILE: hangHome, CLAUDE_CONFIG_DIR: hangHome };
+  for (const script of ['ponytail-mode-tracker.js', 'ponytail-subagent.js']) {
+    const r = spawnSync(process.execPath, [path.join(root, 'hooks', script)], {
+      env: { ...process.env, ...hangEnv },
+      timeout: 2500,
+      encoding: 'utf8',
+    });
+    assert.notEqual(r.status, null, `${script} never exited on its fallback with open stdin (#790)`);
+    assert.equal(r.status, 0, `${script} exited non-zero on its fallback (#790): ${r.stderr}`);
+    assert.ok(r.signal === null || r.signal === undefined, `${script} was watchdog-killed; 1s fallback did not fire (#790)`);
+
+    const src = fs.readFileSync(path.join(root, 'hooks', script), 'utf8');
+    assert.ok(
+      !src.includes('.unref('),
+      `${script} fallback timer must stay ref'd (#790): an unref'd timer never fires while a stuck ref'd stdin keeps the loop alive on Windows`,
+    );
+  }
+}
+
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
## Summary

Fixes #790 (claimed issues older than 5 hours, no existing PR covers it, verified against the open PR list).

The #443 mitigation added a 1s fallback timer to the stdin hooks, but called `.unref()` on it. On Windows, when the PowerShell wrapper swallows the piped prompt JSON and neither `'data'` nor `'end'` fires, the only thing keeping the event loop alive is the ref'd stdin handle itself, and an unref'd timer competing with it never gets scheduled. The fallback was dead code in exactly the case it exists for, so the hook hung until Claude Code's external 5s watchdog killed it, observed at exactly 5000ms in hook telemetry (`hook_cancelled timedOut: true`) instead of the intended ~1000ms.

## Changes

- `hooks/ponytail-mode-tracker.js`, `hooks/ponytail-subagent.js`: drop `.unref()` on the fallback timer so it fires regardless of stdin's ref state
- `'end'` handler now exits explicitly (`finish(); process.exit(0)`) so the ref'd timer adds no latency to the normal fast path

Note: the naive fix suggested in the issue (just dropping `.unref()`) alone would have added ~1s latency to every normal hook run, because nothing exited the process on `'end'` and the then-ref'd timer kept it alive. The explicit exit on `'end'` is what keeps both properties: fast normal path, working fallback.

## Verification

- Stuck-stdin repro (spawn with pipe held open, no EOF): hook self-exits at ~1060ms with correct output instead of hanging
- Normal fast path: mode-tracker 51-54ms, subagent 53-55ms with EOF
- New regression checks in `tests/hooks.test.js`:
  - fast-path timing guard (catches the latency regression)
  - runtime hang guard via spawnSync timeout
  - static ref'd-timer contract, since the unref starvation itself is Windows-only and doesn't reproduce on Linux CI; verified this check fails on the original code and passes with the fix
- Full suite: 83/84 pass; the one failure (`csv: correct pandas one-liner`) is pre-existing on clean main, pandas isn't installed in this env, CI installs it

Fixes #790