### PR TITLE
fix(pi): expand skill alias prompts

### DIFF
--- a/pi-extension/index.js
+++ b/pi-extension/index.js
@@ -103,12 +103,12 @@ export default function ponytailExtension(pi) {
     const message = normalized ? `${skillName} ${normalized}` : skillName;
 
     if (ctx?.isIdle?.() === false) {
-      pi.sendUserMessage(message, { deliverAs: "followUp" });
+      pi.sendUserMessage(message, { deliverAs: "followUp", expandPromptTemplates: true });
       ctx?.ui?.notify?.(`${skillName} queued as follow-up.`, "info");
       return;
     }
 
-    pi.sendUserMessage(message);
+    pi.sendUserMessage(message, { expandPromptTemplates: true });
   };
 
   pi.registerCommand("ponytail", {

--- a/pi-extension/test/extension.test.js
+++ b/pi-extension/test/extension.test.js
@@ -120,7 +120,7 @@ test("session_start restores latest persisted mode", async () => withTempConfig(
   assert.ok(result.systemPrompt.includes("lite"));
 }));
 
-test("skill alias commands delegate to Pi skill commands", async () => {
+test("skill alias commands ask Pi to expand skill prompts", async () => {
   const { commands, sentUserMessages } = createPiHarness();
   const ctx = createCommandContext();
 
@@ -130,13 +130,20 @@ test("skill alias commands delegate to Pi skill commands", async () => {
   await commands.get("ponytail-gain").handler("", ctx);
   await commands.get("ponytail-help").handler("", ctx);
 
-  assert.deepEqual(sentUserMessages.map((entry) => entry.text), [
+  assert.deepEqual(sentUserMessages, [
     "/skill:ponytail-review",
     "/skill:ponytail-audit",
     "/skill:ponytail-debt",
     "/skill:ponytail-gain",
     "/skill:ponytail-help",
-  ]);
+  ].map((text) => ({ text, options: { expandPromptTemplates: true } })));
+
+  const busy = createPiHarness();
+  await busy.commands.get("ponytail-review").handler("", createCommandContext({ isIdle: () => false }));
+  assert.deepEqual(busy.sentUserMessages, [{
+    text: "/skill:ponytail-review",
+    options: { deliverAs: "followUp", expandPromptTemplates: true },
+  }]);
 });
 
 test("normal mode disables persistent instructions", async () => withTempConfig(async () => {


### PR DESCRIPTION
## Summary

- opt in to Pi prompt-template expansion when Ponytail slash aliases send `/skill:...` messages
- preserve follow-up delivery while the agent is busy
- cover idle and busy alias dispatch

Pi 0.84.0 defaults `sendUserMessage(...).expandPromptTemplates` to false, so without this option the model receives the literal skill command instead of the skill body.

## Verification

- `TMPDIR=/tmp node --test pi-extension/test/extension.test.js`

The root suite additionally requires the documented local pandas prerequisite, which is unavailable in the sandbox.