### PR TITLE
fix: harden OIDC publishing dependencies and test gate

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,19 +6,25 @@ on:
   workflow_dispatch:
 
 permissions:
-  id-token: write
   contents: read
 
 jobs:
+  test:
+    uses: ./.github/workflows/test.yml
+
   publish:
+    needs: test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
       # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22 ships npm 10.
-      - run: npm install -g npm@latest
+      - run: npm install -g npm@11.5.1
       # No token: id-token: write above lets npm authenticate via OIDC, and
       # provenance is attached automatically. access set in publishConfig.
       - run: npm publish

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,20 +3,23 @@ name: test
 on:
   push:
     branches: [main]
-    tags: ['v*']
   pull_request:
+  workflow_call:
+
+permissions:
+  contents: read
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '22'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
           python-version: '3.12'
 

--- a/tests/package-scripts.test.js
+++ b/tests/package-scripts.test.js
@@ -23,3 +23,24 @@ test('CI installs MCP dependencies before root npm test', () => {
     'MCP dependencies must be installed before the root test command runs',
   );
 });
+
+test('publishing gates OIDC access on tests and pins executable dependencies', () => {
+  const publish = fs.readFileSync(path.join(root, '.github', 'workflows', 'publish.yml'), 'utf8').replace(/\r\n/g, '\n');
+  const ci = fs.readFileSync(path.join(root, '.github', 'workflows', 'test.yml'), 'utf8').replace(/\r\n/g, '\n');
+
+  assert.match(ci, /^  workflow_call:$/m);
+  assert.doesNotMatch(ci, /^    tags:/m, 'tag tests are run by the publishing workflow');
+  assert.match(publish, /^  test:\n    uses: \.\/\.github\/workflows\/test\.yml$/m);
+  assert.match(publish, /^  publish:\n    needs: test$/m);
+  assert.match(publish, /^permissions:\n  contents: read\n\n/m);
+  assert.match(publish, /^    permissions:\n      contents: read\n      id-token: write$/m);
+  assert.equal((publish.match(/^\s*id-token:/gm) || []).length, 1);
+  assert.doesNotMatch(ci, /id-token:/);
+  assert.match(publish, /npm install -g npm@\d+\.\d+\.\d+(?:\r?\n|$)/);
+
+  for (const workflow of [publish, ci]) {
+    for (const action of workflow.matchAll(/^\s+- uses: (.+)$/gm)) {
+      assert.match(action[1], /^actions\/[\w-]+@[a-f0-9]{40} # v\d+\.\d+\.\d+\r?$/);
+    }
+  }
+});


### PR DESCRIPTION
The publishing workflow currently runs mutable Action tags and `npm@latest` with OIDC access, and a version tag can publish before tests finish. This change pins the Actions to verified release commit SHAs and npm to 11.5.1, scopes `id-token: write` to the publish job, and requires the existing test workflow to pass before publishing.

Expose `test.yml` through `workflow_call` and remove its independent tag trigger to avoid duplicate tag test runs. Pin its Actions as well and keep its permissions read-only. Add a regression check for dependency pinning, the test gate, and OIDC permission scope.

Validation:
- `npm test`: all 111 tests passed locally (Windows, Node 24.11.1).
- `node scripts/check-rule-copies.js` and `node scripts/check-versions.js`: passed.
- actionlint 1.7.12: both modified workflows passed (external shellcheck/pyflakes disabled).
- `git diff --check`: passed.
- Confirmed Action SHAs against upstream release tags and npm 11.5.1's Node engine requirements. Actual OIDC publishing was not triggered.

Closes #825.
