### PR TITLE
fix(pi): restore branch mode after /tree navigation

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -180,15 +180,23 @@ export default function ponytailExtension(pi) {
     }
   });
 
-  pi.on("session_start", async (_event, ctx) => {
+  const restoreSessionMode = (ctx) => {
     const entries = ctx?.sessionManager?.getBranch?.() || ctx?.sessionManager?.getEntries?.() || [];
-    configuredDefaultMode = getDefaultMode();
-    hideStatus = getHideStatus();
     currentMode = resolveSessionMode(entries, configuredDefaultMode);
     syncStatus(ctx);
+  };
+
+  pi.on("session_start", async (_event, ctx) => {
+    configuredDefaultMode = getDefaultMode();
+    hideStatus = getHideStatus();
+    restoreSessionMode(ctx);
     if (!getQuietStartup()) {
       ctx?.ui?.notify?.(`Ponytail loaded: ${currentMode}`, "info");
     }
+  });
+
+  pi.on("session_tree", async (_event, ctx) => {
+    restoreSessionMode(ctx);
   });
 
   pi.on("agent_start", async (_event, ctx) => {

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -44,8 +44,10 @@ function withTempConfig(fn) {
   const tempConfigHome = mkdtempSync(join(tmpdir(), "ponytail-test-"));
   const previousXdg = process.env.XDG_CONFIG_HOME;
   const previousHide = process.env.PONYTAIL_HIDE_STATUS;
+  const previousDefault = process.env.PONYTAIL_DEFAULT_MODE;
   process.env.XDG_CONFIG_HOME = tempConfigHome;
   delete process.env.PONYTAIL_HIDE_STATUS;
+  delete process.env.PONYTAIL_DEFAULT_MODE;
 
   return Promise.resolve()
     .then(fn)
@@ -54,6 +56,8 @@ function withTempConfig(fn) {
       else process.env.XDG_CONFIG_HOME = previousXdg;
       if (previousHide === undefined) delete process.env.PONYTAIL_HIDE_STATUS;
       else process.env.PONYTAIL_HIDE_STATUS = previousHide;
+      if (previousDefault === undefined) delete process.env.PONYTAIL_DEFAULT_MODE;
+      else process.env.PONYTAIL_DEFAULT_MODE = previousDefault;
       rmSync(tempConfigHome, { recursive: true, force: true });
     });
 }
@@ -118,6 +122,44 @@ test("session_start restores latest persisted mode", async () => withTempConfig(
   const result = await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx);
 
   assert.ok(result.systemPrompt.includes("lite"));
+}));
+
+test("session_tree restores the selected branch's mode without persisting it", async () => withTempConfig(async () => {
+  const { events, commands, appendedEntries } = createPiHarness();
+  const lite = { type: "custom", customType: "ponytail-mode", data: { mode: "lite" } };
+  const off = { type: "custom", customType: "ponytail-mode", data: { mode: "off" } };
+  let branch = [lite, off];
+  const statusWrites = [];
+  const notifications = [];
+  const ctx = createCommandContext({
+    sessionManager: { getBranch: () => branch, getEntries: () => [lite, off] },
+    ui: {
+      notify: (text) => notifications.push(text),
+      setStatus: (_key, text) => statusWrites.push(text),
+      theme: { fg: (_color, text) => text },
+    },
+  });
+
+  await events.get("session_start")({ reason: "resume" }, ctx);
+  await commands.get("ponytail").handler("default ultra", ctx);
+  assert.equal(await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx), undefined);
+  const notificationCount = notifications.length;
+
+  for (const [entries, mode] of [[[lite], "lite"], [[lite, off], "off"], [[], "ultra"]]) {
+    branch = entries;
+    await events.get("session_tree")?.({ type: "session_tree" }, ctx);
+    const result = await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx);
+    if (mode === "off") {
+      assert.equal(result, undefined);
+      assert.equal(statusWrites.at(-1), "");
+    } else {
+      assert.ok(result?.systemPrompt.startsWith(`BASE\n\nPONYTAIL MODE ACTIVE — level: ${mode}\n`), `expected ${mode} instructions`);
+      assert.ok(statusWrites.at(-1).includes(mode.toUpperCase()));
+    }
+  }
+
+  assert.deepEqual(appendedEntries, [], "navigation must not append a new mode entry");
+  assert.equal(notifications.length, notificationCount, "navigation must not repeat the startup toast");
 }));
 
 test("skill alias commands delegate to Pi skill commands", async () => {


### PR DESCRIPTION
Navigating back to a `lite` branch with `/tree` after a later `/ponytail off` leaves Ponytail disabled and its status bar empty. Pi emits [`session_tree` after changing the selected branch](https://github.com/earendil-works/pi/blob/9767ba275f3e9a5ee0f5c5342249b629ab1b2282/packages/coding-agent/src/core/agent-session.ts#L3271-L3294), but the extension only restored persisted mode on `session_start`.

Reuse the existing branch-mode restoration for `session_tree` so the injected instructions and status bar follow the selected branch. Navigation does not append a mode entry or repeat the startup toast; a branch without a mode entry uses the configured default.

Validation:

- Added one regression test covering navigation to `lite`, `off`, and a branch without a mode entry, plus status updates and absence of history/toast side effects. It failed before the fix with `expected lite instructions` and passes afterward.
- `npm test`: 84 root tests, 24 Pi tests, and 3 MCP tests passed on macOS with Node 24.18.0, Python 3.14.7, and pandas installed in a local virtual environment.
- `node scripts/check-rule-copies.js`, `node scripts/check-versions.js`, and `git diff --check` passed.

The regression uses the existing Pi extension harness; no interactive Pi session was run.
