### PR TITLE
fix(hooks): raise Claude/Codex hook timeout from 5s to 15s

### DIFF
--- a/hooks/claude-codex-hooks.json
+++ b/hooks/claude-codex-hooks.json
@@ -8,7 +8,7 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-activate.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-activate.js\" }",
-            "timeout": 5,
+            "timeout": 15,
             "statusMessage": "Loading ponytail mode..."
           }
         ]
@@ -21,7 +21,7 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-subagent.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-subagent.js\" }",
-            "timeout": 5,
+            "timeout": 15,
             "statusMessage": "Loading ponytail mode..."
           }
         ]
@@ -34,7 +34,7 @@
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/ponytail-mode-tracker.js\"",
             "commandWindows": "if (Get-Command node -ErrorAction SilentlyContinue) { node \"$env:CLAUDE_PLUGIN_ROOT\\hooks\\ponytail-mode-tracker.js\" }",
-            "timeout": 5,
+            "timeout": 15,
             "statusMessage": "Tracking ponytail mode..."
           }
         ]


### PR DESCRIPTION
On Windows a cold Node start under disk contention (Drive sync, Defender, a second agent) regularly crosses 5 seconds. Claude Code then discards the hook output and prints "UserPromptSubmit hook timed out after 5s" on every prompt, twice per turn once the SessionStart hook is counted.

This raises the three timeouts in hooks/claude-codex-hooks.json to 15 seconds. A fast hook still returns immediately; only the ceiling moves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)