### PR TITLE
fix: do not re-inject SessionStart ruleset on compact

### DIFF
--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -2,7 +2,7 @@
   "hooks": {
     "SessionStart": [
       {
-        "matcher": "startup|resume|clear|compact",
+        "matcher": "startup|resume|clear",
         "hooks": [
           {
             "type": "command",

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -112,3 +112,23 @@ test('Claude and Codex manifests point at the shared host-specific hook config',
     assert.equal(manifest.hooks, `./${HOOKS_JSON}`, `${rel} must not rely on root hooks auto-discovery`);
   }
 });
+
+// compact is a fresh model window on Codex experimental context management
+// (and a summarization cut on Claude). Re-injecting the SessionStart ruleset
+// there makes the agent greet like a new session instead of continuing.
+test('SessionStart does not re-inject the ruleset on compact', () => {
+  const config = JSON.parse(fs.readFileSync(path.join(root, HOOKS_JSON), 'utf8'));
+  const matchers = (config.hooks.SessionStart || []).map((entry) => entry.matcher);
+  assert.ok(matchers.length > 0, 'expected a SessionStart matcher');
+  for (const matcher of matchers) {
+    assert.equal(typeof matcher, 'string');
+    assert.doesNotMatch(
+      matcher,
+      /(^|\|)\s*compact\s*(\||$)/,
+      `SessionStart matcher still includes compact: ${matcher}`,
+    );
+    assert.match(matcher, /\bstartup\b/);
+    assert.match(matcher, /\bresume\b/);
+    assert.match(matcher, /\bclear\b/);
+  }
+});


### PR DESCRIPTION
Fixes #821.

Drop `compact` from the SessionStart matcher in `hooks/claude-codex-hooks.json`. `startup`, `resume`, and `clear` are unchanged.

On Codex experimental context management, compact starts a fresh window with no prior user/assistant messages. Re-injecting `PONYTAIL MODE ACTIVE` there made the agent ask what the task was instead of continuing.

Claude `/compact` will also stop getting a SessionStart ruleset dump. `UserPromptSubmit` mode tracking and `/ponytail` still work.

## Test

`node --test tests/hooks-windows.test.js tests/hooks.test.js`

Asserts the SessionStart matcher has no `compact` token.

Unrelated on this machine: `tests/correctness.test.js` `csv: correct pandas one-liner passes` failed. That file is not in this diff.
