### PR TITLE
feat(pi-extension): render ponytail status in the omp status line

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -67,25 +67,67 @@ export default function ponytailExtension(pi) {
   let isActive = false;
   let lastCtx = null;
 
-  // -- Status bar --
+  // -- Status line --
+  // "🐴 <mode>" — accent while the agent runs, muted when idle. null hides.
+  function ponytailStatus(themeOf) {
+    if (currentMode === "off" || hideStatus) return null;
+    const plain = "🐴 " + currentMode;
+    try {
+      const theme = themeOf?.();
+      return theme?.fg ? "🐴 " + theme.fg(isActive ? "accent" : "muted", currentMode) : plain;
+    } catch {
+      return plain; // theme proxy can throw before initTheme
+    }
+  }
+
+  // Register a real segment in the host's status-line registry — pi.pi is the
+  // host's own module namespace, so this is the object the bar renders from —
+  // and ride the built-in presets so no user config is needed. The ascii
+  // preset stays emoji-free.
+  // Custom-preset hosts bypass the preset tables (they read
+  // statusLine.leftSegments from settings), so also append via a runtime
+  // override — override() is explicitly non-persisted; set() would write the
+  // user's config file.
+  // ponytail: unofficial seam — omp has no extension-segment API as of
+  // 17.4.0; SEGMENTS/presets/settings.override are root exports, so this
+  // breaks if omp stops exporting them. Replace when an official API ships.
+  const hostSegments = pi.pi?.SEGMENTS;
+  if (hostSegments && pi.pi?.STATUS_LINE_PRESETS && !hostSegments.ponytail) {
+    hostSegments.ponytail = {
+      id: "ponytail",
+      render: () => {
+        const text = ponytailStatus(() => pi.pi.theme);
+        return { content: text ?? "", visible: text !== null };
+      },
+    };
+    for (const [name, preset] of Object.entries(pi.pi.STATUS_LINE_PRESETS)) {
+      if (name === "ascii" || !Array.isArray(preset?.leftSegments) || preset.leftSegments.includes("ponytail")) continue;
+      const after = preset.leftSegments.indexOf("mode");
+      preset.leftSegments.splice(after === -1 ? preset.leftSegments.length : after + 1, 0, "ponytail");
+    }
+    const hostSettings = pi.pi.settings;
+    if (
+      typeof hostSettings?.isConfigured === "function" &&
+      hostSettings.get("statusLine.preset") === "custom" &&
+      hostSettings.isConfigured("statusLine.leftSegments")
+    ) {
+      const segments = hostSettings.get("statusLine.leftSegments");
+      if (Array.isArray(segments) && segments.length > 0 && !segments.includes("ponytail")) {
+        const after = segments.indexOf("mode");
+        const next = [...segments.slice(0, after + 1), "ponytail", ...segments.slice(after + 1)];
+        hostSettings.override("statusLine.leftSegments", after === -1 ? [...segments, "ponytail"] : next);
+      }
+    }
+  }
+
   function syncStatus(ctx) {
     if (ctx) lastCtx = ctx;
     const c = ctx || lastCtx;
-    // ponytail: hide the indicator but keep the ruleset active (#324).
-    if (hideStatus) return;
     if (!c?.ui?.setStatus) return;
-    // ponytail: try/catch guards against pi-web theme proxy throwing before initTheme
-    let theme;
-    try { theme = c.ui.theme; if (!theme?.fg) return; } catch { return; }
-    if (currentMode === "off") {
-      c.ui.setStatus("ponytail", "");
-      return;
-    }
-    const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥" };
-    const icon = levelIcons[currentMode] || "";
-    const label = currentMode.toUpperCase();
-    const indicator = isActive ? theme.fg("accent", "●") : theme.fg("dim", "○");
-    c.ui.setStatus("ponytail", indicator + " 🐴 " + theme.fg("muted", "ponytail: ") + theme.fg("text", icon + " " + label));
+    // Segment hosts render lazily from the registry above; this only nudges a
+    // repaint and clears any legacy hook line. Legacy hosts get a hook line.
+    const text = hostSegments ? undefined : ponytailStatus(() => c.ui?.theme);
+    c.ui.setStatus("ponytail", text ?? undefined);
   }
 
   const setMode = (mode, ctx) => {

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -6,11 +6,12 @@ import test from "node:test";
 
 import ponytailExtension from "../index.js";
 
-function createPiHarness() {
+function createPiHarness({ host = true, settings } = {}) {
   const events = new Map();
   const commands = new Map();
   const appendedEntries = [];
   const sentUserMessages = [];
+  const colors = [];
 
   const pi = {
     on(eventName, handler) {
@@ -27,8 +28,22 @@ function createPiHarness() {
     },
   };
 
+  if (host) {
+    // Minimal stand-in for the omp host namespace surface ponytail uses.
+    pi.pi = {
+      SEGMENTS: {},
+      STATUS_LINE_PRESETS: {
+        default: { leftSegments: ["pi", "model", "mode", "path"] },
+        minimal: { leftSegments: ["path", "git"] },
+        ascii: { leftSegments: ["path"] },
+      },
+      theme: { fg: (color, text) => { colors.push(color); return text; } },
+      settings,
+    };
+  }
+
   ponytailExtension(pi);
-  return { events, commands, appendedEntries, sentUserMessages };
+  return { events, commands, appendedEntries, sentUserMessages, colors, host: pi.pi };
 }
 
 function createCommandContext(overrides = {}) {
@@ -163,24 +178,92 @@ test("a request mentioning normal mode stays active", async () => withTempConfig
   assert.match(result.systemPrompt, /PONYTAIL MODE ACTIVE/);
 }));
 
-test("status bar renders the mode and flips active on agent_start", async () => withTempConfig(async () => {
-  const { events } = createPiHarness();
+test("status chip renders in the host status line and flips color on agent_start", async () => withTempConfig(async () => {
+  const { events, colors, host } = createPiHarness();
   const statusWrites = [];
   const ctx = createCommandContext({
     sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "ultra" } }] },
-    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_color, text) => text } },
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_c, t) => t } },
+  });
+
+  await events.get("session_start")({ reason: "resume" }, ctx);
+  const segment = host.SEGMENTS.ponytail;
+  assert.ok(segment, "ponytail segment must be registered in the host registry");
+  assert.equal(segment.render().content, "🐴 ultra");
+  assert.match(colors.at(-1), /muted/);
+
+  await events.get("agent_start")({}, ctx);
+  assert.equal(segment.render().content, "🐴 ultra");
+  assert.match(colors.at(-1), /accent/);
+
+  // The bar owns the indicator now: hook line only receives repaint nudges.
+  assert.ok(statusWrites.length > 0);
+  assert.ok(statusWrites.every((write) => write.text === undefined));
+}));
+
+test("status chip rides the built-in presets (except ascii)", () => {
+  const { host } = createPiHarness();
+
+  assert.deepEqual(host.STATUS_LINE_PRESETS.default.leftSegments, ["pi", "model", "mode", "ponytail", "path"]);
+  assert.deepEqual(host.STATUS_LINE_PRESETS.minimal.leftSegments, ["path", "git", "ponytail"]);
+  assert.deepEqual(host.STATUS_LINE_PRESETS.ascii.leftSegments, ["path"]);
+});
+
+test("custom-preset hosts get the chip via a non-persisted settings override", () => {
+  const values = { "statusLine.preset": "custom", "statusLine.leftSegments": ["model", "mode", "git", "path"] };
+  const overrides = {};
+  const settings = {
+    get: (path) => values[path],
+    isConfigured: (path) => path in values,
+    override: (path, value) => {
+      overrides[path] = value;
+      values[path] = value;
+    },
+  };
+
+  createPiHarness({ settings });
+
+  assert.deepEqual(overrides["statusLine.leftSegments"], ["model", "mode", "ponytail", "git", "path"]);
+  assert.deepEqual(settings.get("statusLine.leftSegments"), ["model", "mode", "ponytail", "git", "path"]);
+});
+
+test("preset hosts never touch settings", () => {
+  const values = { "statusLine.preset": "default", "statusLine.leftSegments": ["model"] };
+  const overrides = {};
+  const settings = {
+    get: (path) => values[path],
+    isConfigured: (path) => path in values,
+    override: (path, value) => {
+      overrides[path] = value;
+      values[path] = value;
+    },
+  };
+
+  createPiHarness({ settings });
+
+  assert.deepEqual(overrides, {});
+  assert.deepEqual(settings.get("statusLine.leftSegments"), ["model"]);
+});
+
+test("hosts without the status-line registry fall back to the hook line", async () => withTempConfig(async () => {
+  const { events, colors } = createPiHarness({ host: false });
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "ultra" } }] },
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (color, text) => { colors.push(color); return text; } } },
   });
 
   await events.get("session_start")({ reason: "resume" }, ctx);
   await events.get("agent_start")({}, ctx);
 
