### PR TITLE
fix(hooks): stop interpolating plugin root into lifecycle hook shell text

### DIFF
--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
+            "command": "node -e \"require(require('node:path').join(process.env.CLAUDE_PLUGIN_ROOT, 'hooks/ponytail-activate.js'))\"",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
           }
@@ -18,7 +18,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"",
+            "command": "node -e \"require(require('node:path').join(process.env.CLAUDE_PLUGIN_ROOT, 'hooks/ponytail-subagent.js'))\"",
             "timeout": 5,
             "statusMessage": "Loading ponytail mode..."
           }
@@ -30,7 +30,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
+            "command": "node -e \"require(require('node:path').join(process.env.CLAUDE_PLUGIN_ROOT, 'hooks/ponytail-mode-tracker.js'))\"",
             "timeout": 5,
             "statusMessage": "Tracking ponytail mode..."
           }

--- a/hooks/copilot-hooks.json
+++ b/hooks/copilot-hooks.json
@@ -4,16 +4,16 @@
     "sessionStart": [
       {
         "type": "command",
-        "bash": "node \"${PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
-        "powershell": "node \"${PLUGIN_ROOT}\\hooks\\ponytail-activate.js\"",
+        "bash": "node -e \"require(require('node:path').join(process.env.PLUGIN_ROOT, 'hooks/ponytail-activate.js'))\"",
+        "powershell": "node -e \"require(require('node:path').join(process.env.PLUGIN_ROOT, 'hooks/ponytail-activate.js'))\"",
         "timeoutSec": 5
       }
     ],
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": "node \"${PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
-        "powershell": "node \"${PLUGIN_ROOT}\\hooks\\ponytail-mode-tracker.js\"",
+        "bash": "node -e \"require(require('node:path').join(process.env.PLUGIN_ROOT, 'hooks/ponytail-mode-tracker.js'))\"",
+        "powershell": "node -e \"require(require('node:path').join(process.env.PLUGIN_ROOT, 'hooks/ponytail-mode-tracker.js'))\"",
         "timeoutSec": 5
       }
     ]

--- a/tests/hooks-windows.test.js
+++ b/tests/hooks-windows.test.js
@@ -3,18 +3,26 @@
 // via PowerShell, so the shared `command` field must be cross-platform (plain
 // `node`, no bash-only syntax). commandWindows is not part of the supported
 // hooks schema on the Claude.ai plugin marketplace validator, so it is omitted
-// — ${CLAUDE_PLUGIN_ROOT} expansion and `node` work everywhere.
+// — plain `node -e "..."` works everywhere without relying on shell-specific
+// variable syntax (see #824: the command text used to embed a
+// ${CLAUDE_PLUGIN_ROOT} placeholder that the *host* substitutes textually
+// before the shell parses the command, which is unsafe if the substituted
+// value carries shell metacharacters — the fixed command instead reads
+// process.env.CLAUDE_PLUGIN_ROOT from inside Node, so the shell never
+// re-parses the plugin root at all).
 //
 // The hook also has to point at a script that actually ships in hooks/.
 
 const test = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
-const { spawn } = require('child_process');
+const { spawn, execFileSync } = require('child_process');
 
 const root = path.join(__dirname, '..');
 const HOOKS_JSON = 'hooks/claude-codex-hooks.json';
