### PR TITLE
docs: 添加 LongHorizon-Harness 指令级组合示例

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,7 @@
 # Examples
 
+## Benchmark comparisons
+
 Real model output, verbatim from benchmark runs, the same task answered by the same model
 with no skill (`## Without Ponytail`) and with ponytail (`## With Ponytail`), so you can
 compare side by side. Model: Claude Haiku 4.5, temperature 1, source `benchmarks/output.json`.
@@ -15,3 +17,9 @@ median-of-10 numbers: [../benchmarks/](../benchmarks/).
 | [CSV Sum](csv-sum.md) | 20 | 3 |
 | [Countdown Timer](react-countdown.md) | 267 | 9 |
 | [Rate Limiting](rate-limit.md) | 128 | 10 |
+
+## Workflow documentation
+
+[Ponytail inside a long-running task](long-horizon-harness.md) maps Ponytail
+to LongHorizon-Harness's execution and verification lifecycle. This is a
+documentation example, not benchmark output or an end-to-end tested integration.

--- a/examples/long-horizon-harness.md
+++ b/examples/long-horizon-harness.md
@@ -1,0 +1,54 @@
+# Ponytail inside a long-running task
+
+This is a documentation example, not a benchmark result or a bundled integration.
+[LongHorizon-Harness](https://github.com/AMAP-ML/LongHorizon-Harness)
+coordinates a task across rounds; Ponytail guides the coding choices within
+an Executor round. Neither requires replacing the underlying agent runtime.
+
+## Responsibility map
+
+| Layer | Responsibility | Ponytail's place |
+|---|---|---|
+| Manager | Recover the goal and verified progress; assign a bounded step | Preserve the requested outcome and acceptance criteria |
+| Fresh-context Executor | Carry out the assigned step | Read Ponytail's rules each coding round; prefer reuse and contained complexity |
+| Independent Auditor | Inspect actual files, behavior, and checks | Verify correctness and requirements; a shorter diff is not proof of success |
+| Durable verified state | Carry accepted evidence into the next round | Record verified results and remaining work, not merely the Executor's claims |
+
+These responsibilities follow the upstream
+[lifecycle description](https://github.com/AMAP-ML/LongHorizon-Harness/blob/a1dd930614972b92361c1b9cd6aac441a6db5a65/README.md#one-loop-three-focused-responsibilities).
+Ponytail's [`ponytail-audit`](../skills/ponytail-audit/SKILL.md) only reviews
+complexity; it does not replace the harness's independent Auditor.
+
+## Instruction-only example
+
+1. In a workspace you control, make the existing
+   [Ponytail skill](../skills/ponytail/SKILL.md) available at
+   `.agents/skills/ponytail/SKILL.md`. Preserve any existing file and project
+   rules. This uses the skill as readable instructions, with no Ponytail hook
+   or automatic plugin-discovery assumption.
+2. Include the following in your task text, alongside the concrete work,
+   permitted paths, and acceptance checks:
+
+   ```text
+   For every coding Executor round, first read
+   .agents/skills/ponytail/SKILL.md in the workspace and apply its coding rules.
+   Keep the assigned task's requirements, project rules, and permission limits.
+   Report the changed paths and actual verification evidence.
+   The independent Auditor must check the acceptance criteria against the
+   resulting files and behavior. Fewer lines do not satisfy a missing requirement.
+   ```
+
+3. For an already configured harness, put the complete task in `task.md` and
+   use its documented task-file entry point: `lh-harness run --task @task.md`.
+   Review workspace and backend permissions before running: this starts real
+   agent work. See upstream [usage](https://github.com/AMAP-ML/LongHorizon-Harness/blob/a1dd930614972b92361c1b9cd6aac441a6db5a65/README.md#common-cli-options).
+
+The upstream [Executor prompt builder](https://github.com/AMAP-ML/LongHorizon-Harness/blob/a1dd930614972b92361c1b9cd6aac441a6db5a65/src/lh_harness/role_prompts.py)
+includes the original task in each Executor prompt. Check the first round's
+trajectory for the skill read and the Auditor's independent evidence before
+relying on this composition. It has not been tested here as an end-to-end run.
+
+Keep the harness's read-only auditing and approval boundaries. Loading Ponytail
+does not authorize publishing, destructive changes, or broader access. A failed
+check remains unfinished work; only independently accepted results belong in
+verified progress.


### PR DESCRIPTION
为 #706 增加 Ponytail 与 LongHorizon-Harness 的指令级组合示例，映射 Manager、Executor、Auditor 与持久验证状态的职责。

基于上游固定提交的 README 和 Executor prompt builder：每轮 Executor 显式读取工作区内的 Ponytail skill；外层验收仍决定任务是否完成。示例没有新增运行时、依赖或自动插件加载假设。

验证：核对固定提交的源码与命令接口、检查相对链接和 diff 格式。尚未安装或端到端运行 LongHorizon-Harness，文档明确该限制；此示例也未被列为 benchmark 原始结果。

Closes #706