-  assert.equal(statusWrites.at(-2).key, "ponytail");
-  assert.match(statusWrites.at(-2).text, /○.*ULTRA/);
-  assert.match(statusWrites.at(-1).text, /●.*ULTRA/);
+  assert.equal(statusWrites.at(-2).text, "🐴 ultra");
+  assert.match(colors.at(-2), /muted/);
+  assert.equal(statusWrites.at(-1).text, "🐴 ultra");
+  assert.match(colors.at(-1), /accent/);
 }));
 
-test("status bar stays silent when ui lacks a theme", async () => withTempConfig(async () => {
-  const { events } = createPiHarness();
+test("hook-line fallback renders unstyled when the host theme is unavailable", async () => withTempConfig(async () => {
+  const { events } = createPiHarness({ host: false });
   const calls = [];
   const ctx = createCommandContext({
     sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "ultra" } }] },
@@ -188,56 +271,51 @@ test("status bar stays silent when ui lacks a theme", async () => withTempConfig
   });
 
   await events.get("session_start")({ reason: "resume" }, ctx);
-  await events.get("agent_start")({}, ctx);
 
-  assert.deepEqual(calls, []);
+  assert.deepEqual(calls, ["🐴 ultra"]);
 }));
 
-test("PONYTAIL_HIDE_STATUS hides the indicator but keeps ponytail active (#324)", async () => withTempConfig(async () => {
+test("PONYTAIL_HIDE_STATUS hides the chip but keeps ponytail active (#324)", async () => withTempConfig(async () => {
   process.env.PONYTAIL_HIDE_STATUS = "1";
-  const { events } = createPiHarness();
-  const statusWrites = [];
+  const { events, host } = createPiHarness();
   const ctx = createCommandContext({
     sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "ultra" } }] },
-    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_c, t) => t } },
+    ui: { notify() {}, setStatus: () => {} },
   });
 
   await events.get("session_start")({ reason: "resume" }, ctx);
   await events.get("agent_start")({}, ctx);
   const injected = await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx);
 
