### PR TITLE
feat(cursor): add native session-start hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,13 @@ Active every session, with a handful of commands (see [Commands](#commands)). `/
 
 Set the level for every new session with the `PONYTAIL_DEFAULT_MODE` env var (`lite`/`full`/`ultra`/`off`), or a `defaultMode` field in `~/.config/ponytail/config.json` (`%APPDATA%\ponytail\config.json` on Windows). The default is `full`.
 
-While active, the ruleset is also injected into every subagent spawned via the Agent tool. To scope that to specific agent types (say, keep it off read-only search agents), set the `PONYTAIL_SUBAGENT_MATCHER` env var to a regex tested against the subagent's `agent_type`. It is unanchored and case-insensitive: `explore|general` matches either, `^general$` is exact, and plugin agent types look like `plugin:name`. Unset means inject into every subagent (the default); an invalid regex, or a subagent whose type the platform doesn't report, also falls back to injecting.
+With the Claude Code/Codex lifecycle hooks, the ruleset is also injected into every subagent spawned via the Agent tool. To scope that to specific agent types (say, keep it off read-only search agents), set the `PONYTAIL_SUBAGENT_MATCHER` env var to a regex tested against the subagent's `agent_type`. It is unanchored and case-insensitive: `explore|general` matches either, `^general$` is exact, and plugin agent types look like `plugin:name`. Unset means inject into every subagent (the default); an invalid regex, or a subagent whose type the platform doesn't report, also falls back to injecting.
+
+### Cursor native hooks
+
+From a clone of this repo, run `node scripts/cursor.js install /absolute/path/to/your-project` to merge a native `sessionStart` hook into `.cursor/hooks.json`. Add `lite`, `full`, `ultra`, or `off` to configure the next new chat for that project. Back up and disable the old `.cursor/rules/ponytail.mdc` first. This adapter supports startup context only: live chat mode commands and subagent injection are unavailable, and a live Cursor delivery check is still pending. See [installation, migration, uninstall and verification](docs/cursor.md).
+
+### Instruction-only adapters
 
 Cursor, Windsurf, Cline, GitHub Copilot Chat (the VS Code, JetBrains, and Visual Studio editor extension, not the standalone Copilot CLI covered under [Install](#install)), Aider, Kiro, Zed, CodeWhale, Swival, Qoder: copy the matching rules file from this repo ([`.cursor/rules/`](.cursor/rules/), [`.windsurf/rules/`](.windsurf/rules/), [`.clinerules/`](.clinerules/), [`.github/copilot-instructions.md`](.github/copilot-instructions.md), [`AGENTS.md`](AGENTS.md), [`.kiro/steering/`](.kiro/steering/), [`.qoder/rules/`](.qoder/rules/)).
 
@@ -301,9 +307,10 @@ Which files map to which agent: [Agent portability](docs/agent-portability.md).
 | Devin CLI | `devin plugins remove ponytail` |
 | Grok Build | `grok plugin uninstall ponytail` |
 | Pi agent | `pi uninstall ponytail` |
-| Cursor / Windsurf / Cline / Qoder / etc. | Delete the copied rule file |
+| Cursor native hooks | `node scripts/cursor.js uninstall /absolute/path/to/your-project` (from the original checkout) |
+| Cursor static rule / Windsurf / Cline / Qoder / etc. | Delete the copied rule file |
 
-These remove the plugin's own files. They leave behind a small amount of state ponytail writes outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` to clean those up too. **Run it before the host remove command above** — the script is itself a plugin file, so removing the plugin first deletes it (or run it from a separate clone of this repo). It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched.
+The Cursor native installer only removes its hook entry and needs no shared-state cleanup. For the other plugin installs, removal can leave behind state ponytail wrote outside the plugin folder: the mode flag, `~/.config/ponytail/config.json`, and (if you accepted the setup nudge) a `statusLine` entry in `~/.claude/settings.json`. Run `node scripts/uninstall.js` to clean those up too. **Run it before the host remove command above** — the script is itself a plugin file, so removing the plugin first deletes it (or run it from a separate clone of this repo). It only removes the statusLine entry if it points at ponytail's own script, so a statusline you set up yourself is left untouched.
 
 ## Commands
 

--- a/docs/agent-portability.md
+++ b/docs/agent-portability.md
@@ -15,7 +15,7 @@ to load in a given agent.
 | pi | `pi-extension/`, `skills/`, `hooks/` | Package extension: injects the ruleset each turn through the shared instruction builder and registers the `/ponytail` commands. |
 | Hermes Agent | `plugin.yaml`, `__init__.py`, `skills/` | Native Hermes plugin: injects active mode through `pre_llm_call`, rewrites gateway `/ponytail-*` skill commands into agent prompts, registers `/ponytail` mode switching, and exposes bundled skills as `ponytail:<skill>`. |
 | Gemini CLI | `gemini-extension.json`, `AGENTS.md`, `commands/`, `skills/` | Extension manifest points `contextFileName` at `AGENTS.md` for always-on rules, and reuses the existing `commands/*.toml` and `skills/`, which Gemini CLI auto-discovers. The Claude/Codex hook map is not placed at Gemini's auto-discovered `hooks/hooks.json` path. |
-| Cursor | `.cursor/rules/ponytail.mdc` | Always-on project rule. |
+| Cursor | `hooks/cursor-hooks.json`, `hooks/ponytail-cursor.js`, `scripts/cursor.js`; alternatively `.cursor/rules/ponytail.mdc` | Native startup context with configurable modes (new chat required; no per-prompt or subagent injection). [Install, migration, limits and pending live check](cursor.md). Static rule remains an alternative; do not combine both. |
 | Windsurf | `.windsurf/rules/ponytail.md` | Project rule. |
 | Cline | `.clinerules/ponytail.md` | Project rule. |
 | GitHub Copilot | `.github/copilot-instructions.md` | Repository instruction file. |

--- a/docs/cursor.md
+++ b/docs/cursor.md
@@ -1,0 +1,140 @@
+# Cursor native hooks
+
+This adapter sends the shared Ponytail ruleset through Cursor's
+`sessionStart.additional_context`. Support is **startup-only**: mode changes
+require a new conversation. It does not write Claude Code or Codex state.
+The static `.cursor/rules/ponytail.mdc` remains an alternative for fixed guidance.
+
+## Install in a project
+
+Requires Node.js on Cursor's hook PATH and a Cursor host with `sessionStart`.
+Use a trusted local workspace. Hosted cloud agents currently do not run
+`sessionStart`, so this adapter does not activate there. Keep the checkout at
+the same path while installed.
+
+```sh
+git clone https://github.com/DietrichGebert/ponytail.git
+cd ponytail
+node scripts/cursor.js install /absolute/path/to/your-project
+```
+
+The installer merges the [template](../hooks/cursor-hooks.json) into the target
+project's `.cursor/hooks.json`, substituting this checkout's absolute path:
+
+```json
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      { "command": "node \"/absolute/path/to/ponytail/hooks/ponytail-cursor.js\"" }
+    ]
+  }
+}
+```
+
+Do not copy this example over existing hooks. The installer preserves unrelated
+events, entries and settings, and refuses malformed or unknown config versions.
+Reinstall replaces only this checkout's exact command; commands chained with
+other scripts remain untouched. Uninstall from the old checkout before moving
+it, to avoid duplicate registrations. User hooks in `~/.cursor/hooks.json` are
+not modified.
+
+### Migrate the always-on rule
+
+Installation refuses an existing `.cursor/rules/ponytail.mdc`. Move it outside
+the rules directory first, preserving your content. From the target project on
+macOS/Linux, for example:
+
+```sh
+mv -n .cursor/rules/ponytail.mdc .cursor/ponytail.mdc.disabled
+```
+
+Check that the move succeeded; never overwrite a pre-existing backup. On Windows,
+use your file manager. Also disable other Ponytail copies in `AGENTS.md`, user
+rules or other hook sources, keeping unrelated project instructions. The
+installer cannot discover every alternate copy. Another always-on copy can
+duplicate instructions and undermine `off`. Start a **new chat** after migration;
+old context cannot be retracted.
+
+## Modes and platform limits
+
+Without a mode argument, startup uses the shared resolver: `PONYTAIL_DEFAULT_MODE`,
+then Ponytail's `config.json` `defaultMode`, then `full`. The environment must be
+available to Cursor itself. Only `lite`, `full`, `ultra`, and `off` are defaults.
+Set a project-specific startup mode by running the installer again:
+
+```sh
+node scripts/cursor.js install /absolute/path/to/your-project lite
+node scripts/cursor.js install /absolute/path/to/your-project full
+node scripts/cursor.js install /absolute/path/to/your-project ultra
+node scripts/cursor.js install /absolute/path/to/your-project off
+```
+
+Each command adds `--mode <level>` to the hook for the **next new chat**. Shared
+defaults for other agents stay unchanged. Reinstall without a mode to return to
+shared defaults. `off` returns `{}` without instructions or state writes.
+Existing chats retain their original context.
+
+`/ponytail lite|full|ultra|off` is not a live hook command here. Subsequent prompts
+receive no reinjection. `beforeSubmitPrompt` supports only submission control;
+its `user_message` is not model context. `postToolUse.additional_context` is a
+possible later delivery point, but misses prompts without successful tools and
+the initial decisions in each turn. This adapter does not register that partial
+substitute or guarantee persistence across context compaction.
+
+`subagentStart` supports only allow/deny and a user-facing denial message.
+`preToolUse` can modify tool input, but the docs do not establish a stable Task
+prompt field or delivery to every built-in subagent. No subagent hook is
+registered; automatic subagent delivery is **unsupported and unverified**.
+
+## Uninstall
+
+```sh
+node scripts/cursor.js uninstall /absolute/path/to/your-project
+```
+
+Only this checkout's exact hook command is removed. Other hooks and settings
+remain; an empty hooks object is retained if no hooks remain. Shared defaults
+and rule backups are untouched. To return to fixed guidance, manually restore
+the backup to `.cursor/rules/ponytail.mdc` after uninstalling. Start a new chat.
+
+## Compatibility and session check
+
+```sh
+node --test tests/cursor.test.js
+```
+
+This executable check covers all defaults, environment/project overrides,
+unsupported events, malformed input, changes between startups, `off`, isolation
+from Claude/Codex state, rule migration, repeat installs and removal with other
+hooks. It proves the adapter contract, not delivery to the model.
+
+Live check record (2026-09-05): Cursor **3.19.10**, macOS arm64, was installed.
+Two attempts to access its UI through the available automation returned
+`timeoutReached`. No model-visible session result was collected. **Startup
+delivery, subsequent prompts and new-chat mode changes remain unverified in
+Cursor.** No subagent delivery claim is made. Complete this check before calling
+the adapter runtime-verified:
+
+1. Use a disposable project outside this checkout, without other Ponytail rules
+   or hooks. Install `lite` and create a fresh Agent chat.
+2. Without attaching files or asking the agent to read the installation, ask
+   which Ponytail level and mode-specific intensity instructions it received in
+   its initial context. Record its answer and Cursor version. Hook logs alone
+   do not establish delivery.
+3. Configure `ultra`, then send another prompt in that same chat and record that
+   no replacement was injected. In a fresh chat, check the `ultra` instructions;
+   repeat with `full` and `off`. An `off` chat should receive no Ponytail
+   instructions. Do not attach the previous conversation.
+4. Confirm that no subagent hook is registered. Do not infer child inheritance
+   from the parent's answer. Any future subagent mechanism needs evidence from
+   the child's own context before claiming parity.
+5. Uninstall; verify unrelated hooks still work and a fresh chat no longer
+   receives instructions from this adapter.
+
+Delivery is separate from adherence. No increased activation or adherence over
+the existing always-on rule is claimed.
+
+Contract references (checked 2026-09-05): [Cursor hooks](https://cursor.com/docs/hooks)
+(`sessionStart`, `beforeSubmitPrompt`, `postToolUse`, `subagentStart`, configuration
+and cloud limits); [Cursor rules](https://cursor.com/docs/rules).

--- a/hooks/cursor-hooks.json
+++ b/hooks/cursor-hooks.json
@@ -1,0 +1,8 @@
+{
+  "version": 1,
+  "hooks": {
+    "sessionStart": [
+      { "command": "node \"__PONYTAIL_ROOT__/hooks/ponytail-cursor.js\"" }
+    ]
+  }
+}

--- a/hooks/ponytail-cursor.js
+++ b/hooks/ponytail-cursor.js
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+// Cursor has its own JSON contract; do not route through Claude/Codex output.
+const { getDefaultMode, normalizeMode } = require('./ponytail-config');
+const { getPonytailInstructions } = require('./ponytail-instructions');
+
+let input = '';
+let done = false;
+function finish() {
+  if (done) return;
+  done = true;
+  let output = {};
+  try {
+    const data = JSON.parse(input.replace(/^\uFEFF/, ''));
+    if (data.hook_event_name === 'sessionStart') {
+      const args = process.argv.slice(2);
+      const mode = args.length === 0 ? getDefaultMode()
+        : args.length === 2 && args[0] === '--mode' ? normalizeMode(args[1]) : null;
+      if (mode && mode !== 'off') {
+        output = { additional_context: getPonytailInstructions(mode) +
+          '\n\nCursor native adapter: the level above is fixed for this conversation. ' +
+          'The generic mode-switch commands in these instructions are unavailable here. ' +
+          'To change levels or turn Ponytail off, configure the next session and start a new chat. ' +
+          'Do not claim that a chat command changed the hook configuration or that subagents received these instructions.' };
+      }
+    }
+  } catch (_) { /* Malformed input must not interrupt Cursor. */ }
+  process.stdout.write(JSON.stringify(output));
+}
+
+process.stdin.on('data', chunk => { input += chunk; });
+process.stdin.on('end', finish);
+process.stdin.on('error', () => { finish(); process.exit(0); });
+// ponytail: mirror the existing hooks' one-second ceiling for missing stdin EOF.
+setTimeout(() => { finish(); process.exit(0); }, 1000).unref();

--- a/package.json
+++ b/package.json
@@ -30,6 +30,8 @@
     ".qoder-plugin/",
     "pi-extension/",
     "scripts/uninstall.js",
+    "scripts/cursor.js",
+    "docs/cursor.md",
     "assets/",
     "LICENSE"
   ],

--- a/scripts/cursor.js
+++ b/scripts/cursor.js
@@ -1,0 +1,68 @@
+#!/usr/bin/env node
+// Project-only install: edit just this checkout's hook entry, never user hooks.
+const fs = require('fs');
+const path = require('path');
+const { isShellSafe, normalizeMode } = require('../hooks/ponytail-config');
+
+function main() {
+  const [action, project, mode, ...extra] = process.argv.slice(2);
+  if (!['install', 'uninstall'].includes(action) || !project || extra.length ||
+      (mode !== undefined && (action !== 'install' || !normalizeMode(mode)))) {
+    throw new Error('Usage: node scripts/cursor.js install <project> [lite|full|ultra|off]\n' +
+      '       node scripts/cursor.js uninstall <project>');
+  }
+  const root = path.resolve(__dirname, '..');
+  if (!isShellSafe(root)) throw new Error('Keep the Ponytail checkout in a path without shell metacharacters.');
+  const projectRoot = fs.realpathSync(project);
+  if (!fs.statSync(projectRoot).isDirectory()) throw new Error('Project must be a directory.');
+  const cursorDir = path.join(projectRoot, '.cursor');
+  const configPath = path.join(cursorDir, 'hooks.json');
+  const template = JSON.parse(fs.readFileSync(path.join(root, 'hooks/cursor-hooks.json'), 'utf8'));
+  const baseCommand = template.hooks.sessionStart[0].command.replace('__PONYTAIL_ROOT__', root);
+  const ownedCommands = new Set([baseCommand,
+    ...['lite', 'full', 'ultra', 'off'].map(level => baseCommand + ' --mode ' + level)]);
+  let config;
+  try {
+    config = JSON.parse(fs.readFileSync(configPath, 'utf8').replace(/^\uFEFF/, ''));
+  } catch (error) {
+    if (error.code !== 'ENOENT') throw error;
+    if (action === 'uninstall') return;
+    config = { version: 1, hooks: {} };
+  }
+  const isObject = value => value && typeof value === 'object' && !Array.isArray(value);
+  if (!isObject(config) || (config.version !== undefined && config.version !== 1) ||
+      (config.hooks !== undefined && !isObject(config.hooks))) {
+    throw new Error('Unsupported Cursor hooks configuration; left unchanged.');
+  }
+  const hooks = config.hooks || {};
+  const entries = hooks.sessionStart === undefined ? [] : hooks.sessionStart;
+  if (!Array.isArray(entries)) throw new Error('sessionStart must be an array; left unchanged.');
+  if (action === 'install' && fs.existsSync(path.join(cursorDir, 'rules/ponytail.mdc'))) {
+    throw new Error('Move .cursor/rules/ponytail.mdc outside the rules directory first. ' +
+      'The always-on rule duplicates hook instructions and overrides off. See docs/cursor.md.');
+  }
+  const others = entries.filter(entry => !entry || !ownedCommands.has(entry.command));
+  if (action === 'uninstall' && others.length === entries.length) return;
+  if (action === 'install') {
+    others.push({ ...template.hooks.sessionStart[0],
+      command: baseCommand + (mode === undefined ? '' : ' --mode ' + normalizeMode(mode)) });
+    config.version = 1;
+  }
+  config.hooks = hooks;
+  if (others.length) hooks.sessionStart = others;
+  else delete hooks.sessionStart;
+  fs.mkdirSync(cursorDir, { recursive: true });
+  // Write beside the destination, then rename so Cursor never reads partial JSON.
+  const temporary = configPath + '.ponytail-' + process.pid;
+  try {
+    fs.writeFileSync(temporary, JSON.stringify(config, null, 2) + '\n', { flag: 'wx' });
+    fs.renameSync(temporary, configPath);
+  } finally {
+    try { fs.unlinkSync(temporary); } catch (error) { if (error.code !== 'ENOENT') throw error; }
+  }
+  console.log(action === 'install'
+    ? 'Installed Cursor sessionStart hook. Start a new chat to apply the mode.'
+    : 'Removed this checkout\'s Cursor hook. Start a new chat; existing context is unchanged.');
+}
+
+try { main(); } catch (error) { console.error(error.message); process.exitCode = 1; }

--- a/tests/cursor.test.js
+++ b/tests/cursor.test.js
@@ -1,0 +1,133 @@
+#!/usr/bin/env node
+// Runnable contract check: node --test tests/cursor.test.js (no Cursor required).
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { spawnSync } = require('child_process');
+const { getPonytailInstructions } = require('../hooks/ponytail-instructions');
+
+const root = path.resolve(__dirname, '..');
+const adapter = path.join(root, 'hooks/ponytail-cursor.js');
+const installer = path.join(root, 'scripts/cursor.js');
+
+test('Cursor lifecycle JSON, defaults, mode changes and off stay within the supported contract', t => {
+  const home = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail-cursor-'));
+  t.after(() => fs.rmSync(home, { recursive: true, force: true }));
+  const env = { ...process.env, HOME: home, USERPROFILE: home,
+    XDG_CONFIG_HOME: home, PONYTAIL_DEFAULT_MODE: '',
+    CLAUDE_CONFIG_DIR: path.join(home, 'claude'), PLUGIN_DATA: path.join(home, 'codex') };
+  const configDir = path.join(home, 'ponytail');
+  fs.mkdirSync(configDir);
+  const config = path.join(configDir, 'config.json');
+  const run = (data, args = [], overrides = {}) => {
+    const result = spawnSync(process.execPath, [adapter, ...args], {
+      env: { ...env, ...overrides }, encoding: 'utf8', timeout: 5000,
+      input: typeof data === 'string' ? data : JSON.stringify(data),
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return JSON.parse(result.stdout);
+  };
+  const startup = { hook_event_name: 'sessionStart', session_id: 'one',
+    conversation_id: 'one', generation_id: 'first', workspace_roots: [home],
+    composer_mode: 'agent', is_background_agent: false };
+  assert.ok(run(startup).additional_context.startsWith(getPonytailInstructions('full')));
+  for (const mode of ['lite', 'full', 'ultra', 'off']) {
+    fs.writeFileSync(config, '\uFEFF' + JSON.stringify({ defaultMode: mode }));
+    const output = run(startup);
+    if (mode === 'off') assert.deepEqual(output, {});
+    else {
+      assert.deepEqual(Object.keys(output), ['additional_context']);
+      assert.ok(output.additional_context.startsWith(getPonytailInstructions(mode)));
+      assert.ok(output.additional_context.includes('fixed for this conversation'));
+      assert.ok(!output.additional_context.includes('STATUSLINE SETUP'));
+    }
+    // Editing the default cannot replace instructions already in a conversation.
+    assert.deepEqual(run({ ...startup, hook_event_name: 'beforeSubmitPrompt',
+      prompt: '/ponytail ' + mode }), {});
+    assert.deepEqual(run({ ...startup, hook_event_name: 'subagentStart',
+      subagent_type: 'generalPurpose', task: 'Check instructions' }), {});
+    assert.deepEqual(run({ ...startup, hook_event_name: 'postToolUse' }), {});
+    assert.deepEqual(run({ ...startup, hook_event_name: 'sessionEnd' }), {});
+    // Explicit project mode takes precedence without changing the shared config.
+    assert.deepEqual(run(startup, ['--mode', 'off'], { PONYTAIL_DEFAULT_MODE: 'full' }), {});
+    assert.ok(run(startup, ['--mode', 'lite']).additional_context.startsWith(getPonytailInstructions('lite')));
+    assert.equal(JSON.parse(fs.readFileSync(config, 'utf8').replace(/^\uFEFF/, '')).defaultMode, mode);
+  }
+  assert.ok(run(startup, [], { PONYTAIL_DEFAULT_MODE: 'ultra' }).additional_context.startsWith(getPonytailInstructions('ultra')));
+  for (const input of ['', '{', 'null', '[]', '42', '{}', '{"hook_event_name":"SessionStart"}']) {
+    assert.deepEqual(run(input), {});
+  }
+  assert.ok(run('\uFEFF' + JSON.stringify(startup), ['--mode', 'FULL']).additional_context);
+  assert.deepEqual(run(startup, ['--mode', 'invalid']), {});
+  assert.deepEqual(run(startup, ['unexpected']), {});
+  assert.ok(!fs.existsSync(env.CLAUDE_CONFIG_DIR));
+  assert.ok(!fs.existsSync(env.PLUGIN_DATA));
+});
+
+test('Cursor install, update and uninstall preserve unrelated hooks and rule backups', t => {
+  const project = fs.mkdtempSync(path.join(os.tmpdir(), 'ponytail cursor project '));
+  t.after(() => fs.rmSync(project, { recursive: true, force: true }));
+  const cursorDir = path.join(project, '.cursor');
+  const configPath = path.join(cursorDir, 'hooks.json');
+  const run = (action, mode, expected = 0) => {
+    const args = [installer, action, project];
+    if (mode !== undefined) args.push(mode);
+    const result = spawnSync(process.execPath, args, { encoding: 'utf8' });
+    assert.equal(result.status, expected, result.stderr);
+  };
+  run('uninstall');
+  assert.ok(!fs.existsSync(cursorDir));
+  fs.mkdirSync(path.join(cursorDir, 'rules'), { recursive: true });
+  const unrelated = { version: 1, custom: { keep: true }, hooks: {
+    sessionStart: [{ command: 'node unrelated.js', timeout: 20 },
+      { command: 'node "' + adapter + '" && echo user-owned-chain' }],
+    afterFileEdit: [{ command: './format.sh' }],
+  } };
+  const original = JSON.stringify(unrelated);
+  fs.writeFileSync(configPath, original);
+  const rulePath = path.join(cursorDir, 'rules/ponytail.mdc');
+  const rule = fs.readFileSync(path.join(root, '.cursor/rules/ponytail.mdc'), 'utf8');
+  fs.writeFileSync(rulePath, rule);
+  run('install', undefined, 1);
+  assert.equal(fs.readFileSync(configPath, 'utf8'), original);
+  assert.equal(fs.readFileSync(rulePath, 'utf8'), rule);
+  const backup = path.join(cursorDir, 'ponytail.mdc.disabled');
+  fs.renameSync(rulePath, backup);
+  for (const mode of [undefined, undefined, 'lite', 'full', 'ultra', 'off']) {
+    run('install', mode);
+    const installed = JSON.parse(fs.readFileSync(configPath, 'utf8'));
+    assert.equal(installed.hooks.sessionStart.length, 3);
+    assert.deepEqual(installed.hooks.sessionStart.slice(0, 2), unrelated.hooks.sessionStart);
+    assert.deepEqual(installed.hooks.afterFileEdit, unrelated.hooks.afterFileEdit);
+    assert.deepEqual(installed.custom, unrelated.custom);
+    const command = installed.hooks.sessionStart[2].command;
+    assert.ok(!command.includes('__PONYTAIL_ROOT__'));
+    const result = spawnSync(command, { shell: true, cwd: project, encoding: 'utf8',
+      input: '{"hook_event_name":"sessionStart"}',
+      env: { ...process.env, PONYTAIL_DEFAULT_MODE: 'full' } });
+    assert.equal(result.status, 0, result.stderr);
+    const output = JSON.parse(result.stdout);
+    if (mode === 'off') assert.deepEqual(output, {});
+    else assert.ok(output.additional_context.startsWith(getPonytailInstructions(mode || 'full')));
+  }
+  run('uninstall');
+  run('uninstall');
+  assert.deepEqual(JSON.parse(fs.readFileSync(configPath, 'utf8')), unrelated);
+  assert.equal(fs.readFileSync(backup, 'utf8'), rule);
+  assert.ok(!fs.existsSync(rulePath), 'uninstall must not silently reactivate an always-on rule');
+  for (const invalid of ['{broken', 'null', '[]', '{"version":2}',
+    '{"hooks":[]}', '{"hooks":{"sessionStart":{}}}']) {
+    fs.writeFileSync(configPath, invalid);
+    run('install', undefined, 1);
+    run('uninstall', undefined, 1);
+    assert.equal(fs.readFileSync(configPath, 'utf8'), invalid);
+  }
+  fs.writeFileSync(configPath, '{}');
+  run('install', 'review', 1);
+  assert.equal(fs.readFileSync(configPath, 'utf8'), '{}');
+  run('install', 'off');
+  run('uninstall');
+  assert.deepEqual(JSON.parse(fs.readFileSync(configPath, 'utf8')), { version: 1, hooks: {} });
+});


### PR DESCRIPTION
Refs #817.

Cursor currently offers fixed Ponytail guidance through an always-on rule. This adds a native `sessionStart` adapter that returns the shared, mode-filtered instructions through Cursor's documented `additional_context` field. `off` returns an empty JSON object. It leaves the Claude Code/Codex runtime unchanged.

The project installer merges `.cursor/hooks.json`, preserves unrelated hooks/settings, and supports an explicit `lite`, `full`, `ultra`, or `off` startup mode without changing other agents' defaults. Reinstall updates only this checkout's exact command; uninstall removes only that command. Installation refuses the old active `.cursor/rules/ponytail.mdc`; the migration guide preserves it as a backup outside the rules directory.

### Supported scope

- Mode changes apply to **new chats only**. Existing conversations retain their initial context; live `/ponytail` switches and per-prompt reinjection are unsupported.
- `beforeSubmitPrompt` and `subagentStart` have no documented context-injection output. `postToolUse.additional_context` misses prompts without successful tools and the start of each turn, so it is not used as a partial replacement. No automatic subagent delivery is claimed.
- Hosted cloud agents do not currently run `sessionStart`. The docs cover this restriction, other instruction copies that can undermine `off`, and the lack of an adherence comparison against the static rule.

### Validation

- `node --test tests/cursor.test.js` — passed. Exercises real adapter processes for all modes, overrides, unsupported events, malformed input, state isolation, installation/update/removal, rule migration, and preservation of unrelated/chained hooks.
- `npm test` — passed (root, pi extension, and MCP suites; Node.js 22.14.0 with pandas installed in an isolated Python environment).
- `node scripts/check-rule-copies.js` and `node scripts/check-versions.js` — passed.
- `npm pack --dry-run --json` — verified the adapter, template, installer and guide ship.
- `git diff --check` — passed.
