### PR TITLE
docs: 在 README 顶部提供核心 prompt 和安装入口

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 <h1 align="center">Ponytail</h1>
 
 <p align="center">
+  <a href="skills/ponytail/SKILL.md">Core prompt</a> &middot; <a href="#quick-start">Quick start</a> &middot; <a href="#install">Install</a>
+</p>
+
+<p align="center">
   <em>He says nothing. He writes one line. It works.</em>
 </p>
 
@@ -58,6 +62,12 @@
 You know him. Long ponytail. Oval glasses. Has been at the company longer than the version control. You show him fifty lines; he looks at them, says nothing, and replaces them with one.
 
 Ponytail puts him inside your AI agent.
+
+## Quick start
+
+**Looking for the prompt?** Read the [compact rules in `AGENTS.md`](AGENTS.md) or the [full skill prompt](skills/ponytail/SKILL.md). For an instruction-only setup, merge the compact rules into your project's existing agent instructions; do not overwrite rules you already have. Your agent must load that file. This gives it the guidance, not the plugin's commands or lifecycle hooks.
+
+For the plugin, use your agent's [install instructions](#install), then ask for a concrete task, for example: `Add a date input to this form. Reuse what is already here and keep validation intact.` See [Commands](#commands) for review and audit tools.
 
 ## Before / after
 


### PR DESCRIPTION
在 README 顶部提供核心 prompt、Quick start 和安装入口，读者无需先浏览 benchmark 与各宿主适配目录。

Quick start 区分指令文件与完整插件，要求合并已有项目规则，避免覆盖用户配置。

验证：相对链接、三个页面锚点及 diff 格式检查通过。仅文档修改。

Closes #808
