### PR TITLE
chore(ci): bump GitHub Actions to Node 24-compatible versions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,8 +13,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
       # Trusted publishing (OIDC) needs npm >= 11.5.1; Node 22 ships npm 10.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,13 +10,13 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: '22'
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 


### PR DESCRIPTION
## Summary

Bumps `actions/checkout`, `actions/setup-node`, and `actions/setup-python` to Node 24-compatible majors across both GitHub Actions workflows (`publish.yml`, `test.yml`). These versions run natively on the current runner runtime (Node 24) instead of relying on a compatibility override.

Detected with driftcheck.

## Workflow files changed

- `.github/workflows/publish.yml` — `actions/checkout@v4` to `v5`, `actions/setup-node@v4` to `v5`
- `.github/workflows/test.yml` — `actions/checkout@v4` to `v5`, `actions/setup-node@v4` to `v5`, `actions/setup-python@v5` to `v6`

## Verification

- YAML syntax validated locally (`yaml.safe_load` passes on both files).
- No code changes — action major bumps with identical `with:` inputs (`node-version: '22'`, `python-version: '3.12'` are unchanged and supported by the new majors).
- Grepped the repo for hardcoded action-version assertions in tests — none found, so no test updates needed.
- CI on this PR is the verification for the workflow change itself.

## Scope

Out of scope: `node-version` itself (stays `'22'` — a runtime bump is a separate decision), `FUNDING.yml`, dependabot config.
