### PR TITLE
fix(pi-extension): clear disabled footer status

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -78,7 +78,7 @@ export default function ponytailExtension(pi) {
     let theme;
     try { theme = c.ui.theme; if (!theme?.fg) return; } catch { return; }
     if (currentMode === "off") {
-      c.ui.setStatus("ponytail", "");
+      c.ui.setStatus("ponytail", undefined);
       return;
     }
     const levelIcons = { lite: "🌿", full: "⚡", ultra: "🔥" };

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -179,6 +179,19 @@ test("status bar renders the mode and flips active on agent_start", async () => 
   assert.match(statusWrites.at(-1).text, /●.*ULTRA/);
 }));
 
+test("off mode clears the status bar entry", async () => withTempConfig(async () => {
+  const { events } = createPiHarness();
+  const statusWrites = [];
+  const ctx = createCommandContext({
+    sessionManager: { getEntries: () => [{ type: "custom", customType: "ponytail-mode", data: { mode: "off" } }] },
+    ui: { notify() {}, setStatus: (key, text) => statusWrites.push({ key, text }), theme: { fg: (_color, text) => text } },
+  });
+
+  await events.get("session_start")({ reason: "resume" }, ctx);
+
+  assert.deepEqual(statusWrites.at(-1), { key: "ponytail", text: undefined });
+}));
+
 test("status bar stays silent when ui lacks a theme", async () => withTempConfig(async () => {
   const { events } = createPiHarness();
   const calls = [];


### PR DESCRIPTION
##

Minor tweak to improve footer status behaviour.

## What changed

When Ponytail is off, remove its Pi footer status instead of replacing the text with an empty string.

```diff
 off mode
-  empty string → status entry stays → trailing separator
+  undefined    → status entry is removed
```

This also adds a regression test for the off state.

## Why

Pi uses `undefined` to clear a footer status. An empty string leaves the Ponytail entry registered, so another footer status can end with an extra separator.

### Reference docs

Just to confirm I'm not lying:

1. **Extension docs** explicitly demonstrate clearing with `undefined`:

   > `ctx.ui.setStatus("my-ext", undefined); // Clear`

   [Pi extension docs](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/docs/extensions.md#L2593-L2598)

2. **The API type declaration** says:

   > “Pass undefined to clear.”

   [Extension UI type](https://github.com/earendil-works/pi/blob/main/packages/coding-agent/src/core/extensions/types.ts#L149-L150)

## Test

- `npm test` (84 root tests, 24 Pi extension tests, and 3 MCP tests passed)
