### PR TITLE
fix(benchmarks): correctness harness crashed instead of scoring a FAIL when the model's code raised

### DIFF
--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -48,13 +48,19 @@ function exec(cmd, opts = {}) {
 }
 
 // ponytail: probe once at load; macOS and many Linux images ship python3 only.
+// A bare `python3` can resolve to a minimal interpreter (uv/pyenv shim) that
+// lacks pandas while the system one has it, so prefer a pandas-capable
+// interpreter first and fall back to any working one.
+const PY_CANDIDATES = ['python3', 'python', '/usr/bin/python3'];
 let pythonCmd;
 function python() {
   if (pythonCmd) return pythonCmd;
-  for (const cmd of ['python3', 'python']) {
-    if (exec(`${cmd} -c "import sys"`).ok) {
-      pythonCmd = cmd;
-      return pythonCmd;
+  for (const probe of ['import pandas', 'import sys']) {
+    for (const cmd of PY_CANDIDATES) {
+      if (exec(`${cmd} -c "${probe}"`).ok) {
+        pythonCmd = cmd;
+        return pythonCmd;
+      }
     }
   }
   pythonCmd = 'python3';

--- a/benchmarks/correctness.js
+++ b/benchmarks/correctness.js
@@ -194,16 +194,16 @@ os.chdir(r"${path.dirname(csvPath)}")
 # Capture print output
 import io
 _stdout = sys.stdout
-sys.stdout = io.StringIO()
+_buf = io.StringIO()
+sys.stdout = _buf
 
 try:
 ${patched.split('\n').map((l) => '    ' + l).join('\n')}
 except Exception as e:
-    sys.stdout = _stdout
-    # If it needs sales.csv in cwd, write it there and retry
+    # Swallow: the output check below reports a FAIL verdict either way.
     pass
 
-output = sys.stdout.getvalue()
+output = _buf.getvalue()
 sys.stdout = _stdout
 
 # Check output contains the number 351 (100.5 + 200.0 + 50.5)


### PR DESCRIPTION
Two small fixes to `benchmarks/correctness.js`, found while running the correctness suite on macOS.

### 1. The CSV harness crashed with `AttributeError` instead of reporting a FAIL

The generated Python harness restored `sys.stdout` inside the `except` branch, then unconditionally called `sys.stdout.getvalue()` after the `try` block:

```python
sys.stdout = io.StringIO()
try:
    <model code>
except Exception as e:
    sys.stdout = _stdout   # <- restored here
    pass
output = sys.stdout.getvalue()   # <- real stdout has no .getvalue()
```

So *any* exception in the model's code (in my case `ModuleNotFoundError: pandas`) made the checker itself die with `AttributeError`, masking the real reason and losing the score entirely.

Fix: keep the `StringIO` in a `_buf` reference so the capture survives the except path. The verdict logic is unchanged, a raising model still scores FAIL, just cleanly.

### 2. Probe for a pandas-capable interpreter

A uv- or pyenv-managed `python3` earlier on `PATH` satisfies `import sys` but lacks pandas, so the csv check failed on machines where `/usr/bin/python3` had pandas all along. Now probes `import pandas` across candidates first and falls back to any working interpreter.

### Verification
Confirmed the post-fix harness shape returns a clean empty-output FAIL rather than raising, when the guarded code throws `ModuleNotFoundError`. Both commits are scoped to `benchmarks/correctness.js`; no changes to scoring thresholds or to the ponytail ruleset itself.