### PR TITLE
feat(hermes): expose Ponytail skills to awareness index

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import inspect
 import os
 import re
 from pathlib import Path
@@ -194,10 +195,19 @@ def _make_skill_command_handler(ctx: Any, command: str) -> Callable[[str], str]:
 
 def register(ctx: Any) -> None:
     """Register Ponytail hooks, skills, and slash commands with Hermes."""
+    try:
+        parameters = inspect.signature(ctx.register_skill).parameters
+        awareness_supported = (
+            "list_in_awareness" in parameters
+            or any(param.kind is inspect.Parameter.VAR_KEYWORD for param in parameters.values())
+        )
+    except (TypeError, ValueError):
+        awareness_supported = False
     for child in sorted(SKILLS_DIR.iterdir() if SKILLS_DIR.exists() else []):
         skill_md = child / "SKILL.md"
         if child.is_dir() and skill_md.exists():
-            ctx.register_skill(child.name, skill_md)
+            kwargs = {"list_in_awareness": True} if awareness_supported else {}
+            ctx.register_skill(child.name, skill_md, **kwargs)
 
     ctx.register_hook("pre_llm_call", _pre_llm_call)
     ctx.register_hook("pre_gateway_dispatch", rewrite_gateway_command)

--- a/tests/hermes-plugin.test.js
+++ b/tests/hermes-plugin.test.js
@@ -69,15 +69,21 @@ class Ctx:
         self.skills = []
         self.hooks = []
         self.commands = []
-    def register_skill(self, name, path):
-        self.skills.append((name, pathlib.Path(path).as_posix()))
+    def register_skill(self, name, path, **kwargs):
+        self.skills.append((name, pathlib.Path(path).as_posix(), kwargs))
     def register_hook(self, name, handler):
         self.hooks.append(name)
     def register_command(self, name, handler, description='', args_hint=''):
         self.commands.append(name)
+class LegacyCtx(Ctx):
+    def register_skill(self, name, path):
+        self.skills.append((name, pathlib.Path(path).as_posix()))
 ctx = Ctx()
 mod.register(ctx)
-print(json.dumps({'skills': ctx.skills, 'hooks': ctx.hooks, 'commands': ctx.commands}, sort_keys=True))
+legacy = LegacyCtx()
+mod.register(legacy)
+print(json.dumps({'skills': ctx.skills, 'hooks': ctx.hooks, 'commands': ctx.commands,
+                  'legacy_skill_count': len(legacy.skills)}, sort_keys=True))
 `);
   const data = JSON.parse(output);
   assert.deepEqual(data.skills.map(([name]) => name).sort(), [
@@ -89,6 +95,8 @@ print(json.dumps({'skills': ctx.skills, 'hooks': ctx.hooks, 'commands': ctx.comm
     'ponytail-review',
   ]);
   assert.ok(data.skills.every(([, skillPath]) => skillPath.endsWith('/SKILL.md')));
+  assert.ok(data.skills.every(([, , options]) => options.list_in_awareness === true));
+  assert.equal(data.legacy_skill_count, 6);
   assert.ok(data.hooks.includes('pre_llm_call'));
   assert.ok(data.commands.includes('ponytail'));
   assert.ok(data.commands.includes('ponytail-review'));
@@ -124,7 +132,7 @@ mod = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(mod)
 class Ctx:
     def __init__(self): self.commands = {}
-    def register_skill(self, name, path): pass
+    def register_skill(self, name, path, **kwargs): pass
     def register_hook(self, name, handler): pass
     def register_command(self, name, handler, description='', args_hint=''):
         self.commands[name] = handler
@@ -175,7 +183,7 @@ class Ctx:
     def __init__(self):
         self.hooks = {}
         self.commands = {}
-    def register_skill(self, name, path): pass
+    def register_skill(self, name, path, **kwargs): pass
     def register_hook(self, name, handler): self.hooks[name] = handler
     def register_command(self, name, handler, description='', args_hint=''):
         self.commands[name] = handler


### PR DESCRIPTION
## Problem

Hermes registers Ponytail's six namespaced Skills, but they remain explicit-load only and cannot participate in the normal `<available_skills>` / retrieval awareness band.

## Change

Opt all six bundled Ponytail Skills into Hermes' new per-Skill `list_in_awareness` contract from NousResearch/hermes-agent#107964. Runtime signature detection preserves compatibility with current Hermes versions that do not yet accept the keyword, so hooks, commands, and explicit Skill loading keep working before the core PR lands.

## Verification

- full repository `npm test`: 110 passed
- Ruff on `__init__.py`: passed
- Python bytecode compilation: passed
- test covers both awareness-capable and legacy Hermes contexts

No Skill content, identity, hook, command, or mode behavior changes.