-  assert.deepEqual(statusWrites, [], "status bar must not be drawn when hidden");
+  assert.equal(host.SEGMENTS.ponytail.render().visible, false, "chip must hide while the ruleset stays active");
   assert.match(injected.systemPrompt, /PONYTAIL MODE ACTIVE/, "ruleset must still inject while status is hidden");
 }));
 
-test("config.hideStatus hides the indicator but keeps ponytail active (#324)", async () => withTempConfig(async () => {
+test("config.hideStatus hides the chip but keeps ponytail active (#324)", async () => withTempConfig(async () => {
   mkdirSync(join(process.env.XDG_CONFIG_HOME, "ponytail"), { recursive: true });
   writeFileSync(join(process.env.XDG_CONFIG_HOME, "ponytail", "config.json"), JSON.stringify({ hideStatus: true }));
-  const { events } = createPiHarness();
-  const statusWrites = [];
+  const { events, host } = createPiHarness();
   const ctx = createCommandContext({
-    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_c, t) => t } },
+    ui: { notify() {}, setStatus: () => {} },
   });
 
   await events.get("session_start")({ reason: "startup" }, ctx);
   await events.get("agent_start")({}, ctx);
   const injected = await events.get("before_agent_start")({ systemPrompt: "BASE" }, ctx);
 
-  assert.deepEqual(statusWrites, [], "config.hideStatus must suppress the status bar");
+  assert.equal(host.SEGMENTS.ponytail.render().visible, false, "chip must hide while the ruleset stays active");
   assert.match(injected.systemPrompt, /PONYTAIL MODE ACTIVE/, "ruleset must still inject while status is hidden");
 }));
 
-test("PONYTAIL_HIDE_STATUS=0 does not hide the indicator", async () => withTempConfig(async () => {
+test("PONYTAIL_HIDE_STATUS=0 does not hide the chip", async () => withTempConfig(async () => {
   process.env.PONYTAIL_HIDE_STATUS = "0";
-  const { events } = createPiHarness();
-  const statusWrites = [];
+  const { events, host } = createPiHarness();
   const ctx = createCommandContext({
     sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "ultra" } }] },
-    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_c, t) => t } },
+    ui: { notify() {}, setStatus: () => {} },
   });
 
   await events.get("session_start")({ reason: "resume" }, ctx);
-  await events.get("agent_start")({}, ctx);
 
-  assert.ok(statusWrites.length > 0, "0 must be treated as 'do not hide'");
+  assert.equal(host.SEGMENTS.ponytail.render().visible, true, "0 must be treated as 'do not hide'");
 }));


### PR DESCRIPTION
the status chip was ugly — `○ 🐴 ponytail: ⚡ FULL` sitting in its own line below the composer. this moves it into omp's actual status bar, next to the `mode` segment:

- registers a real segment in the host's status-line registry via `pi.pi.SEGMENTS`. `pi.pi` is the namespace object omp hands the plugin, so it's the same object the bar renders from. 
- chip is just `🐴 full` (or lite/ultra), accent while the agent runs, muted when idle.

one caveat, marked with a `ponytail:` comment: omp has no official extension-segment API as of 17.4.0 — this leans on root exports (`SEGMENTS`, `STATUS_LINE_PRESETS`, `settings.override`). if they move, the chip falls back to the hook line instead of crashing. also cosmetic: omp's `/settings` segment picker won't list `ponytail` since `ALL_SEGMENT_IDS` is computed before plugins load.

pi-extension suite 27/27; repo suite 83/84 (the csv pandas failure is pre-existing on main, env-related).