### PR TITLE
docs: add Skills CLI install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ Copilot CLI namespaces plugin commands by plugin name. For example:
 pi install git:github.com/DietrichGebert/ponytail
 ```
 
+### Skills CLI
+
+```bash
+npx skills add https://github.com/DietrichGebert/ponytail
+```
+
+Install one skill instead with `--skill`, or add `-g` to install globally.
+
 ### OpenCode
 
 Add to `opencode.json`:


### PR DESCRIPTION
## Summary

Adds installation instructions for the Skills CLI:

```bash
npx skills add https://github.com/DietrichGebert/ponytail
```

Also notes how to install a specific skill or install globally.

## Verification

- Verified the command with `npx skills add ... --list`
- Confirmed all six Ponytail skills are available
- `git diff --check` passes