### PR TITLE
fix: per-process PONYTAIL_DEFAULT_MODE=off no longer clears shared flag

### DIFF
--- a/hooks/ponytail-activate.js
+++ b/hooks/ponytail-activate.js
@@ -8,7 +8,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { getDefaultMode, getClaudeDir, isShellSafe } = require('./ponytail-config');
+const { getDefaultMode, getClaudeDir, isPerProcessOff, isShellSafe } = require('./ponytail-config');
 const { getPonytailInstructions } = require('./ponytail-instructions');
 const {
   clearMode,
@@ -23,9 +23,12 @@ const settingsPath = path.join(claudeDir, 'settings.json');
 
 const mode = getDefaultMode();
 
-// "off" mode — skip activation entirely, don't write flag or emit rules
+// "off" mode — skip activation entirely, don't write flag or emit rules.
+// A per-process PONYTAIL_DEFAULT_MODE=off exempts only this session: it must
+// not delete the shared flag other sessions' subagents read (#809). An off
+// resolved from config still clears stale state as before.
 if (mode === 'off') {
-  clearMode();
+  if (!isPerProcessOff()) clearMode();
   const hookOutput = (isCodex || isCopilot) ? '' : 'OK';
   writeHookOutput('SessionStart', 'off', hookOutput);
   process.exit(0);

--- a/hooks/ponytail-config.js
+++ b/hooks/ponytail-config.js
@@ -73,17 +73,7 @@ function getClaudeDir() {
   return process.env.CLAUDE_CONFIG_DIR || path.join(os.homedir(), '.claude');
 }
 
-function getDefaultMode() {
-  // 1. Environment variable (highest priority)
-  const envMode = process.env.PONYTAIL_DEFAULT_MODE;
-  // ponytail: a default must be a runtime level (off/lite/full/ultra); review is
-  // a session-only mode, never a valid default (#377). Validate against
-  // RUNTIME_MODES so a stray env var or config can't make review the default.
-  if (envMode && RUNTIME_MODES.includes(envMode.toLowerCase())) {
-    return envMode.toLowerCase();
-  }
-
-  // 2. Config file
+function getConfigFileDefaultMode() {
   try {
     const configPath = getConfigPath();
     // Strip UTF-8 BOM (common on Windows-saved files) so JSON.parse doesn't choke
@@ -94,9 +84,31 @@ function getDefaultMode() {
   } catch (e) {
     // Config file doesn't exist or is invalid — fall through
   }
+  return null;
+}
 
-  // 3. Default
-  return DEFAULT_MODE;
+function getDefaultMode() {
+  // 1. Environment variable (highest priority)
+  const envMode = process.env.PONYTAIL_DEFAULT_MODE;
+  // ponytail: a default must be a runtime level (off/lite/full/ultra); review is
+  // a session-only mode, never a valid default (#377). Validate against
+  // RUNTIME_MODES so a stray env var or config can't make review the default.
+  if (envMode && RUNTIME_MODES.includes(envMode.toLowerCase())) {
+    return envMode.toLowerCase();
+  }
+
+  // 2. Config file, else 3. built-in default
+  return getConfigFileDefaultMode() || DEFAULT_MODE;
+}
+
+// PONYTAIL_DEFAULT_MODE=off set for one process (e.g. a headless `claude -p`
+// worker) exempts only that session — it must not wipe the shared mode flag
+// other sessions rely on (#809). True only when the env override says off
+// while the configured default is something else; a config-file off means off
+// everywhere, so the normal clearing stands.
+function isPerProcessOff() {
+  const envMode = (process.env.PONYTAIL_DEFAULT_MODE || '').trim().toLowerCase();
+  return envMode === 'off' && getConfigFileDefaultMode() !== 'off';
 }
 
 // Silence the pi "Ponytail loaded" startup toast while keeping ponytail active.
@@ -155,6 +167,8 @@ module.exports = {
   VALID_MODES,
   RUNTIME_MODES,
   getDefaultMode,
+  getConfigFileDefaultMode,
+  isPerProcessOff,
   getConfigDir,
   getConfigPath,
   getClaudeDir,

--- a/hooks/ponytail-subagent.js
+++ b/hooks/ponytail-subagent.js
@@ -11,7 +11,14 @@
 // "^general$" is exact. Unset means inject into every subagent, as before.
 
 const { getPonytailInstructions } = require('./ponytail-instructions');
+const { isPerProcessOff } = require('./ponytail-config');
 const { readMode, writeHookOutput } = require('./ponytail-runtime');
+
+// A per-process PONYTAIL_DEFAULT_MODE=off exempts this session entirely:
+// inject nothing, without touching the shared flag other sessions use (#809).
+if (isPerProcessOff()) {
+  process.exit(0);
+}
 
 const mode = readMode();
 

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -489,4 +489,55 @@ try {
   if (prevEnvModeRev === undefined) delete process.env.PONYTAIL_DEFAULT_MODE; else process.env.PONYTAIL_DEFAULT_MODE = prevEnvModeRev;
 }
 
+// Issue #809: a per-process PONYTAIL_DEFAULT_MODE=off (e.g. one headless
+// `claude -p` worker) exempts only that session — SessionStart must not delete
+// the shared flag other sessions' subagents read.
+const sharedHome = path.join(temp, 'shared-flag-home');
+const sharedFlagDir = path.join(sharedHome, '.claude');
+const sharedFlag = path.join(sharedFlagDir, '.ponytail-active');
+fs.mkdirSync(sharedFlagDir, { recursive: true });
+fs.writeFileSync(sharedFlag, 'full');
+result = run('ponytail-activate.js', {
+  HOME: sharedHome,
+  USERPROFILE: sharedHome,
+  XDG_CONFIG_HOME: path.join(sharedHome, '.config'),
+  PONYTAIL_DEFAULT_MODE: 'off',
+});
+assert.equal(result.status, 0, result.stderr);
+assert.equal(
+  fs.readFileSync(sharedFlag, 'utf8'),
+  'full',
+  'per-process PONYTAIL_DEFAULT_MODE=off must leave the shared flag alone (#809)',
+);
+
+// ...and that exempt session's subagents stay clean too.
+result = run('ponytail-subagent.js', {
+  HOME: sharedHome,
+  USERPROFILE: sharedHome,
+  XDG_CONFIG_HOME: path.join(sharedHome, '.config'),
+  PONYTAIL_DEFAULT_MODE: 'off',
+});
+assert.equal(result.status, 0, result.stderr);
+assert.equal(result.stdout, '', 'an exempt session must inject nothing into its subagents (#809)');
+
+// A config-file off still means off everywhere: stale flags get cleared.
+const cfgHome = path.join(temp, 'config-off-home');
+const cfgDir = path.join(cfgHome, '.config', 'ponytail');
+fs.mkdirSync(cfgDir, { recursive: true });
+fs.writeFileSync(path.join(cfgDir, 'config.json'), JSON.stringify({ defaultMode: 'off' }));
+const cfgFlagDir = path.join(cfgHome, '.claude');
+fs.mkdirSync(cfgFlagDir, { recursive: true });
+fs.writeFileSync(path.join(cfgFlagDir, '.ponytail-active'), 'full');
+result = run('ponytail-activate.js', {
+  HOME: cfgHome,
+  USERPROFILE: cfgHome,
+  XDG_CONFIG_HOME: path.join(cfgHome, '.config'),
+});
+assert.equal(result.status, 0, result.stderr);
+assert.equal(
+  fs.existsSync(path.join(cfgFlagDir, '.ponytail-active')),
+  false,
+  'a config-file off must still clear a stale flag',
+);
+
 console.log('hook compatibility checks passed');


### PR DESCRIPTION
Fixes #809 (partial: the env-override blast radius; full session-scoping of /ponytail-review is a bigger redesign, deliberately out of scope).

Starting one session with `PONYTAIL_DEFAULT_MODE=off` ran `clearMode()` in `ponytail-activate.js`, deleting the shared flag and silently turning ponytail off for every other session's subagents. Reproduced per the issue: flag `full` -> env-off activate -> flag gone.

- New `isPerProcessOff()` in `hooks/ponytail-config.js`: true only when the env override says off while the configured default is something else (a config-file off still means off everywhere).
- `ponytail-activate.js` skips `clearMode()` in that case; `ponytail-subagent.js` exits silently so the exempt session injects nothing.

Verification: issue repro now leaves flag `full` (hook prints OK, exit 0); config-file off still clears stale flags; `node --test tests/*.test.js` 84/84 + `pi-extension` 23/23 pass