+const COPILOT_HOOKS_JSON = 'hooks/copilot-hooks.json';
 const HOST_PLUGIN_MANIFESTS = [
   '.claude-plugin/plugin.json',
   '.codex-plugin/plugin.json',
@@ -23,6 +31,10 @@ const HOST_PLUGIN_MANIFESTS = [
 const POSIX_GUARD_SYNTAX = /\bcommand\s+-v\b|&&|\|\||>\/dev\/null|2>&1/;
 // Pull the hooks/<script> a command launches, so we can check it exists.
 const HOOK_SCRIPT = /hooks[\\/]([\w.-]+\.(?:js|mjs|cjs|ps1|sh))/;
+// #824: a plugin-root placeholder textually interpolated into shell command
+// text is unsafe — the host substitutes it before the shell parses the
+// command, so a hostile install path can break out of the quoting.
+const PLUGIN_ROOT_PLACEHOLDER = /\$\{(?:CLAUDE_)?PLUGIN_ROOT\}/;
 
 // Read inside each case so a missing/malformed file fails as a clean assertion,
 // not a load-time crash.
@@ -33,11 +45,18 @@ function commandHooks() {
     .flatMap((entry) => entry.hooks);
 }
 
+function copilotCommands() {
+  const config = JSON.parse(fs.readFileSync(path.join(root, COPILOT_HOOKS_JSON), 'utf8'));
+  return Object.values(config.hooks)
+    .flat()
+    .flatMap((entry) => [entry.bash, entry.powershell]);
+}
+
 // commandWindows is not part of the supported hooks schema on the Claude.ai
 // plugin marketplace validator (#593). Since the shared `command` field
-// already runs cross-platform (Claude Code expands ${CLAUDE_PLUGIN_ROOT}
-// before the shell sees it, and VS Code Copilot ignores commandWindows and
-// runs `command` through PowerShell on Windows anyway), it is omitted.
+// already runs cross-platform (plain `node -e "..."`, no shell-specific
+// syntax, and VS Code Copilot ignores commandWindows and runs `command`
+// through PowerShell on Windows anyway), it is omitted.
 test('hooks.json omits commandWindows for marketplace validation (#593)', () => {
   for (const hook of commandHooks()) {
     assert.equal(hook.commandWindows, undefined, `hook must not use commandWindows (not supported by marketplace validator): ${hook.command}`);
@@ -111,4 +130,64 @@ test('Claude and Codex manifests point at the shared host-specific hook config',
     const manifest = JSON.parse(fs.readFileSync(path.join(root, rel), 'utf8'));
     assert.equal(manifest.hooks, `./${HOOKS_JSON}`, `${rel} must not rely on root hooks auto-discovery`);
   }
+});
+
+// #824: lifecycle hook commands must not interpolate the plugin-root
+// placeholder into shell text — a host that substitutes it textually before
+// the shell parses the command lets a hostile install path break out of the
+// quoting. Commands must instead have the invoked script read the root from
+// its own process.env.
+test('claude-codex-hooks.json commands contain no plugin-root placeholder', () => {
+  const commands = commandHooks().map((h) => h.command).filter(Boolean);
+  assert.ok(commands.length > 0, 'expected at least one shared command entry');
+  for (const cmd of commands) {
+    assert.doesNotMatch(cmd, PLUGIN_ROOT_PLACEHOLDER, `command interpolates the plugin root into shell text: ${cmd}`);
+  }
+});
+
+test('copilot-hooks.json commands contain no plugin-root placeholder', () => {
+  const commands = copilotCommands().filter(Boolean);
+  assert.ok(commands.length > 0, 'expected at least one copilot command entry');
+  for (const cmd of commands) {
+    assert.doesNotMatch(cmd, PLUGIN_ROOT_PLACEHOLDER, `command interpolates the plugin root into shell text: ${cmd}`);
+  }
+});
+
+// End-to-end proof for #824. The reported mechanism is specifically a HOST
+// that textually substitutes a ${CLAUDE_PLUGIN_ROOT}/${PLUGIN_ROOT}
+// placeholder into the command STRING itself before a shell parses it — a
+// real shell's own quoted ${VAR} expansion is safe (no re-parsing inside
+// double quotes), so invoking the raw command with the env var merely SET
+// does not reproduce the bug. This test instead performs that host-style
+// substitution explicitly, matching the threat model in the issue: before
+// the fix this created MARKER; after the fix there is no placeholder left to
+// substitute, so the hostile value never reaches shell text at all.
+test('a hostile plugin root cannot inject shell commands via host-side textual substitution (#824)', () => {
+  const isWindows = process.platform === 'win32';
+  const commands = [...commandHooks().map((h) => h.command), ...copilotCommands()].filter(Boolean);
+  assert.ok(commands.length > 0, 'expected at least one command to check');
+
+  const marker = path.join(os.tmpdir(), `ponytail-824-marker-${process.pid}`);
+  const hostileRoot = isWindows
+    ? `C:\\x" ; New-Item -ItemType File -Path "${marker}" ; "`
+    : `/tmp/x"; touch "${marker}"; echo "`;
+
+  for (const cmd of commands) {
+    fs.rmSync(marker, { force: true });
+    const substituted = cmd
+      .replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, hostileRoot)
+      .replace(/\$\{PLUGIN_ROOT\}/g, hostileRoot);
+    try {
+      if (isWindows) {
+        execFileSync('powershell', ['-NoProfile', '-Command', substituted], { stdio: 'ignore' });
+      } else {
+        execFileSync('bash', ['-c', substituted], { stdio: 'ignore' });
+      }
+    } catch (e) {
+      // Expected to fail (resolves to a bogus module path) — only whether
+      // MARKER was created matters.
+    }
+    assert.equal(fs.existsSync(marker), false, `hostile plugin root injected shell commands via: ${cmd}`);
+  }
+  fs.rmSync(marker, { force: true });
 });


### PR DESCRIPTION
Fixes #824.

## Root cause

`hooks/claude-codex-hooks.json` and `hooks/copilot-hooks.json` embedded a `${CLAUDE_PLUGIN_ROOT}` / `${PLUGIN_ROOT}` placeholder directly inside the `command`/`bash`/`powershell` shell-command text for every lifecycle hook. Hosts substitute this placeholder into the command **as text**, before a shell parses the resulting string. If the substituted install root contains shell-significant characters, the shell re-parses them, and the command can be altered rather than remaining an opaque path argument. Quoting the placeholder in the manifest doesn't help, since the vulnerable step happens one layer up, in the host's own textual substitution — the shell only ever sees the *result* of that substitution.

This is the same path-to-shell trust-boundary class previously fixed in #200 / PR #224 (the statusline setup nudge), but in the lifecycle hook manifests instead.

## Fix

The command text for every lifecycle hook (`SessionStart`, `SubagentStart`, `UserPromptSubmit` / `sessionStart`, `userPromptSubmitted`) no longer contains the plugin-root placeholder at all. Each is now a **fixed** `node -e "..."` script that reads the root from its own `process.env.CLAUDE_PLUGIN_ROOT` (Claude/Codex) or `process.env.PLUGIN_ROOT` (Copilot) and resolves the target script with `node:path`, instead of the host splicing the root into shell text:

```
node -e "require(require('node:path').join(process.env.CLAUDE_PLUGIN_ROOT, 'hooks/ponytail-activate.js'))"
```

Both env vars are confirmed to already be exposed as real process environment variables to the hook process (not just a textual template token): this codebase already reads `process.env.CLAUDE_PLUGIN_ROOT` directly in `hooks/ponytail-runtime.js` (VS Code Copilot detection, #528), and the Agent Plugins 1.0 spec documents `${PLUGIN_ROOT}` as "expanded at runtime and also set as an environment variable in the hook or server process." Since the command text is now fixed and contains no shell-agnostic-syntax difference, `copilot-hooks.json`'s `bash` and `powershell` fields collapse to the same literal string — `node -e` scripts are JS evaluated by Node, not shell syntax, so there's nothing platform-specific left to duplicate.

This also satisfies the issue's request to avoid quoting-as-a-defense: there's no substitution left in the shell string for a host to perform.

## Tests

Added to `tests/hooks-windows.test.js`:
- A static check that no command in either manifest contains the plugin-root placeholder (`${CLAUDE_PLUGIN_ROOT}` / `${PLUGIN_ROOT}`).
- An end-to-end regression test that explicitly performs the *host's* reported substitution mechanism (a real shell's own quoted `${VAR}` expansion is safe on its own — merely running the old command with the env var *set* does not reproduce the bug, since bash's native double-quote expansion never re-parses the value) with a shell-metacharacter-laden install path, and asserts no injected command executes.

Verified red→green: reverted just the two manifest files and confirmed both the placeholder check and the injection e2e test fail (the e2e test creates a marker file via injected `touch`/`New-Item`), then restored the fix and confirmed all 9 tests in the file pass, plus the full suite (`node --test tests/*.test.js`, 87/87 pass, no regressions).

## Scope note

While investigating, I grepped the rest of the codebase for the same anti-pattern (shell-string interpolation of a path). `benchmarks/correctness.js`, `benchmarks/robustness-audit.js`, and `scripts/publish-openclaw-skills.js` all build shell command strings with interpolated paths (temp files under `os.tmpdir()`, a resolved Python binary, a skill slug), but those paths are internally generated/maintainer-invoked, not an attacker-influenced install root reachable the way the lifecycle hooks are — so I left them out of this PR's scope, but flagging them here in case they're worth a follow-up look.
