### PR TITLE
fix: inject the ruleset when the mode is switched mid-session

### DIFF
--- a/hooks/ponytail-mode-tracker.js
+++ b/hooks/ponytail-mode-tracker.js
@@ -64,16 +64,6 @@ function finish() {
       } else if (mode && mode !== 'off') {
         setMode(mode);
         modeSwitched = true;
-        // ponytail: Qoder needs the full ruleset every turn, so when a mode
-        // switch happens we fold the confirmation into the ruleset output
-        // below (one JSON on stdout) instead of emitting two separate writes.
-        if (!isQoder) {
-          writeHookOutput(
-            'UserPromptSubmit',
-            mode,
-            'PONYTAIL MODE CHANGED — level: ' + mode,
-          );
-        }
       } else if (mode === 'off') {
         clearMode();
         deactivated = true;
@@ -92,8 +82,12 @@ function finish() {
     // activate the default mode on first prompt (if no flag exists yet), then
     // inject the ruleset on every prompt. Claude Code/Codex do this in
     // SessionStart via ponytail-activate.js; Qoder can't, so we do it here.
+    // A mode switch takes the same path on every host: the flag alone only
+    // reaches the next SessionStart, while subagents read it immediately, so
+    // without the ruleset here the main thread stays un-ponytailed while its
+    // own subagents are not (#663).
     // Skip when deactivated — user just turned ponytail off.
-    if (isQoder && !deactivated) {
+    if ((isQoder || modeSwitched) && !deactivated) {
       let currentMode = readMode();
       if (!currentMode) {
         // First prompt in session — initialize from config/env default
@@ -104,7 +98,7 @@ function finish() {
       }
       if (currentMode && currentMode !== 'off') {
         // ponytail: one JSON per invocation — mode-switch confirmation is
-        // folded into the ruleset header so Qoder gets both in one write.
+        // folded into the ruleset header so the host gets both in one write.
         const header = modeSwitched
           ? 'PONYTAIL MODE CHANGED — level: ' + currentMode + '\n\n'
           : '';

--- a/tests/hooks.test.js
+++ b/tests/hooks.test.js
@@ -134,6 +134,51 @@ assert.equal(
   'full',
 );
 
+// #663: a mid-session switch must deliver the ruleset, not just the flag. The
+// flag alone reaches the next SessionStart, but subagents read it right away,
+// so the main thread would be the only part of the session left un-ponytailed.
+const switchDir = path.join(temp, 'mid-session-switch');
+result = run(
+  'ponytail-mode-tracker.js',
+  { HOME: home, USERPROFILE: home, CLAUDE_CONFIG_DIR: switchDir, PONYTAIL_DEFAULT_MODE: 'off' },
+  JSON.stringify({ prompt: '/ponytail full' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(fs.readFileSync(path.join(switchDir, '.ponytail-active'), 'utf8'), 'full');
+assert.match(result.stdout, /^PONYTAIL MODE CHANGED — level: full/);
+assert.match(
+  result.stdout,
+  /## The ladder/,
+  'a mid-session switch must inject the ruleset, not only confirm the level (#663)',
+);
+
+// Report-only and deactivation stay one line — neither changes what is active.
+result = run(
+  'ponytail-mode-tracker.js',
+  { HOME: home, USERPROFILE: home, CLAUDE_CONFIG_DIR: switchDir },
+  JSON.stringify({ prompt: '/ponytail' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(result.stdout, 'PONYTAIL MODE ACTIVE — level: full');
+
+result = run(
+  'ponytail-mode-tracker.js',
+  { HOME: home, USERPROFILE: home, CLAUDE_CONFIG_DIR: switchDir },
+  JSON.stringify({ prompt: '/ponytail off' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(result.stdout, 'PONYTAIL MODE OFF');
+assert.equal(fs.existsSync(path.join(switchDir, '.ponytail-active')), false);
+
+// An ordinary prompt must stay silent — only Qoder re-sends rules every turn.
+result = run(
+  'ponytail-mode-tracker.js',
+  { HOME: home, USERPROFILE: home, CLAUDE_CONFIG_DIR: switchDir },
+  JSON.stringify({ prompt: 'write a function' }),
+);
+assert.equal(result.status, 0, result.stderr);
+assert.equal(result.stdout, '', 'non-command prompts must not re-inject the ruleset');
+
 // CLAUDE_CONFIG_DIR overrides ~/.claude for the flag file (issue #34).
 const home2 = path.join(temp, 'home2');
 fs.mkdirSync(home2, { recursive: true });


### PR DESCRIPTION
## Problem

Reported in #663. On Claude Code, switching level mid-session sets the flag, confirms, and delivers nothing else:

```
$ echo '{"prompt":"/ponytail full"}' | CLAUDE_CONFIG_DIR="$SB" node hooks/ponytail-mode-tracker.js
PONYTAIL MODE CHANGED — level: full
$ cat "$SB/.ponytail-active"
full
```

The flag is correct, so the switch *looks* successful, but the main thread receives no rules until the next `SessionStart`. Subagents spawned afterwards read the flag directly and do get them (`ponytail-subagent.js`), so the session ends up split — ponytail-aware workers under an unaware main thread. The "leave it off, flip it on when I need it" flow silently does nothing.

## Cause

The re-injection already exists, but it sits behind the Qoder branch at `hooks/ponytail-mode-tracker.js:95`:

```js
if (isQoder && !deactivated) {
```

That block was added because Qoder has no `SessionStart` event to carry the ruleset. A mode switch has exactly the same gap on every host — the flag alone only reaches the next session start — so the condition was narrower than the problem it solves.

## Change

Widen the existing condition instead of adding a second, host-specific write:

```js
if ((isQoder || modeSwitched) && !deactivated) {
```

The block already folds the `MODE CHANGED` confirmation into the ruleset header for precisely this case (`const header = modeSwitched ? ... : ''`), so the separate confirmation-only write above it becomes dead and is removed. Net **ten lines fewer**, no new code path, and Qoder's output is byte-identical to before.

Only an actual switch takes the path. Deliberately unchanged:

- bare `/ponytail` — report-only, still one line, still does not touch the mode
- `/ponytail off` and "stop ponytail" — still `PONYTAIL MODE OFF`, no rules
- an ordinary prompt on a non-Qoder host — still no output, so nothing starts paying for the ruleset every turn
- `/ponytail default <mode>` — returns before this point, untouched

## Tests

Added to `tests/hooks.test.js`, next to the existing native-Claude assertions:

- a switch from `off` to `full` writes the flag **and** its stdout carries both the confirmation and the ladder
- bare `/ponytail` still emits exactly `PONYTAIL MODE ACTIVE — level: full`
- `/ponytail off` still emits exactly `PONYTAIL MODE OFF` and clears the flag
- a plain prompt still emits nothing

Confirmed the new assertion fails against current `main`:

```
AssertionError: a mid-session switch must inject the ruleset, not only confirm the level (#663)
  actual: 'PONYTAIL MODE CHANGED — level: full'
```

Full suite, before and after this change: **83 passed, 1 failed**. The one failure is `csv: correct pandas one-liner passes` in `tests/correctness.test.js`, which fails identically on unmodified `main` on my machine — pandas is not installed here, so it is environmental and unrelated.

Also verified by hand that Codex (`PLUGIN_DATA`) still returns a single JSON with `systemMessage` plus the ruleset, and that Qoder's output is unchanged.

Fixes #663
