### PR TITLE
fix: keep hook stdin-fallback timer ref'd so it fires on Windows

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -123,8 +123,9 @@ process.stdin.on('end', finish);
 // PowerShell `if {}` wrapper that can swallow the piped prompt JSON, so stdin
 // 'end' never fires and the hook blocks forever — freezing the session (#443).
 // On error, or after a short fallback, process whatever arrived (recovering the
-// mode if data came without EOF) and exit. unref() keeps the timer from adding
-// latency to the normal path, where 'end' fires first. Mirrors the best-effort,
+// mode if data came without EOF) and exit. The fallback stays ref'd so it fires
+// even when stdin never ends (#790) — an unref'd timer never runs while the
+// ref'd stdin handle is open. Mirrors the best-effort,
 // never-block contract the other lifecycle hooks already follow.
 process.stdin.on('error', () => { finish(); process.exit(0); });
-setTimeout(() => { finish(); process.exit(0); }, 1000).unref();
+setTimeout(() => { finish(); process.exit(0); }, 1000);

--- a/hooks/ponytail-subagent.js
+++ b/hooks/ponytail-subagent.js
@@ -73,5 +73,6 @@ function finish() {
 process.stdin.on('data', chunk => { input += chunk; });
 process.stdin.on('end', finish);
 // Never block the session (#443): recover on stdin error or a short fallback.
+// The fallback stays ref'd so it fires even when stdin never ends (#790).
 process.stdin.on('error', () => { finish(); process.exit(0); });
-setTimeout(() => { finish(); process.exit(0); }, 1000).unref();
+setTimeout(() => { finish(); process.exit(0); }, 1000);


### PR DESCRIPTION
Fixes #790 (follow-up to #443; related open PR #806).

The 1s stdin-fallback timer in `hooks/ponytail-mode-tracker.js` was `.unref()'d`, so in exactly the stdin-swallow scenario it guards, the fallback cannot fire and the hook falls through to Claude Code's 5s hook watchdog instead of the intended ~1s worst case.

- Removed `.unref()` on the fallback timer in `ponytail-mode-tracker.js` (and updated the stale comment claiming unref avoids latency).
- Same fix in `hooks/ponytail-subagent.js`, which shares the identical fallback pattern.

Verification: `node --test tests/*.test.js` — 84/84 pass, including `ponytail-mode-tracker self-exits when stdin never closes`