### PR TITLE
fix: Claude-only exec-form hooks to avoid Windows console flash

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -6,5 +6,5 @@
     "name": "Dietrich Gebert",
     "url": "https://github.com/DietrichGebert"
   },
-  "hooks": "./hooks/claude-codex-hooks.json"
+  "hooks": "./hooks/claude-hooks.json"
 }

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -8,7 +8,7 @@ to load in a given agent.
 
 | Host | Files | Notes |
 |------|-------|-------|
-| Claude Code | `.claude-plugin/plugin.json`, `commands/`, `hooks/claude-codex-hooks.json`, `hooks/` | Full plugin install with session activation, mode tracking, commands, and statusline support. |
+| Claude Code | `.claude-plugin/plugin.json`, `commands/`, `hooks/claude-hooks.json`, `hooks/` | Full plugin install with session activation, mode tracking, commands, and statusline support. |
 | Codex | `.codex-plugin/plugin.json`, `hooks/claude-codex-hooks.json`, `hooks/`, `skills/` | Plugin install with the same skills plus lifecycle hooks for activation and mode tracking. |
 | Grok Build | root `plugin.json`, `.grok-plugin/marketplace.json`, `skills/`, `commands/` | `grok plugin install DietrichGebert/ponytail --trust`, then enable. Grok can auto-invoke ponytail from its coding-task skill description; `/ponytail` makes activation explicit. Grok lifecycle hooks are not used because passive hook output cannot inject instructions. |
 | OpenCode | `.opencode/plugins/ponytail.mjs`, `.opencode/command/`, `hooks/`, `skills/` | Server plugin injects the ruleset each turn via `experimental.chat.system.transform` and persists `/ponytail` switches; reuses the shared instruction builder. |

--- a/hooks/claude-hooks.json
+++ b/hooks/claude-hooks.json
@@ -1,0 +1,44 @@
+{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume|clear|compact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js"],
+            "timeout": 5,
+            "statusMessage": "Loading ponytail mode..."
+          }
+        ]
+      }
+    ],
+    "SubagentStart": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js"],
+            "timeout": 5,
+            "statusMessage": "Loading ponytail mode..."
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js"],
+            "timeout": 5,
+            "statusMessage": "Tracking ponytail mode..."
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -15,10 +15,6 @@ const { spawn } = require('child_process');
 
 const root = path.join(__dirname, '..');
 const HOOKS_JSON = 'hooks/claude-codex-hooks.json';
-const HOST_PLUGIN_MANIFESTS = [
-  '.claude-plugin/plugin.json',
-  '.codex-plugin/plugin.json',
-];
 // PowerShell 5.1 rejects these POSIX shell guards when a host runs `command`.
 const POSIX_GUARD_SYNTAX = /\bcommand\s+-v\b|&&|\|\||>\/dev\/null|2>&1/;
 // Pull the hooks/<script> a command launches, so we can check it exists.
@@ -106,9 +102,47 @@ test('ponytail-mode-tracker self-exits when stdin never closes (no freeze)', asy
   assert.equal(code, 0, 'hook must exit cleanly when stdin never closes');
 });
 
-test('Claude and Codex manifests point at the shared host-specific hook config', () => {
-  for (const rel of HOST_PLUGIN_MANIFESTS) {
+// Issue #791: Claude Code gets its own exec-form hook config so Windows hook
+// dispatch spawns node directly (no shell, no console flash). Codex keeps the
+// shared shell-form file — its hook schema has no `args` field.
+test('Claude and Codex manifests point at a hooks config that ships', () => {
+  const expected = {
+    '.claude-plugin/plugin.json': './hooks/claude-hooks.json',
+    '.codex-plugin/plugin.json': `./${HOOKS_JSON}`,
+  };
+  for (const [rel, hooks] of Object.entries(expected)) {
     const manifest = JSON.parse(fs.readFileSync(path.join(root, rel), 'utf8'));
-    assert.equal(manifest.hooks, `./${HOOKS_JSON}`, `${rel} must not rely on root hooks auto-discovery`);
+    assert.equal(manifest.hooks, hooks, `${rel} must not rely on root hooks auto-discovery`);
+    assert.ok(
+      fs.existsSync(path.join(root, hooks.replace(/^\.\//, ''))),
+      `${rel} points at a hooks config that must ship: ${hooks}`,
+    );
+  }
+});
+
+test('claude-hooks.json uses exec form so Windows spawns node with no shell (#791)', () => {
+  const config = JSON.parse(fs.readFileSync(path.join(root, 'hooks/claude-hooks.json'), 'utf8'));
+  const entries = Object.values(config.hooks)
+    .flat()
+    .flatMap((entry) => entry.hooks);
+  assert.ok(entries.length > 0, 'expected at least one Claude hook entry');
+  for (const hook of entries) {
+    assert.ok(
+      Array.isArray(hook.args) && hook.args.length > 0,
+      `exec-form hook must carry args: ${hook.command}`,
+    );
+    assert.doesNotMatch(
+      hook.command,
+      /\s/,
+      `exec-form command must be a bare executable, not a shell string: ${hook.command}`,
+    );
+    const script = hook.args
+      .map((a) => String(a).match(HOOK_SCRIPT)?.[1])
+      .find(Boolean);
+    assert.ok(script, `exec-form args must reference a hooks/ script: ${hook.args}`);
+    assert.ok(
+      fs.existsSync(path.join(root, 'hooks', script)),
+      `exec-form hook references a missing hook script: ${script}`,
+    );
   }
 });


### PR DESCRIPTION
Fixes #791.

`hooks/claude-codex-hooks.json` is shell-form, so Claude Code on Windows spawns a shell per hook call (visible conhost flash on every prompt). Claude Code supports exec form (`command` + `args`: spawn directly, no shell), but Codex's schema has no `args` field, so the shared file can't just be converted.

- New `hooks/claude-hooks.json`: same 3 events (SessionStart/SubagentStart/UserPromptSubmit), exec form (`command: node` + `args`).
- `.claude-plugin/plugin.json` now points at it; `claude-codex-hooks.json` untouched for Codex.
- `docs/agent-portability.md` updated; `tests/hooks-windows.test.js` updated (per-manifest expectations + exec-form validation).

Verification: `node --test tests/hooks.test.js tests/hooks-windows.test.js` — 8/8 pass