### PR TITLE
fix: avoid deleting similarly named statuslines

### DIFF
--- a/scripts/uninstall.js
+++ b/scripts/uninstall.js
@@ -9,7 +9,7 @@ const fs = require('fs');
 const path = require('path');
 const { getConfigPath, getClaudeDir } = require('../hooks/ponytail-config');
 
-const STATUSLINE_SCRIPT = 'ponytail-statusline';
+const STATUSLINE_SCRIPT = /(?:^|[\s"'\\/])ponytail-statusline\.(?:sh|ps1)(?=$|[\s"'])/;
 
 function removeIfExists(filePath, label) {
   try {
@@ -32,12 +32,12 @@ try {
   // (e.g. caveman && ponytail), keep the other plugin's command intact.
   // ponytail: splits on && / ; to detect other segments — good enough; a user
   // piping statuslines together is on their own.
-  if (typeof cmd === 'string' && cmd.includes(STATUSLINE_SCRIPT)) {
+  if (typeof cmd === 'string' && STATUSLINE_SCRIPT.test(cmd)) {
     const parts = cmd
       .split(/&&|;/)
       .map((s) => s.trim())
       .filter(Boolean);
-    const others = parts.filter((s) => !s.includes(STATUSLINE_SCRIPT));
+    const others = parts.filter((s) => !STATUSLINE_SCRIPT.test(s));
     if (others.length === 0) {
       delete settings.statusLine;
       fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2), 'utf8');

--- a/tests/uninstall.test.js
+++ b/tests/uninstall.test.js
@@ -69,6 +69,20 @@ assert.equal(
   "a user's own statusLine must not be touched",
 );
 
+// A user command that merely contains ponytail's script name must also survive.
+fs.writeFileSync(settingsPath, JSON.stringify({
+  statusLine: { type: 'command', command: 'bash ~/my-ponytail-statusline.sh' },
+}));
+
+result = runUninstall(env);
+assert.equal(result.status, 0, result.stderr);
+const settingsAfterSimilarName = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
+assert.equal(
+  settingsAfterSimilarName.statusLine.command,
+  'bash ~/my-ponytail-statusline.sh',
+  "a similarly named user statusLine must not be touched",
+);
+
 // #374: a combined statusline (another plugin && ponytail) must keep the other
 // plugin's part — uninstall must not nuke the whole command or leave a husk.
 fs.writeFileSync(settingsPath, JSON.stringify({


### PR DESCRIPTION
The cleanup script currently identifies Ponytail's statusline with a substring check. As a result, a user-owned command such as `bash ~/my-ponytail-statusline.sh` is mistaken for Ponytail's script and removed from `~/.claude/settings.json` during uninstall, despite the README promising that custom statuslines are left untouched.

Match the exact shipped basenames, `ponytail-statusline.sh` and `ponytail-statusline.ps1`, at command-token/path boundaries. This keeps the existing standalone and combined-statusline cleanup behavior while preserving similarly named user scripts.

Validation:
- The new regression case fails before the fix because `settings.statusLine` is deleted, and passes after it.
- Full root suite: 84/84 passed.
- Pi extension: 23/23 passed.
- MCP package: 3/3 passed.
- Rule-copy check, eight-file version check, and `git diff --check` passed.
